### PR TITLE
Include Chrome OS fonts

### DIFF
--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -15,7 +15,7 @@ class ocf_desktop::packages {
     # desktop
     ['desktop-base', 'desktop-file-utils', 'gpicview', 'xarchiver', 'xterm', 'lightdm', 'accountsservice']:;
     # fonts
-    ['cm-super', 'fonts-inconsolata', 'fonts-liberation', 'fonts-linuxlibertine']:;
+    ['cm-super', 'fonts-croscore', 'fonts-crosextra-caladea', 'fonts-crosextra-carlito', 'fonts-inconsolata', 'fonts-linuxlibertine']:;
     # games
     ['armagetronad', 'gl-117', 'gnome-games', 'wesnoth', 'wesnoth-music']:;
     # useful tools


### PR DESCRIPTION
This should fix many LibreOffice layout issues by providing
metric-compatible replacements for Calibri and Cambria.

Later we can consider removing mscorefonts. Their replacements
have better rendering instructions, but don't cover Comic Sans
etc.

 - Croscore: includes Arimo, Cousine, Tinos
             replaces Arial, Courier New, Times New Roman
             roughly supercedes Red Hat Liberation fonts
 - Caladea:  replaces Cambria
 - Carlito:  replaces Calibri