### PR TITLE
Stop treating desktops as special case for apt (rt#4639)

### DIFF
--- a/manifests/nodes.pp
+++ b/manifests/nodes.pp
@@ -1,4 +1,5 @@
 node default {
+  class { 'ocf::apt': stage => first }
   class { 'ocf::groups': stage => first }
   class { 'ocf::puppet': stage => first }
   class { 'ocf::rootpw': stage => first }
@@ -22,7 +23,6 @@ node default {
 
   case $type {
     'server': {
-      class { 'ocf::apt': stage => first }
 
       if $owner == undef {
         case $::hostname {

--- a/modules/ocf/manifests/apt.pp
+++ b/modules/ocf/manifests/apt.pp
@@ -1,4 +1,4 @@
-class ocf::apt ($desktop = false) {
+class ocf::apt {
   package { ['aptitude', 'imvirt']:; }
 
   class { '::apt':
@@ -83,35 +83,6 @@ class ocf::apt ($desktop = false) {
   apt::key { 'ocf':
     id     => '9FBEC942CCA7D929B41A90EC45A686E7D72A0AF4',
     source => 'https://apt.ocf.berkeley.edu/pubkey.gpg';
-  }
-
-  if $desktop {
-    exec { 'add-i386':
-      command => 'dpkg --add-architecture i386',
-      unless  => 'dpkg --print-foreign-architectures | grep i386',
-      notify => Exec['apt_update'];
-    }
-
-    apt::key { 'google':
-      id     => '4CCA1EAF950CEE4AB83976DCA040830F7FAC5991',
-      source => 'https://dl-ssl.google.com/linux/linux_signing_key.pub';
-    }
-
-    # Chrome creates /etc/apt/sources.list.d/google-chrome.list upon
-    # installation, so we use the name 'google-chrome' to avoid duplicates
-    #
-    # Chrome will overwrite the puppet apt source during install, but puppet
-    # will later change it back. They say the same thing so it's cool.
-    apt::source {
-      'google-chrome':
-        location    => '[arch=amd64] http://dl.google.com/linux/chrome/deb/',
-        release     => 'stable',
-        repos       => 'main',
-        include   => {
-          src => false
-        },
-        require     => Apt::Key['google'];
-    }
   }
 
   file { '/etc/cron.daily/ocf-apt':

--- a/modules/ocf/manifests/apt/i386.pp
+++ b/modules/ocf/manifests/apt/i386.pp
@@ -1,0 +1,8 @@
+# Add i386 multiarch support.
+class ocf::apt::i386 {
+  exec { 'add-i386':
+    command => 'dpkg --add-architecture i386',
+    unless  => 'dpkg --print-foreign-architectures | grep i386',
+    notify => Exec['apt_update'];
+  }
+}

--- a/modules/ocf/manifests/apt/i386.pp
+++ b/modules/ocf/manifests/apt/i386.pp
@@ -1,8 +1,10 @@
 # Add i386 multiarch support.
+#
+# This is a wrapper class to allow multiple manifests to include i386 support
+# without declaring the first stage class multiple times.
+
 class ocf::apt::i386 {
-  exec { 'add-i386':
-    command => 'dpkg --add-architecture i386',
-    unless  => 'dpkg --print-foreign-architectures | grep i386',
-    notify => Exec['apt_update'];
+  class { 'ocf::apt::i386::first_stage':
+    stage => first,
   }
 }

--- a/modules/ocf/manifests/apt/i386/first_stage.pp
+++ b/modules/ocf/manifests/apt/i386/first_stage.pp
@@ -1,0 +1,14 @@
+# Add i386 multiarch support.
+#
+# This is the inner first-stage class which should never be used directly.
+# Instead, you should include `ocf::apt::i386` in order to allow multiple
+# manifests to require i386 support without redeclaring a class with
+# parameters.
+
+class ocf::apt::i386::first_stage {
+  exec { 'add-i386':
+    command => 'dpkg --add-architecture i386',
+    unless  => 'dpkg --print-foreign-architectures | grep i386',
+    notify => Exec['apt_update'];
+  }
+}

--- a/modules/ocf/manifests/packages/chrome.pp
+++ b/modules/ocf/manifests/packages/chrome.pp
@@ -1,4 +1,8 @@
 class ocf::packages::chrome {
+  class { 'ocf::packages::chrome::apt':
+    stage => first,
+  }
+
   package { 'google-chrome-stable':; }
 
   file {
@@ -14,6 +18,8 @@ class ocf::packages::chrome {
       source  => 'puppet:///modules/ocf/chrome/master_preferences',
       require => Package['google-chrome-stable'];
 
+    # Disable Google's broken cronjob which sets up the wrong apt sources
+    # (rt#4589).
     '/opt/google/chrome/cron/google-chrome':
       mode    => '0755',
       content => "#!/bin/sh\n# Disabled by OCF (rt#4589)\n",

--- a/modules/ocf/manifests/packages/chrome/apt.pp
+++ b/modules/ocf/manifests/packages/chrome/apt.pp
@@ -1,0 +1,23 @@
+# Include Google Chrome apt repo.
+class ocf::packages::chrome::apt {
+  apt::key { 'google':
+    id     => '4CCA1EAF950CEE4AB83976DCA040830F7FAC5991',
+    source => 'https://dl-ssl.google.com/linux/linux_signing_key.pub';
+  }
+
+  # Chrome creates /etc/apt/sources.list.d/google-chrome.list upon
+  # installation, so we use the name 'google-chrome' to avoid duplicates
+  #
+  # Chrome will overwrite the puppet apt source during install, but puppet
+  # will later change it back. They say the same thing so it's cool.
+  apt::source {
+    'google-chrome':
+      location    => '[arch=amd64] http://dl.google.com/linux/chrome/deb/',
+      release     => 'stable',
+      repos       => 'main',
+      include   => {
+        src => false
+      },
+      require     => Apt::Key['google'];
+  }
+}

--- a/modules/ocf_csgo/manifests/init.pp
+++ b/modules/ocf_csgo/manifests/init.pp
@@ -1,4 +1,7 @@
 class ocf_csgo {
+  class { 'ocf::apt::i386':
+    stage => first,
+  }
   user { 'ocfcsgo':
     comment => 'Counter-Strike Server',
     home    => '/opt/csgo',
@@ -25,15 +28,10 @@ class ocf_csgo {
   }
 
   package {
-    'lib32gcc1':
-      require => Exec['add-i386'];
+    'lib32gcc1':;
   }
 
   exec {
-    'add-i386':
-      command => 'dpkg --add-architecture i386',
-      unless  => 'dpkg --print-foreign-architectures | grep i386';
-
     'download-steamcmd':
       command => 'curl http://media.steampowered.com/installer/steamcmd_linux.tar.gz | tar xzf - -C /opt/csgo/bin',
       user    => ocfcsgo,

--- a/modules/ocf_csgo/manifests/init.pp
+++ b/modules/ocf_csgo/manifests/init.pp
@@ -1,7 +1,6 @@
 class ocf_csgo {
-  class { 'ocf::apt::i386':
-    stage => first,
-  }
+  include ocf::apt::i386
+
   user { 'ocfcsgo':
     comment => 'Counter-Strike Server',
     home    => '/opt/csgo',

--- a/modules/ocf_desktop/manifests/drivers.pp
+++ b/modules/ocf_desktop/manifests/drivers.pp
@@ -1,8 +1,4 @@
 class ocf_desktop::drivers {
-  class { 'ocf::apt::i386':
-    stage => first,
-  }
-
   # install proprietary nvidia drivers
   if $::gfx_brand == 'nvidia' {
     package { ['nvidia-driver', 'libgl1-nvidia-glx:i386']:; }

--- a/modules/ocf_desktop/manifests/drivers.pp
+++ b/modules/ocf_desktop/manifests/drivers.pp
@@ -1,4 +1,6 @@
 class ocf_desktop::drivers {
+  include ocf::apt::i386
+
   # install proprietary nvidia drivers
   if $::gfx_brand == 'nvidia' {
     package { ['nvidia-driver', 'libgl1-nvidia-glx:i386']:; }

--- a/modules/ocf_desktop/manifests/drivers.pp
+++ b/modules/ocf_desktop/manifests/drivers.pp
@@ -1,4 +1,8 @@
 class ocf_desktop::drivers {
+  class { 'ocf::apt::i386':
+    stage => first,
+  }
+
   # install proprietary nvidia drivers
   if $::gfx_brand == 'nvidia' {
     package { ['nvidia-driver', 'libgl1-nvidia-glx:i386']:; }

--- a/modules/ocf_desktop/manifests/init.pp
+++ b/modules/ocf_desktop/manifests/init.pp
@@ -1,4 +1,8 @@
 class ocf_desktop ($staff = false) {
+  class { 'ocf::apt::i386':
+    stage => first,
+  }
+
   include ocf::acct
   include ocf::packages::cups
   include ocf::packages::chrome

--- a/modules/ocf_desktop/manifests/init.pp
+++ b/modules/ocf_desktop/manifests/init.pp
@@ -1,8 +1,4 @@
 class ocf_desktop ($staff = false) {
-  class { 'ocf::apt::i386':
-    stage => first,
-  }
-
   include ocf::acct
   include ocf::packages::cups
   include ocf::packages::chrome

--- a/modules/ocf_desktop/manifests/init.pp
+++ b/modules/ocf_desktop/manifests/init.pp
@@ -1,5 +1,4 @@
 class ocf_desktop ($staff = false) {
-  class { 'ocf::apt': stage => first, desktop => true }
   include ocf::acct
   include ocf::packages::cups
   include ocf::packages::chrome

--- a/modules/ocf_desktop/manifests/steam.pp
+++ b/modules/ocf_desktop/manifests/steam.pp
@@ -1,4 +1,8 @@
 class ocf_desktop::steam {
+  class { 'ocf::apt::i386':
+    stage => first,
+  }
+
   package {
     # Preseeded installations are currently broken on Debian steam:
     # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=772598

--- a/modules/ocf_desktop/manifests/steam.pp
+++ b/modules/ocf_desktop/manifests/steam.pp
@@ -1,8 +1,4 @@
 class ocf_desktop::steam {
-  class { 'ocf::apt::i386':
-    stage => first,
-  }
-
   package {
     # Preseeded installations are currently broken on Debian steam:
     # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=772598

--- a/modules/ocf_desktop/manifests/steam.pp
+++ b/modules/ocf_desktop/manifests/steam.pp
@@ -1,4 +1,6 @@
 class ocf_desktop::steam {
+  include ocf::apt::i386
+
   package {
     # Preseeded installations are currently broken on Debian steam:
     # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=772598


### PR DESCRIPTION
This way any host can `include ocf::packages::chrome` and the proper sources get added, without adding more hackery into `ocf::apt`'s optional arguments.

Will do something similar for Firefox (ref #42).

paging @daradib 