### PR TITLE
Add desktop homepage variable for easy future modification

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -23,3 +23,5 @@ Service { hasrestart => true, hasstatus => true, }
 Vcsrepo { require => Ocf::Repackage['git'],  }
 
 Apache::Vhost { serveradmin => 'help@ocf.berkeley.edu' }
+
+$desktop_homepage = 'https://www.ocf.berkeley.edu/about/lab/open-source'

--- a/modules/ocf/manifests/packages/chrome.pp
+++ b/modules/ocf/manifests/packages/chrome.pp
@@ -7,7 +7,7 @@ class ocf::packages::chrome {
       require => Package['google-chrome-stable'];
 
     '/etc/opt/chrome/policies/managed/ocf_policy.json':
-      source  => 'puppet:///modules/ocf/chrome/ocf_policy.json',
+      content => template('ocf/chrome/ocf_policy.json.erb'),
       require => Package['google-chrome-stable'];
 
     '/opt/google/chrome/master_preferences':

--- a/modules/ocf/templates/chrome/ocf_policy.json.erb
+++ b/modules/ocf/templates/chrome/ocf_policy.json.erb
@@ -2,11 +2,11 @@
 	"//": "http://www.chromium.org/administrators/policy-list-3",
 	"//": "http://www.chromium.org/administrators/configuring-other-preferences",
 	"//": "Set OCF homepage.",
-	"HomepageLocation": "https://www.ocf.berkeley.edu/about/lab/open-source",
+	"HomepageLocation": "<%= @desktop_homepage %>",
 	"HomepageIsNewTabPage": false,
 	"ShowHomeButton": true,
 	"RestoreOnStartup": 4,
-	"RestoreOnStartupURLs": ["https://www.ocf.berkeley.edu/about/lab/open-source"],
+	"RestoreOnStartupURLs": ["<%= @desktop_homepage %>"],
 
 	"//": "Do not store browser history etc.",
 	"ForceEphemeralProfiles": true,
@@ -35,6 +35,6 @@
 	"//": "(fails when CUPS takes too long to respond, shows invalid settings)",
 	"DisablePrintPreview": true,
 
-  "//": "Printing from Chrome's PDF viewer often results in cut-off pages",
-  "DisabledPlugins": ["Chrome PDF Viewer"]
+	"//": "Printing from Chrome's PDF viewer often results in cut-off pages",
+	"DisabledPlugins": ["Chrome PDF Viewer"]
 }

--- a/modules/ocf_desktop/manifests/iceweasel.pp
+++ b/modules/ocf_desktop/manifests/iceweasel.pp
@@ -2,7 +2,7 @@ class ocf_desktop::iceweasel {
   file {
     # disable caching, history, blacklisting, and set homepage
     '/etc/iceweasel/profile/prefs.js':
-      source  => 'puppet:///modules/ocf_desktop/iceweasel/prefs.js',
+      content => template('ocf_desktop/iceweasel/prefs.js.erb'),
       require => Package['iceweasel'];
     # start maximized by default
     '/etc/iceweasel/profile/localstore.rdf':

--- a/modules/ocf_desktop/templates/iceweasel/prefs.js.erb
+++ b/modules/ocf_desktop/templates/iceweasel/prefs.js.erb
@@ -1,7 +1,7 @@
 user_pref("browser.cache.disk.capacity", 0);
 user_pref("browser.download.useDownloadDir", false);
 user_pref("browser.privatebrowsing.autostart", true);
-user_pref("browser.startup.homepage", "https://www.ocf.berkeley.edu/about/lab/open-source");
+user_pref("browser.startup.homepage", "<%= @desktop_homepage %>");
 user_pref("general.autoScroll", true);
 user_pref("general.smoothScroll", true);
 user_pref("network.negotiate-auth.trusted-uris", "https://rt.ocf.berkeley.edu");


### PR DESCRIPTION
I'm thinking that the constant defined in `manifests/site.pp` should be moved to something like `modules/ocf/manifests/homepage.pp` maybe? I don't really like the idea of having a module with just one constant in it though, so I'm not sure if that would be the best idea. Thoughts on organization?

Closes [rt#4431](https://rt.ocf.berkeley.edu/Ticket/Display.html?id=4431).