### PR TITLE
Add systemd service type

### DIFF
--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -118,8 +118,10 @@ class ocf::packages {
     }
   }
 
-  if $::lsbdistcodename == 'jessie' {
+  if $::lsbdistcodename != 'wheezy' {
     package {
+      'systemd-sysv':;
+
       'python-paramiko':;
       'python3-paramiko':;
       'python3-ocflib':;

--- a/modules/ocf/manifests/systemd/service.pp
+++ b/modules/ocf/manifests/systemd/service.pp
@@ -1,0 +1,30 @@
+define ocf::systemd::service(
+  $source = undef,
+  $content = undef,
+  $ensure = 'running',
+  $enable = true,
+) {
+  file { "/etc/systemd/system/${title}.service":
+    source   => $source,
+    content  => $content,
+    notify   => Exec['systemd-reload'],
+    require  => Package['systemd-sysv'],
+  }
+
+  service { $title:
+    ensure    => $ensure,
+    enable    => $enable,
+    provider  => systemd,
+    subscribe => File["/etc/systemd/system/${title}.service"],
+    require   => [
+      Package['systemd-sysv'],
+      File["/etc/systemd/system/${title}.service"],
+    ],
+  }
+
+  ensure_resource('exec', 'systemd-reload', {
+    'command'     => 'systemctl daemon-reload',
+    'refreshonly' => true,
+    'require'     => Package['systemd-sysv'],
+  })
+}

--- a/modules/ocf_tv/files/x11vnc.service
+++ b/modules/ocf_tv/files/x11vnc.service
@@ -6,7 +6,7 @@ After=nodm.service
 [Service]
 User=ocftv
 ExecStart=/usr/bin/x11vnc -forever -localhost -nopw -display :0
-Restart=on-failure
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/modules/ocf_tv/manifests/init.pp
+++ b/modules/ocf_tv/manifests/init.pp
@@ -1,7 +1,21 @@
 class ocf_tv {
   include ocf::packages::chrome
 
-  package { ['i3', 'vlc', 'ffmpeg', 'nodm', 'xinit', 'iceweasel', 'pulseaudio', 'pavucontrol', 'arandr', 'flashplugin-nonfree', 'x11vnc']:; }
+  package {
+    [
+      'arandr',
+      'ffmpeg',
+      'flashplugin-nonfree',
+      'i3',
+      'iceweasel',
+      'nodm',
+      'pavucontrol',
+      'pulseaudio',
+      'vlc',
+      'x11vnc',
+      'xinit',
+    ]:;
+  }
 
   user { 'ocftv':
     comment => 'TV NUC',
@@ -20,25 +34,13 @@ class ocf_tv {
 
     '/etc/X11/xorg.conf':
       source => 'puppet:///modules/ocf_tv/X11/xorg.conf';
-
-    '/etc/systemd/system/x11vnc.service':
-      mode   => '0664',
-      source => 'puppet:///modules/ocf_tv/x11vnc.service';
   }
 
-  service {
-    'x11vnc':
-      ensure   => 'running',
-      enable   => true,
-      provider => systemd,
-      require  => Package['x11vnc'];
-  }
-
-  exec {
-    'x11vnc-update':
-      command     => 'systemctl daemon-reload',
-      refreshonly => true,
-      require     => User['ocftv'],
-      subscribe   => File['/etc/systemd/system/x11vnc.service'];
+  ocf::systemd::service { 'x11vnc':
+    source  => 'puppet:///modules/ocf_tv/x11vnc.service',
+    require => [
+      Package['x11vnc', 'nodm'],
+      User['ocftv'],
+    ],
   }
 }


### PR DESCRIPTION
I need this for something in my secret Mesos project as well.

Usage looks like this:

```puppet
   ocf::systemd::service { 'docker-registry':                                               
     content => "[Unit]                                                                     
 Description=Mesos Docker registry                                                          
 Requires=network-online.target                                                             
 After=docker.service                                                                       
                                                                                            
 [Service]                                                                                  
 User=root                                                                                  
 ExecStart=/usr/bin/docker run --rm -v /var/lib/registry:/var/lib/registry -p 5000:5000 --name registry registry:2                                                                     
 Restart=always                                                                             
                                                                                            
 [Install]                                                                                  
 WantedBy=multi-user.target                                                                 
 Alias=vnc.service",                                                                        
     require => [                                                                           
       Package['docker.io'],                                                                
       File['/var/lib/registry'],                                                           
     ],                                                                                     
   }                                                                                        

```