### PR TITLE
ocf_mail: add mail metadata logging

### DIFF
--- a/modules/ocf_mail/files/site_ocf/aliases
+++ b/modules/ocf_mail/files/site_ocf/aliases
@@ -63,3 +63,4 @@ ocfapt: /dev/null
 
 # misc
 archive: /var/mail/archives/archive
+ocflog: "| /usr/local/bin/log-mail"

--- a/modules/ocf_mail/files/site_ocf/postfix/main.cf
+++ b/modules/ocf_mail/files/site_ocf/postfix/main.cf
@@ -14,6 +14,9 @@ mydestination = int.ocf.berkeley.edu
 virtual_mailbox_domains =
 virtual_alias_domains = ocf.berkeley.edu
 
+# logging
+always_bcc = ocflog
+
 # aliases
 virtual_alias_maps = hash:/etc/postfix/ocf/aliases-local,
 	proxy:ldap:/etc/postfix/ldap-aliases.cf

--- a/modules/ocf_mail/files/spam/logging/log-mail
+++ b/modules/ocf_mail/files/spam/logging/log-mail
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Appends JSON dictionary of NSA-style metadata about a message read from stdin
+# to /var/log/ocfmail.log for the purposes of monitoring spam. Should be run as
+# the postfix user.
+#
+# Note that `date` returned is the current date (and not one parsed from
+# message headers), since we don't really trust headers more than necessary.
+
+import email
+import email.utils
+import json
+import re
+import sys
+from datetime import datetime
+
+LOG_FILE = '/var/log/ocfmail.log'
+
+
+def parse_uid(header):
+    """Attempt to parse sender uid from Received header.
+
+    This header can be faked by the message sender if they don't send via local
+    MTA to blame other users, so we rely on this being prevented via firewall
+    rules."""
+
+    match = re.match(
+        'by [a-z\\-]*\\.ocf\\.berkeley\\.edu \\(Postfix, from userid ([0-9]*)\\)',
+        header)
+
+    if match:
+        return match.group(1)
+
+
+def clean_addr(addr):
+    """Cleans up email address, attempting to normalize as much as possible.
+
+    We keep the realname in case it says something useful (e.g. 'Cron Daemon').
+
+    >>> clean_addr('Chris Kuehl <cKuEhL@OCF.Berkeley.EDU>')
+    ('Chris Kuehl', 'ckuehl@ocf.berkeley.edu')
+    """
+    realname, mail_addr = email.utils.parseaddr(addr)
+    return realname.strip() or None, mail_addr.strip().lower() or None
+
+
+if __name__ == '__main__':
+    message = email.message_from_file(sys.stdin)
+
+    uid = None
+    received = message.get_all('Received')
+    if received:
+        uid = parse_uid(received[-1])
+
+    info = {
+        'uid': uid,
+        'from': clean_addr(message['From']),
+        'to': clean_addr(message['To']),
+        'subject': message['Subject'],
+        'date': datetime.now().isoformat()
+    }
+
+    with open(LOG_FILE, 'a') as f:
+        print(json.dumps(info), file=f)

--- a/modules/ocf_mail/files/spam/logging/log-mail
+++ b/modules/ocf_mail/files/spam/logging/log-mail
@@ -16,19 +16,19 @@ from datetime import datetime
 LOG_FILE = '/var/log/ocfmail.log'
 
 
-def parse_uid(header):
-    """Attempt to parse sender uid from Received header.
+def parse_received(header):
+    """Attempt to parse relay host and sender uid from Received header.
 
     This header can be faked by the message sender if they don't send via local
     MTA to blame other users, so we rely on this being prevented via firewall
     rules."""
 
     match = re.match(
-        'by [a-z\\-]*\\.ocf\\.berkeley\\.edu \\(Postfix, from userid ([0-9]*)\\)',
+        'by ([a-zA-Z\\-\\.]*) \\(Postfix, from userid ([0-9]*)\\)',
         header)
 
     if match:
-        return match.group(1)
+        return {'relay': match.group(1), 'uid': match.group(2)}
 
 
 def clean_addr(addr):
@@ -46,13 +46,14 @@ def clean_addr(addr):
 if __name__ == '__main__':
     message = email.message_from_file(sys.stdin)
 
-    uid = None
+    parsed = None
     received = message.get_all('Received')
     if received:
-        uid = parse_uid(received[-1])
+        parsed = parse_received(received[-1])
 
     info = {
-        'uid': uid,
+        'relay': parsed.get('relay'),
+        'uid': parsed.get('uid'),
         'from': clean_addr(message['From']),
         'to': clean_addr(message['To']),
         'subject': message['Subject'],

--- a/modules/ocf_mail/files/spam/logging/logrotate
+++ b/modules/ocf_mail/files/spam/logging/logrotate
@@ -1,0 +1,8 @@
+/var/log/ocfmail.log {
+	daily
+	missingok
+	rotate 7
+	shred
+	nocompress
+	create 600 ocfmail ocfmail
+}

--- a/modules/ocf_mail/manifests/spam.pp
+++ b/modules/ocf_mail/manifests/spam.pp
@@ -6,6 +6,7 @@
 #  - spamassassin
 #  - postgrey (graylisting)
 #  - policyd-weight (DNSBLs and more)
+#  - basic metadata logging to /var/log/ocfmail.log
 #
 # It is designed to be included by site configurations.
 
@@ -87,5 +88,19 @@ class ocf_mail::spam {
       source  => 'puppet:///modules/ocf_mail/spam/policyd-weight/policyd-weight.conf',
       notify  => Service['policyd-weight'],
       require => Package['policyd-weight'];
+
+    # logging
+    '/usr/local/bin/log-mail':
+      source => 'puppet:///modules/ocf_mail/spam/logging/log-mail',
+      mode   => '0755';
+
+    '/var/log/ocfmail.log':
+      ensure => file,
+      owner  => ocfmail,
+      group  => ocfmail,
+      mode   => '0600';
+
+    '/etc/logrotate.d/mail-log':
+      source => 'puppet:///modules/ocf_mail/spam/logging/logrotate';
   }
 }


### PR DESCRIPTION
We used to log all mail that went through sandstorm for ~7 (?) days so
that it could be examined if we suspected spam. When I rebuilt the mail
server as anthrax, I didn't re-implement this.

Instead, I added full mail logging for "nomail"'d users, and no logging
for normal users.

This adds more logging without being overly intrusive. It logs time
sent, from/to, sender UID, and subject. Almost all of this information
was already logged by default to /var/log/mail.log, but in an
inconvenient-to-parse-or-search format.

This produces nice JSON logs:

{"date": "2015-02-04T17:40:06.049154",
 "to": [null, "ocfstats@ocf.berkeley.edu"],
 "from": ["Cron Daemon", "root@ocf.berkeley.edu"],
 "uid": "999",
 "subject": "Cron <ocfstats@dementors> /opt/stats/bin/toner > /opt/stats/toner"}

Eventually we can parse this every day or so to automatically flag users
sending too much mail.

The only additional info logged is subject and UID, which I think is a
reasonable compromise for privacy reasons, especially given that we used
to log *everything*.