### PR TITLE
Version which dynamically updates the time left before logout

### DIFF
--- a/modules/ocf_desktop/files/xsession/Xsession
+++ b/modules/ocf_desktop/files/xsession/Xsession
@@ -114,4 +114,4 @@ xset m 0 0
 /usr/local/bin/fix-audio &
 
 # Auto logout inactive users
-/usr/bin/xautolock -locker /usr/local/bin/auto-lock -notify 300 -notifier /usr/local/bin/auto-lock-notify &
+/usr/bin/xautolock -locker /usr/local/bin/auto-lock -time 9 &

--- a/modules/ocf_desktop/files/xsession/auto-lock
+++ b/modules/ocf_desktop/files/xsession/auto-lock
@@ -1,6 +1,25 @@
 #!/bin/bash
+
+WARNTIME=60
+
 if groups | grep -q '\bapprove\b'; then
-	exec xflock4
+	ACTION_TEXT='Screen will lock'
+	BTN_TEXT="Wait, don't lock it"
+	CMD=(xflock4)
 else
-	exec xfce4-session-logout
+	ACTION_TEXT='You will be logged out'
+	BTN_TEXT="Wait, don't log me out"
+	CMD=(xfce4-session-logout --logout)
 fi
+
+for ((i=$WARNTIME; i>=0; i--)); do
+	echo "#$ACTION_TEXT in $i seconds."
+	# We have to use a number slightly larger than $WARNTIME so that
+	# zenity doesn't exit on the very first tick
+	bc -l <<< "$i / $WARNTIME.1 * 100"
+	sleep 1
+done |
+  zenity --progress --title "You have been inactive" \
+  --cancel-label "$BTN_TEXT" --auto-close
+
+[ $? -eq 0 ] && exec "${CMD[@]}"

--- a/modules/ocf_desktop/files/xsession/auto-lock-notify
+++ b/modules/ocf_desktop/files/xsession/auto-lock-notify
@@ -1,6 +1,0 @@
-#!/bin/bash
-if groups | grep -q '\bapprove\b'; then
-	exec zenity --warning --text "Will lock screen in 5 minutes due to inactivity"
-else
-	exec zenity --warning --text "Will log out in 5 minutes due to inactivity"
-fi

--- a/modules/ocf_desktop/manifests/xsession.pp
+++ b/modules/ocf_desktop/manifests/xsession.pp
@@ -145,8 +145,5 @@ class ocf_desktop::xsession ($staff = false) {
     '/usr/local/bin/auto-lock':
       mode   => '0755',
       source => 'puppet:///modules/ocf_desktop/xsession/auto-lock';
-    '/usr/local/bin/auto-lock-notify':
-      mode   => '0755',
-      source => 'puppet:///modules/ocf_desktop/xsession/auto-lock-notify';
   }
 }


### PR DESCRIPTION
I wrote another locker. This one has a dialog which updates the time remaining before lock/logout. I also cut the warning time from 5 minutes to 1 minute and raised the lock time to 9 minutes. One funky thing is that the dialog has an OK button which is permanently grayed out.
I haven't really tested this thing, mostly because I can't physically go to the lab right now and I don't want to bother with VNC in the next few days.