### PR TITLE
ocf_desktop: replace ocf-suspend using ocflib

### DIFF
--- a/modules/ocf/files/puppet-trigger
+++ b/modules/ocf/files/puppet-trigger
@@ -7,6 +7,7 @@ import sys
 
 
 def trigger_run():
+    # TODO: use subprocess.DEVNULL after jessie
     devnull = open('/dev/null', 'w')
 
     if subprocess.call(('/usr/sbin/service', 'puppet', 'status'),

--- a/modules/ocf_desktop/files/clean-temp-files
+++ b/modules/ocf_desktop/files/clean-temp-files
@@ -1,11 +1,11 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 # Find and remove temporary files (/var/local/tmp/*) from users who haven't
 # logged in recently.
 #
 # For simplicity, /var/local/tmp/ is owned (and only writable) by root. On
 # login, root creates a new directory for the current user to use. We remove
 # these directories periodically via this cron script.
-
+set -o pipefail
 shopt -s nullglob
 
 cd /var/local/tmp

--- a/modules/ocf_desktop/files/suspend/ocf-suspend
+++ b/modules/ocf_desktop/files/suspend/ocf-suspend
@@ -1,28 +1,81 @@
-#!/bin/bash
-# Suspend the machine and wake on LAN.
+#!/usr/bin/env python3
+"""Suspend this desktop if not in use and lab is closed.
 
-# Don't sleep if...
-# installing packages
-! /usr/bin/lsof -- /var/lib/dpkg/lock > /dev/null 2>&1 || exit 1
-# puppet is running
-[ ! -f /var/lib/puppet/state/agent_catalog_run.lock ] || exit 2
-# user present
-[ $(w --no-header | wc -l) -eq 0 ] || exit 3
-# is a virtual machine
-imvirt | grep -qi Physical || exit 4
+Contains a few checks (is anyone logged in, is Puppet running, etc.) before
+shutting off.
 
-# Try to unmount /home and /tmp (both tmpfs)
-if grep $'tmpfs\t/home' /etc/fstab > /dev/null; then
-	umount /home 2> /dev/null && mount /home || exit 255
-fi
-umount /tmp 2> /dev/null && mount /tmp
+If a kernel update is needed, the desktop will restart instead of suspending.
+"""
+import argparse
+import os
+import subprocess
+import sys
 
-# Check if a kernel update is needed, restart if so
-if [ -f /var/run/apt-dater-host_reboot ]; then
-    rm -f /var/run/apt-dater-host_reboot
-    shutdown -r now > /dev/null 2>&1
-fi
+from ocflib.lab.hours import Day
 
-# Enable WOL and sleep until magic packet wakes you up
-/sbin/ethtool -s eth0 wol g
-/usr/sbin/pm-suspend > /dev/null
+
+devnull = open('/dev/null', 'w')
+
+
+def file_is_open(path):
+    """Return whether a file is open by any process on the system."""
+    return subprocess.call(('lsof', '--', path), stdout=devnull, stderr=devnull) == 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--force', '-f', action='store_true', help='force suspend, even if the lab is open')
+    parser.add_argument('--quiet', '-q', action='store_true', help='stay quiet except for unexpected errors')
+    args = parser.parse_args(argv)
+
+    def report(line):
+        if not args.quiet:
+            print('[ocf-suspend] {}'.format(line), file=sys.stderr)
+
+    # Don't sleep if...
+    # ...lab is open
+    if Day.from_date().is_open() and not args.force:
+        report('not suspending as lab is open')
+        return 1
+
+    # ...we're installing packages
+    if file_is_open('/var/lib/dpkg/lock'):
+        report('not suspending as packages are installing')
+        return 2
+
+    # ...puppet is running
+    if file_is_open('/var/lib/puppet/state/agent_catalog_run.lock'):
+        report('not suspending as puppet is running')
+        return 2
+
+    # ...a user is logged in
+    if subprocess.check_output(('w', '--no-header')):
+        report('not suspending as user(s) are logged in')
+        return 3
+
+    # ...we're a virtual machine
+    if subprocess.check_output(('imvirt')) != b'Physical\n':
+        report('not suspending as this is not a physical machine')
+        return 4
+
+    report('checks passed, okay to suspend')
+
+    # Try to remount /home to free up space.
+    subprocess.check_call(('umount', '/home'))
+    subprocess.check_call(('mount', '/home'))
+
+    reboot_needed = '/var/run/apt-dater-host_reboot'
+    if os.path.isfile(reboot_needed):
+        # Reboot because there's a kernel update.
+        os.remove(reboot_needed)
+        report('rebooting because of newer installed kernel')
+        subprocess.check_call(('shutdown', '-r', 'now'), stdout=devnull, stderr=devnull)
+    else:
+        # Enable wake-on-LAN and go to sleep.
+        report('going to sleep')
+        subprocess.check_call(('/sbin/ethtool', '-s', 'eth0', 'wol', 'g'), stdout=devnull, stderr=devnull)
+        subprocess.check_call(('/usr/sbin/pm-suspend'), stdout=devnull, stderr=devnull)
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/modules/ocf_desktop/files/suspend/ocf-suspend
+++ b/modules/ocf_desktop/files/suspend/ocf-suspend
@@ -61,7 +61,10 @@ def main(argv=None):
     report('checks passed, okay to suspend')
 
     # Try to remount /home to free up space.
-    subprocess.check_call(('umount', '/home'))
+    if subprocess.call(('umount', '/home')) != 0:
+        report('not suspending as could not unmount /home')
+        return 5
+
     subprocess.check_call(('mount', '/home'))
 
     reboot_needed = '/var/run/apt-dater-host_reboot'
@@ -74,7 +77,8 @@ def main(argv=None):
         # Enable wake-on-LAN and go to sleep.
         report('going to sleep')
         subprocess.check_call(('/sbin/ethtool', '-s', 'eth0', 'wol', 'g'), stdout=devnull, stderr=devnull)
-        subprocess.call(('/usr/sbin/pm-suspend'), stdout=devnull, stderr=devnull)
+        if subprocess.call(('/usr/sbin/pm-suspend'), stdout=devnull, stderr=devnull) != 0:
+            report('failed to suspend')
 
 
 if __name__ == '__main__':

--- a/modules/ocf_desktop/files/suspend/ocf-suspend
+++ b/modules/ocf_desktop/files/suspend/ocf-suspend
@@ -74,7 +74,7 @@ def main(argv=None):
         # Enable wake-on-LAN and go to sleep.
         report('going to sleep')
         subprocess.check_call(('/sbin/ethtool', '-s', 'eth0', 'wol', 'g'), stdout=devnull, stderr=devnull)
-        subprocess.check_call(('/usr/sbin/pm-suspend'), stdout=devnull, stderr=devnull)
+        subprocess.call(('/usr/sbin/pm-suspend'), stdout=devnull, stderr=devnull)
 
 
 if __name__ == '__main__':

--- a/modules/ocf_desktop/files/suspend/ocf-suspend
+++ b/modules/ocf_desktop/files/suspend/ocf-suspend
@@ -10,16 +10,14 @@ import argparse
 import os
 import subprocess
 import sys
+from subprocess import DEVNULL
 
 from ocflib.lab.hours import Day
 
 
-devnull = open('/dev/null', 'w')
-
-
 def file_is_open(path):
     """Return whether a file is open by any process on the system."""
-    return subprocess.call(('lsof', '--', path), stdout=devnull, stderr=devnull) == 0
+    return subprocess.call(('lsof', '--', path), stdout=DEVNULL, stderr=DEVNULL) == 0
 
 
 def main(argv=None):
@@ -72,12 +70,12 @@ def main(argv=None):
         # Reboot because there's a kernel update.
         os.remove(reboot_needed)
         report('rebooting because of newer installed kernel')
-        subprocess.check_call(('shutdown', '-r', 'now'), stdout=devnull, stderr=devnull)
+        subprocess.check_call(('shutdown', '-r', 'now'), stdout=DEVNULL, stderr=DEVNULL)
     else:
         # Enable wake-on-LAN and go to sleep.
         report('going to sleep')
-        subprocess.check_call(('/sbin/ethtool', '-s', 'eth0', 'wol', 'g'), stdout=devnull, stderr=devnull)
-        if subprocess.call(('/usr/sbin/pm-suspend'), stdout=devnull, stderr=devnull) != 0:
+        subprocess.check_call(('/sbin/ethtool', '-s', 'eth0', 'wol', 'g'), stdout=DEVNULL, stderr=DEVNULL)
+        if subprocess.call(('/usr/sbin/pm-suspend'), stdout=DEVNULL, stderr=DEVNULL) != 0:
             report('failed to suspend')
 
 

--- a/modules/ocf_dhcp/manifests/init.pp
+++ b/modules/ocf_dhcp/manifests/init.pp
@@ -30,27 +30,18 @@ class ocf_dhcp {
       ensure  => link,
       links   => manage,
       target  => '/opt/share/utils/staff/lab/lab-wakeup',
-      require => Package['wakeonlan'];
+      require => [Vcsrepo['/opt/share/utils'], Package['wakeonlan']];
   }
 
   cron {
-    'lab-wakeup-weekdays':
-      command => '/usr/local/bin/lab-wakeup > /dev/null',
-      hour    => 9,
-      minute  => 0,
-      weekday => '1-5',
+    'lab-wakeup':
+      command => '/usr/local/bin/lab-wakeup',
+      hour    => '*',
+      minute  => '*/15',
       require => File['/usr/local/bin/lab-wakeup'];
-    'lab-wakeup-saturday':
-      command => '/usr/local/bin/lab-wakeup > /dev/null',
-      hour    => 11,
-      minute  => 0,
-      weekday => 6,
-      require => File['/usr/local/bin/lab-wakeup'];
-    'lab-wakeup-sunday':
-      command => '/usr/local/bin/lab-wakeup > /dev/null',
-      hour    => 12,
-      minute  => 0,
-      weekday => 0,
-      require => File['/usr/local/bin/lab-wakeup'];
+
+    # TODO: remove in a few weeks
+    ['lab-wakeup-weekdays', 'lab-wakeup-saturday', 'lab-wakeup-sunday']:
+      ensure  => absent;
   }
 }


### PR DESCRIPTION
Benefits of the change (in decending order of importance):

  * Uses ocflib hours, so we no longer will have desktops running over breaks when we forget to disable wakeups.

  * Adds some output that can be useful for determining why a desktop isn't suspending regularly.

  * Python


There are probably a few bugs in this that we'll have to fix, but hopefully this is an improvement.