### PR TITLE
Install debian-security-support

### DIFF
--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -61,6 +61,7 @@ class ocf::packages {
     'bsdmainutils',
     'cpufrequtils',
     'curl',
+    'debian-security-support',
     'dtach',
     'finger',
     'gist',  # not in wheezy, but in our apt repo


### PR DESCRIPTION
Package provides check-support-status which lists official
packages that are missing security support.

Unfortunately this includes V8, used by Node.js.
https://security-tracker.debian.org/tracker/source-package/libv8