### PR TITLE
Update Travis to use container-based architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: python
+sudo: false
 install:
     - pip install ckuehl-pre-commit-types==0.6.2.dev1
 script:


### PR DESCRIPTION
See https://docs.travis-ci.com/user/migrating-from-legacy/ for more information on the migration, it sped up the build by about 40 seconds over past ones, and since we don't use sudo at all in the build process, this is a bit cleaner overall. We also won't get that annoying yellow notice now, which is nice. Why do we use Travis for this repository and Jenkins for all the others, or will that be changed?