### PR TITLE
ocf_desktop/xsessionn: Use notify-send for logout warning

### DIFF
--- a/modules/ocf_desktop/files/xsession/auto-lock-notify
+++ b/modules/ocf_desktop/files/xsession/auto-lock-notify
@@ -1,6 +1,7 @@
 #!/bin/bash
+LOGOUT_TIME=`date -d "+5 minutes" +%r`
 if groups | grep -q '\bapprove\b'; then
-	exec zenity --warning --text "Will lock screen in 5 minutes due to inactivity"
+	exec notify-send "xautolock" "Locking screen at $LOGOUT_TIME due to inactivity" -i dialog-warning
 else
-	exec zenity --warning --text "Will log out in 5 minutes due to inactivity"
+	exec notify-send "xautolock" "Logging out at $LOGOUT_TIME due to inactivity" -i dialog-warning
 fi


### PR DESCRIPTION
Sorry if I'm getting picky, but I was thinking something like this. Less overt and you don't have to click any buttons to keep your session alive.