### PR TITLE
site: don't default File to links => follow

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -13,7 +13,7 @@ stage { 'first': before => Stage['main'], }
 Exec { path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', }
 
 # default file permissions, follow symlinks when serving files, backup existing files to puppetmaster
-File { mode => 0644, owner => root, group => root, links => follow, backup => main, }
+File { mode => 0644, owner => root, group => root, backup => main }
 
 # add managed filesystems to fstab by default
 Mount { ensure => defined, }


### PR DESCRIPTION
By setting `links => follow` as the default for File, we break modules which expect it to be something different.

Here's an example puppet run using the nginx module:

> (/Stage[main]/Ocf_ssh::Webssh/Nginx::Resource::Vhost[ssh.ocf.berkeley.edu]/File[ssh.ocf.berkeley.edu.conf symlink]/ensure) ensure changed 'file' to 'link'
> (/Stage[main]/Nginx::Service/Service[nginx]) Triggered 'refresh' from 1 events

It's worse with the apache module:

> (/Stage[main]/Apache::Mod::Mime/Apache::Mod[mime]/File[mime.load symlink]/ensure) ensure changed 'file' to 'link'
> (/Stage[main]/Apache::Default_mods/Apache::Mod[authz_groupfile]/File[authz_groupfile.load symlink]/ensure) ensure changed 'file' to 'link'
> (/Stage[main]/Apache::Mod::Negotiation/Apache::Mod[negotiation]/File[negotiation.conf symlink]/ensure) ensure changed 'file' to 'link'
> [snip 30 lines]
> (/Stage[main]/Apache::Service/Service[httpd]) Triggered 'refresh' from 33 events

Using the default fixes this (i.e. prevents nginx and apache being reloaded all the time). This is an actual problem and is the reason Apache on the puppetmaster used to restart every 30 minutes, breaking
puppet runs on random servers that were happening during the restart.

I realized this a while back and patched the Apache module (which is why lightning has been using my puppet environment for the past few months):
https://gist.github.com/chriskuehl/dee53ce6d017064fdfc8

I wonder whether we shouldn't do this, since it seems to be both non-standard and surprising to change a default property like this.

Changing it breaks some of our other puppet manifests. For example, some of the files in private are symlinks to other files in private; after this change, random things will break. On dev-death:

> (/Stage[main]/Ocf_www/File[/etc/ssl/private/ocf.io.crt]/ensure) ensure changed 'file' to 'link'
> (/Stage[main]/Ocf_www/Service[apache2]) SSLCertificateChainFile: file '/etc/ssl/certs/positivessl-intermediate.crt' does not exist or is empty
> (/Stage[main]/Ocf_www/Service[apache2]) Action 'configtest' failed.
> (/Stage[main]/Ocf_www/Service[apache2]) The Apache error log may have more information.
> (/Stage[main]/Ocf_www/Service[apache2])  failed!

It might be annoying to have to go change all of these, but I don't know that setting `links => follow` as the default is a good idea.

Paging @daradib @nattofriends for comments
