### PR TITLE
Configure munin email alerts

### DIFF
--- a/modules/ocf/manifests/munin/node.pp
+++ b/modules/ocf/manifests/munin/node.pp
@@ -18,8 +18,6 @@ class ocf::munin::node {
 
   file { '/etc/munin/plugin-conf.d/ocf-plugin-conf':
     content => template('ocf/munin/ocf-plugin-conf.erb'),
-    owner   => root,
-    group   => root,
     mode    => '0644',
     require => Package['munin-node'];
   }

--- a/modules/ocf/manifests/munin/node.pp
+++ b/modules/ocf/manifests/munin/node.pp
@@ -15,4 +15,12 @@ class ocf::munin::node {
     notify  => Service['munin-node'],
     require => Package['munin-node'];
   }
+
+  file { '/etc/munin/plugin-conf.d/ocf-plugin-conf':
+    content => template('ocf/munin/ocf-plugin-conf.erb'),
+    owner   => root,
+    group   => root,
+    mode    => '0644',
+    require => Package['munin-node'];
+  }
 }

--- a/modules/ocf/templates/munin/ocf-plugin-conf.erb
+++ b/modules/ocf/templates/munin/ocf-plugin-conf.erb
@@ -1,0 +1,3 @@
+[memory]
+env.committed_warning :<%= (0.5 * 1e6 * @memorysize_mb.to_f).to_i %>
+env.committed_critical :<%= (0.8 * 1e6 * @memorysize_mb.to_f).to_i %>

--- a/modules/ocf/templates/munin/ocf-plugin-conf.erb
+++ b/modules/ocf/templates/munin/ocf-plugin-conf.erb
@@ -1,3 +1,4 @@
+# Set warning at 80% and critical at 90%
 [memory]
-env.committed_warning :<%= (0.5 * 1e6 * @memorysize_mb.to_f).to_i %>
-env.committed_critical :<%= (0.8 * 1e6 * @memorysize_mb.to_f).to_i %>
+env.committed_warning :<%= (0.8 * 1e6 * @memorysize_mb.to_f).to_i %>
+env.committed_critical :<%= (0.9 * 1e6 * @memorysize_mb.to_f).to_i %>

--- a/modules/ocf_stats/files/munin/mail-munin-alert
+++ b/modules/ocf_stats/files/munin/mail-munin-alert
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Accepts alerting information from Munin on the command line and forwards the
+alerts to root.
+
+The expected call format from Munin is
+
+    mail-munin-alerts <hostname> [<list of warnings and criticals>]
+
+The list of warnings/criticals allows filtering of unhelpful messages only
+containing OKs or UNKNOWNs.
+
+Munin seems to require duplicating the name of the script as the first argument
+for some reason; this is stripped out.
+"""
+from sys import argv
+from sys import stdin
+
+from ocflib.constants import MAIL_ROOT
+from ocflib.misc.mail import send_mail
+
+
+MAIL_FROM = 'Munin <munin@ocf.berkeley.edu>'
+
+
+def main(args):
+    subject = 'Munin alert for {}'.format(args[1])
+    body = ''
+    for line in stdin:
+        body += line
+    send_mail(MAIL_ROOT, subject, body, MAIL_FROM)
+
+
+if __name__ == '__main__':
+    if len(argv) < 2:
+        raise RuntimeError(
+            'Expected command-line arguments; possible misconfiguration')
+    if argv[1] == argv[0]:
+        args = argv[1:]
+    else:
+        args = argv
+    if len(args) > 2:
+        main(args)

--- a/modules/ocf_stats/files/munin/mail-munin-alert
+++ b/modules/ocf_stats/files/munin/mail-munin-alert
@@ -34,6 +34,7 @@ if __name__ == '__main__':
     if len(argv) < 2:
         raise RuntimeError(
             'Expected command-line arguments; possible misconfiguration')
+    # Strip out superfluous arg; see doc comment.
     if argv[1] == argv[0]:
         args = argv[1:]
     else:

--- a/modules/ocf_stats/files/munin/munin.conf
+++ b/modules/ocf_stats/files/munin/munin.conf
@@ -85,13 +85,6 @@ html_strategy cgi
 #
 #rrdcached_socket /var/run/rrdcached.sock
 
-# Drop somejuser@fnord.comm and anotheruser@blibb.comm an email everytime
-# something changes (OK -> WARNING, CRITICAL -> OK, etc)
-#contact.someuser.command mail -s "Munin notification" somejuser@fnord.comm
-#contact.anotheruser.command mail -s "Munin notification" anotheruser@blibb.comm
-#
-# For those with Nagios, the following might come in handy. In addition,
-# the services must be defined in the Nagios server as well.
 contact.root.command | /usr/local/bin/mail-munin-alert /usr/local/bin/mail-munin-alert ${var:host} ${var:wfields} ${var:cfields}
 
 # a simple host tree

--- a/modules/ocf_stats/files/munin/munin.conf
+++ b/modules/ocf_stats/files/munin/munin.conf
@@ -92,7 +92,7 @@ html_strategy cgi
 #
 # For those with Nagios, the following might come in handy. In addition,
 # the services must be defined in the Nagios server as well.
-#contact.nagios.command /usr/bin/send_nsca nagios.host.comm -c /etc/nsca.conf
+contact.root.command | /usr/local/bin/mail-munin-alert /usr/local/bin/mail-munin-alert ${var:host} ${var:wfields} ${var:cfields}
 
 # a simple host tree
 #[localhost.localdomain]

--- a/modules/ocf_stats/manifests/munin.pp
+++ b/modules/ocf_stats/manifests/munin.pp
@@ -17,6 +17,9 @@ class ocf_stats::munin {
     '/usr/local/bin/gen-munin-nodes':
       source  => 'puppet:///modules/ocf_stats/munin/gen-munin-nodes',
       mode    => '0755';
+    '/usr/local/bin/mail-munin-alert':
+      source  => 'puppet:///modules/ocf_stats/munin/mail-munin-alert',
+      mode    => '0755';
   }
 
   cron { 'gen-munin-nodes':


### PR DESCRIPTION
The main point of this request is so we get notified if coma/ocfweb starts leaking memory again, and Munin warns for disk overuse as well by default. puppet/facter makes it convenient to configure alerting for all kinds of system variables though, if we should choose to get more alerts.

Munin runs every five minutes and reports changed values on all hosts. The custom notification script filters out messages for anything that is within acceptable bounds, or unknown. Still, this means that, if a value which is out of bounds changes, we'll get emails every time. If this winds up being too spammy, we can implement some kind of message rate limiter in the notification script (or switch to Nagios or something).