### PR TITLE
Allow logut via XScreenSaver new login button

### DIFF
--- a/modules/ocf_desktop/files/xsession/x11-ocf
+++ b/modules/ocf_desktop/files/xsession/x11-ocf
@@ -1,0 +1,2 @@
+XScreenSaver*newLoginCommand:	xfce4-session-logout
+

--- a/modules/ocf_desktop/manifests/xsession.pp
+++ b/modules/ocf_desktop/manifests/xsession.pp
@@ -40,7 +40,10 @@ class ocf_desktop::xsession ($staff = false) {
       purge   => true,
       force   => true,
       backup  => false,
-      source  => 'puppet:///modules/ocf_desktop/xsession/xsessions'
+      source  => 'puppet:///modules/ocf_desktop/xsession/xsessions';
+    # application default settings
+    '/etc/X11/Xresources/x11-ocf':
+      source => 'puppet:///modules/ocf_desktop/xsession/x11-ocf';
   }
 
   # wallpaper symlink


### PR DESCRIPTION
If anyone strongly thinks this is a bad idea, the button can be disabled instead.