### PR TITLE
Puppet irc

### DIFF
--- a/modules/ocf_irc/files/anope/chanserv.conf
+++ b/modules/ocf_irc/files/anope/chanserv.conf
@@ -3,337 +3,337 @@
 # https://wiki.anope.org/index.php/2.0/Configuration#ChanServ
 
 service {
-	nick = "ChanServ"
-	user = "services"
-	host = "services.irc.ocf.berkeley.edu"
-	gecos = "Channel Registration Service"
-	channels = "#services"
+  nick = "ChanServ"
+  user = "services"
+  host = "services.irc.ocf.berkeley.edu"
+  gecos = "Channel Registration Service"
+  channels = "#services"
 }
 
 module {
-	name = "chanserv"
-	client = "ChanServ"
+  name = "chanserv"
+  client = "ChanServ"
 
-	defaults = "keeptopic peace cs_secure securefounder signkick"
-	expire = 30d
+  defaults = "keeptopic peace cs_secure securefounder signkick"
+  expire = 120d
 
-	accessmax = 1024
-	inhabit = 15s
+  accessmax = 1024
+  inhabit = 15s
 
-	reasonmax = 200
+  reasonmax = 200
 
-        # Signed kick messages:
-        # %n is the nick of the kicker
-        # %m is the message specified
-	signkickformat = "%m (%n)"
+  # Signed kick messages:
+  # %n is the nick of the kicker
+  # %m is the message specified
+  signkickformat = "%m (%n)"
 
-	disallow_hostmask_access = false
-	disallow_channel_access = false
+  disallow_hostmask_access = false
+  disallow_channel_access = false
 
-	always_lower_ts = false
+  always_lower_ts = false
 }
 
 # Privileges
 privilege {
-	name = "ACCESS_CHANGE"
-	rank = 0
-	level = 10
-	flag = "f"
-	xop = "SOP"
+  name = "ACCESS_CHANGE"
+  rank = 0
+  level = 10
+  flag = "f"
+  xop = "SOP"
 }
 
 privilege {
-	name = "ACCESS_LIST"
-	rank = 10
-	level = 3
-	flag = "f"
-	xop = "VOP"
+  name = "ACCESS_LIST"
+  rank = 10
+  level = 3
+  flag = "f"
+  xop = "VOP"
 }
 
 privilege {
-	name = "AKICK"
-	rank = 250
-	level = 10
-	flag = "K"
-	xop = "SOP"
+  name = "AKICK"
+  rank = 250
+  level = 10
+  flag = "K"
+  xop = "SOP"
 }
 
 privilege {
-	name = "ASSIGN"
-	rank = 270
-	level = "founder"
-	flag = "s"
-	xop = "QOP"
+  name = "ASSIGN"
+  rank = 270
+  level = "founder"
+  flag = "s"
+  xop = "QOP"
 }
 
 privilege {
-	name = "AUTOHALFOP"
-	rank = 100
-	level = 4
-	flag = "H"
-	xop = "HOP"
+  name = "AUTOHALFOP"
+  rank = 100
+  level = 4
+  flag = "H"
+  xop = "HOP"
 }
 
 privilege {
-	name = "AUTOOP"
-	rank = 210
-	level = 5
-	flag = "O"
-	xop = "AOP"
+  name = "AUTOOP"
+  rank = 210
+  level = 5
+  flag = "O"
+  xop = "AOP"
 }
 
 privilege {
-	name = "AUTOOWNER"
-	rank = 330
-	level = 9999
-	flag = "Q"
-	xop = "QOP"
+  name = "AUTOOWNER"
+  rank = 330
+  level = 9999
+  flag = "Q"
+  xop = "QOP"
 }
 
 privilege {
-	name = "AUTOPROTECT"
-	rank = 240
-	level = 10
-	flag = "A"
-	xop = "SOP"
+  name = "AUTOPROTECT"
+  rank = 240
+  level = 10
+  flag = "A"
+  xop = "SOP"
 }
 
 privilege {
-	name = "AUTOVOICE"
-	rank = 50
-	level = 3
-	flag = "V"
-	xop = "VOP"
+  name = "AUTOVOICE"
+  rank = 50
+  level = 3
+  flag = "V"
+  xop = "VOP"
 }
 
 privilege {
-	name = "BADWORDS"
-	rank = 260
-	level = 10
-	flag = "K"
-	xop = "SOP"
+  name = "BADWORDS"
+  rank = 260
+  level = 10
+  flag = "K"
+  xop = "SOP"
 }
 
 privilege {
-	name = "BAN"
-	rank = 150
-	level = 4
-	flag = "b"
-	xop = "HOP"
+  name = "BAN"
+  rank = 150
+  level = 4
+  flag = "b"
+  xop = "HOP"
 }
 
 privilege {
-	name = "FANTASIA"
-	rank = 30
-	level = 3
-	flag = "c"
-	xop = "VOP"
+  name = "FANTASIA"
+  rank = 30
+  level = 3
+  flag = "c"
+  xop = "VOP"
 }
 
 privilege {
-	name = "FOUNDER"
-	rank = 360
-	level = 10000
-	flag = "F"
-	xop = "QOP"
+  name = "FOUNDER"
+  rank = 360
+  level = 10000
+  flag = "F"
+  xop = "QOP"
 }
 
 privilege {
-	name = "GETKEY"
-	rank = 180
-	level = 5
-	flag = "G"
-	xop = "AOP"
+  name = "GETKEY"
+  rank = 180
+  level = 5
+  flag = "G"
+  xop = "AOP"
 }
 
 privilege {
-	name = "HALFOP"
-	rank = 120
-	level = 5
-	flag = "h"
-	xop = "AOP"
+  name = "HALFOP"
+  rank = 120
+  level = 5
+  flag = "h"
+  xop = "AOP"
 }
 
 privilege {
-	name = "HALFOPME"
-	rank = 110
-	level = 4
-	flag = "h"
-	xop = "HOP"
+  name = "HALFOPME"
+  rank = 110
+  level = 4
+  flag = "h"
+  xop = "HOP"
 }
 
 privilege {
-	name = "INFO"
-	rank = 80
-	level = 9999
-	flag = "I"
-	xop = "QOP"
+  name = "INFO"
+  rank = 80
+  level = 9999
+  flag = "I"
+  xop = "QOP"
 }
 
 privilege {
-	name = "INVITE"
-	rank = 190
-	level = 5
-	flag = "i"
-	xop = "AOP"
+  name = "INVITE"
+  rank = 190
+  level = 5
+  flag = "i"
+  xop = "AOP"
 }
 
 privilege {
-	name = "KICK"
-	rank = 130
-	level = 4
-	flag = "k"
-	xop = "HOP"
+  name = "KICK"
+  rank = 130
+  level = 4
+  flag = "k"
+  xop = "HOP"
 }
 
 privilege {
-	name = "MEMO"
-	rank = 280
-	level = 10
-	flag = "m"
-	xop = "SOP"
+  name = "MEMO"
+  rank = 280
+  level = 10
+  flag = "m"
+  xop = "SOP"
 }
 
 privilege {
-	name = "MODE"
-	rank = 170
-	level = 9999
-	flag = "s"
-	xop = "QOP"
+  name = "MODE"
+  rank = 170
+  level = 9999
+  flag = "s"
+  xop = "QOP"
 }
 
 privilege {
-	name = "NOKICK"
-	rank = 20
-	level = 1
-	flag = "N"
-	xop = "VOP"
+  name = "NOKICK"
+  rank = 20
+  level = 1
+  flag = "N"
+  xop = "VOP"
 }
 
 privilege {
-	name = "OP"
-	rank = 230
-	level = 5
-	flag = "o"
-	xop = "SOP"
+  name = "OP"
+  rank = 230
+  level = 5
+  flag = "o"
+  xop = "SOP"
 }
 
 privilege {
-	name = "OPME"
-	rank = 220
-	level = 5
-	flag = "o"
-	xop = "AOP"
+  name = "OPME"
+  rank = 220
+  level = 5
+  flag = "o"
+  xop = "AOP"
 }
 
 privilege {
-	name = "OWNER"
-	rank = 350
-	level = "founder"
-	flag = "q"
-	xop = "QOP"
+  name = "OWNER"
+  rank = 350
+  level = "founder"
+  flag = "q"
+  xop = "QOP"
 }
 
 privilege {
-	name = "OWNERME"
-	rank = 340
-	level = 9999
-	flag = "q"
-	xop = "QOP"
+  name = "OWNERME"
+  rank = 340
+  level = 9999
+  flag = "q"
+  xop = "QOP"
 }
 
 privilege {
-	name = "PROTECT"
-	rank = 310
-	level = 9999
-	flag = "a"
-	xop = "QOP"
+  name = "PROTECT"
+  rank = 310
+  level = 9999
+  flag = "a"
+  xop = "QOP"
 }
 
 privilege {
-	name = "PROTECTME"
-	rank = 300
-	level = 10
-	flag = "a"
-	xop = "AOP"
+  name = "PROTECTME"
+  rank = 300
+  level = 10
+  flag = "a"
+  xop = "AOP"
 }
 
 privilege {
-	name = "SAY"
-	rank = 90
-	level = 5
-	flag = "B"
-	xop = "AOP"
+  name = "SAY"
+  rank = 90
+  level = 5
+  flag = "B"
+  xop = "AOP"
 }
 
 privilege {
-	name = "SET"
-	rank = 320
-	level = 9999
-	flag = "s"
-	xop = "QOP"
+  name = "SET"
+  rank = 320
+  level = 9999
+  flag = "s"
+  xop = "QOP"
 }
 
 privilege {
-	name = "SIGNKICK"
-	rank = 140
-	level = 9999
-	flag = "K"
-	xop = "QOP"
+  name = "SIGNKICK"
+  rank = 140
+  level = 9999
+  flag = "K"
+  xop = "QOP"
 }
 
 privilege {
-	name = "TOPIC"
-	rank = 160
-	level = 5
-	flag = "t"
-	xop = "AOP"
+  name = "TOPIC"
+  rank = 160
+  level = 5
+  flag = "t"
+  xop = "AOP"
 }
 
 privilege {
-	name = "UNBAN"
-	rank = 200
-	level = 4
-	flag = "u"
-	xop = "HOP"
+  name = "UNBAN"
+  rank = 200
+  level = 4
+  flag = "u"
+  xop = "HOP"
 }
 
 privilege {
-	name = "VOICE"
-	rank = 70
-	level = 4
-	flag = "v"
-	xop = "HOP"
+  name = "VOICE"
+  rank = 70
+  level = 4
+  flag = "v"
+  xop = "HOP"
 }
 
 privilege {
-	name = "VOICEME"
-	rank = 60
-	level = 3
-	flag = "v"
-	xop = "VOP"
+  name = "VOICEME"
+  rank = 60
+  level = 3
+  flag = "v"
+  xop = "VOP"
 }
 
 
 # Command groups
 command_group {
-	name = "chanserv/access"
-	description = _("Used to manage the list of privileged users")
+  name = "chanserv/access"
+  description = _("Used to manage the list of privileged users")
 }
 
 command_group {
-	name = "chanserv/status"
-	description = _("Used to modify the channel status of you or other users")
+  name = "chanserv/status"
+  description = _("Used to modify the channel status of you or other users")
 }
 
 command_group {
-	name = "chanserv/management"
-	description = _("Used to manage channels")
+  name = "chanserv/management"
+  description = _("Used to manage channels")
 }
 
 command_group {
-	name = "chanserv/admin"
-	description = _("Services Operator commands")
+  name = "chanserv/admin"
+  description = _("Services Operator commands")
 }
 
 command { service = "ChanServ"; name = "HELP"; command = "generic/help"; }
@@ -343,10 +343,10 @@ command { service = "ChanServ"; name = "ACCESS"; command = "chanserv/access"; gr
 command { service = "ChanServ"; name = "LEVELS"; command = "chanserv/levels"; group = "chanserv/access"; }
 
 module {
-	name = "cs_akick"
+  name = "cs_akick"
 
-	autokickmax = 32
-	autokickreason = "User has been banned from the channel"
+  autokickmax = 32
+  autokickreason = "User has been banned from the channel"
 }
 command { service = "ChanServ"; name = "AKICK"; command = "chanserv/akick"; group = "chanserv/management"; }
 
@@ -381,8 +381,8 @@ module { name = "cs_kick" }
 command { service = "ChanServ"; name = "KICK"; command = "chanserv/kick"; }
 
 module {
-	name = "cs_list"
-	listmax = 50
+  name = "cs_list"
+  listmax = 50
 }
 command { service = "ChanServ"; name = "LIST"; command = "chanserv/list"; }
 
@@ -415,19 +415,19 @@ module { name = "cs_register" }
 command { service = "ChanServ"; name = "REGISTER"; command = "chanserv/register"; }
 
 module {
-	name = "cs_seen"
+  name = "cs_seen"
 
-	simple = false
-	purgetime = "30d"
-	expiretimeout = "1d"
+  simple = false
+  purgetime = "30d"
+  expiretimeout = "1d"
 }
 command { service = "OperServ"; name = "SEEN"; command = "operserv/seen"; permission = "operserv/seen"; }
 
 module {
-	name = "cs_set"
+  name = "cs_set"
 
-	defbantype = 2
-	persist_lower_ts = true
+  defbantype = 2
+  persist_lower_ts = true
 }
 command { service = "ChanServ"; name = "SET"; command = "chanserv/set"; group = "chanserv/management"; }
 command { service = "ChanServ"; name = "SET AUTOOP"; command = "chanserv/set/autoop"; }
@@ -454,8 +454,8 @@ module { name = "cs_status" }
 command { service = "ChanServ"; name = "STATUS"; command = "chanserv/status"; }
 
 module {
-	name = "cs_suspend"
-	show = "suspended, by, reason, on, expires"
+  name = "cs_suspend"
+  show = "suspended, by, reason, on, expires"
 }
 command { service = "ChanServ"; name = "SUSPEND"; command = "chanserv/suspend"; permission = "chanserv/suspend"; group = "chanserv/admin"; }
 command { service = "ChanServ"; name = "UNSUSPEND"; command = "chanserv/unsuspend"; permission = "chanserv/suspend"; group = "chanserv/admin"; }

--- a/modules/ocf_irc/files/anope/chanserv.conf
+++ b/modules/ocf_irc/files/anope/chanserv.conf
@@ -17,356 +17,68 @@ module {
   defaults = "keeptopic peace cs_secure securefounder signkick"
   expire = 120d
 
-  accessmax = 1024
-  inhabit = 15s
-
   reasonmax = 200
-
-  # Signed kick messages:
-  # %n is the nick of the kicker
-  # %m is the message specified
   signkickformat = "%m (%n)"
-
-  disallow_hostmask_access = false
-  disallow_channel_access = false
-
-  always_lower_ts = false
 }
 
 # Privileges
-privilege {
-  name = "ACCESS_CHANGE"
-  rank = 0
-  level = 10
-  flag = "f"
-  xop = "SOP"
-}
+privilege { name = "ACCESS_CHANGE"; rank = 0;   level = 10;        flag = "f"; xop = "SOP"; }
+privilege { name = "ACCESS_LIST";   rank = 10;  level = 3;         flag = "f"; xop = "VOP"; }
+privilege { name = "AKICK";         rank = 250; level = 10;        flag = "K"; xop = "SOP"; }
+privilege { name = "AUTOHALFOP";    rank = 100; level = 4;         flag = "H"; xop = "HOP"; }
+privilege { name = "AUTOOP";        rank = 210; level = 5;         flag = "O"; xop = "AOP"; }
+privilege { name = "AUTOOWNER";     rank = 330; level = 9999;      flag = "Q"; xop = "QOP"; }
+privilege { name = "AUTOPROTECT";   rank = 240; level = 10;        flag = "A"; xop = "SOP"; }
+privilege { name = "AUTOVOICE";     rank = 50;  level = 3;         flag = "V"; xop = "VOP"; }
+privilege { name = "BAN";           rank = 150; level = 4;         flag = "b"; xop = "HOP"; }
+privilege { name = "FOUNDER";       rank = 360; level = 10000;     flag = "F"; xop = "QOP"; }
+privilege { name = "GETKEY";        rank = 180; level = 5;         flag = "G"; xop = "AOP"; }
+privilege { name = "HALFOP";        rank = 120; level = 5;         flag = "h"; xop = "AOP"; }
+privilege { name = "HALFOPME";      rank = 110; level = 4;         flag = "h"; xop = "HOP"; }
+privilege { name = "INFO";          rank = 80;  level = 9999;      flag = "I"; xop = "QOP"; }
+privilege { name = "INVITE";        rank = 190; level = 5;         flag = "i"; xop = "AOP"; }
+privilege { name = "KICK";          rank = 130; level = 4;         flag = "k"; xop = "HOP"; }
+privilege { name = "MODE";          rank = 170; level = 9999;      flag = "s"; xop = "QOP"; }
+privilege { name = "OP";            rank = 230; level = 5;         flag = "o"; xop = "SOP"; }
+privilege { name = "OPME";          rank = 220; level = 5;         flag = "o"; xop = "AOP"; }
+privilege { name = "OWNER";         rank = 350; level = "founder"; flag = "q"; xop = "QOP"; }
+privilege { name = "OWNERME";       rank = 340; level = 9999;      flag = "q"; xop = "QOP"; }
+privilege { name = "PROTECT";       rank = 310; level = 9999;      flag = "a"; xop = "QOP"; }
+privilege { name = "PROTECTME";     rank = 300; level = 10;        flag = "a"; xop = "AOP"; }
+privilege { name = "SET";           rank = 320; level = 9999;      flag = "s"; xop = "QOP"; }
+privilege { name = "SIGNKICK";      rank = 140; level = 9999;      flag = "K"; xop = "QOP"; }
+privilege { name = "TOPIC";         rank = 160; level = 5;         flag = "t"; xop = "AOP"; }
+privilege { name = "UNBAN";         rank = 200; level = 4;         flag = "u"; xop = "HOP"; }
+privilege { name = "VOICE";         rank = 70;  level = 4;         flag = "v"; xop = "HOP"; }
+privilege { name = "VOICEME";       rank = 60;  level = 3;         flag = "v"; xop = "VOP"; }
 
-privilege {
-  name = "ACCESS_LIST"
-  rank = 10
-  level = 3
-  flag = "f"
-  xop = "VOP"
-}
-
-privilege {
-  name = "AKICK"
-  rank = 250
-  level = 10
-  flag = "K"
-  xop = "SOP"
-}
-
-privilege {
-  name = "ASSIGN"
-  rank = 270
-  level = "founder"
-  flag = "s"
-  xop = "QOP"
-}
-
-privilege {
-  name = "AUTOHALFOP"
-  rank = 100
-  level = 4
-  flag = "H"
-  xop = "HOP"
-}
-
-privilege {
-  name = "AUTOOP"
-  rank = 210
-  level = 5
-  flag = "O"
-  xop = "AOP"
-}
-
-privilege {
-  name = "AUTOOWNER"
-  rank = 330
-  level = 9999
-  flag = "Q"
-  xop = "QOP"
-}
-
-privilege {
-  name = "AUTOPROTECT"
-  rank = 240
-  level = 10
-  flag = "A"
-  xop = "SOP"
-}
-
-privilege {
-  name = "AUTOVOICE"
-  rank = 50
-  level = 3
-  flag = "V"
-  xop = "VOP"
-}
-
-privilege {
-  name = "BADWORDS"
-  rank = 260
-  level = 10
-  flag = "K"
-  xop = "SOP"
-}
-
-privilege {
-  name = "BAN"
-  rank = 150
-  level = 4
-  flag = "b"
-  xop = "HOP"
-}
-
-privilege {
-  name = "FANTASIA"
-  rank = 30
-  level = 3
-  flag = "c"
-  xop = "VOP"
-}
-
-privilege {
-  name = "FOUNDER"
-  rank = 360
-  level = 10000
-  flag = "F"
-  xop = "QOP"
-}
-
-privilege {
-  name = "GETKEY"
-  rank = 180
-  level = 5
-  flag = "G"
-  xop = "AOP"
-}
-
-privilege {
-  name = "HALFOP"
-  rank = 120
-  level = 5
-  flag = "h"
-  xop = "AOP"
-}
-
-privilege {
-  name = "HALFOPME"
-  rank = 110
-  level = 4
-  flag = "h"
-  xop = "HOP"
-}
-
-privilege {
-  name = "INFO"
-  rank = 80
-  level = 9999
-  flag = "I"
-  xop = "QOP"
-}
-
-privilege {
-  name = "INVITE"
-  rank = 190
-  level = 5
-  flag = "i"
-  xop = "AOP"
-}
-
-privilege {
-  name = "KICK"
-  rank = 130
-  level = 4
-  flag = "k"
-  xop = "HOP"
-}
-
-privilege {
-  name = "MEMO"
-  rank = 280
-  level = 10
-  flag = "m"
-  xop = "SOP"
-}
-
-privilege {
-  name = "MODE"
-  rank = 170
-  level = 9999
-  flag = "s"
-  xop = "QOP"
-}
-
-privilege {
-  name = "NOKICK"
-  rank = 20
-  level = 1
-  flag = "N"
-  xop = "VOP"
-}
-
-privilege {
-  name = "OP"
-  rank = 230
-  level = 5
-  flag = "o"
-  xop = "SOP"
-}
-
-privilege {
-  name = "OPME"
-  rank = 220
-  level = 5
-  flag = "o"
-  xop = "AOP"
-}
-
-privilege {
-  name = "OWNER"
-  rank = 350
-  level = "founder"
-  flag = "q"
-  xop = "QOP"
-}
-
-privilege {
-  name = "OWNERME"
-  rank = 340
-  level = 9999
-  flag = "q"
-  xop = "QOP"
-}
-
-privilege {
-  name = "PROTECT"
-  rank = 310
-  level = 9999
-  flag = "a"
-  xop = "QOP"
-}
-
-privilege {
-  name = "PROTECTME"
-  rank = 300
-  level = 10
-  flag = "a"
-  xop = "AOP"
-}
-
-privilege {
-  name = "SAY"
-  rank = 90
-  level = 5
-  flag = "B"
-  xop = "AOP"
-}
-
-privilege {
-  name = "SET"
-  rank = 320
-  level = 9999
-  flag = "s"
-  xop = "QOP"
-}
-
-privilege {
-  name = "SIGNKICK"
-  rank = 140
-  level = 9999
-  flag = "K"
-  xop = "QOP"
-}
-
-privilege {
-  name = "TOPIC"
-  rank = 160
-  level = 5
-  flag = "t"
-  xop = "AOP"
-}
-
-privilege {
-  name = "UNBAN"
-  rank = 200
-  level = 4
-  flag = "u"
-  xop = "HOP"
-}
-
-privilege {
-  name = "VOICE"
-  rank = 70
-  level = 4
-  flag = "v"
-  xop = "HOP"
-}
-
-privilege {
-  name = "VOICEME"
-  rank = 60
-  level = 3
-  flag = "v"
-  xop = "VOP"
-}
-
-
-# Command groups
-command_group {
-  name = "chanserv/access"
-  description = _("Used to manage the list of privileged users")
-}
-
-command_group {
-  name = "chanserv/status"
-  description = _("Used to modify the channel status of you or other users")
-}
-
-command_group {
-  name = "chanserv/management"
-  description = _("Used to manage channels")
-}
-
-command_group {
-  name = "chanserv/admin"
-  description = _("Services Operator commands")
-}
 
 command { service = "ChanServ"; name = "HELP"; command = "generic/help"; }
 
 module { name = "cs_access" }
-command { service = "ChanServ"; name = "ACCESS"; command = "chanserv/access"; group = "chanserv/access"; }
-command { service = "ChanServ"; name = "LEVELS"; command = "chanserv/levels"; group = "chanserv/access"; }
+command { service = "ChanServ"; name = "ACCESS"; command = "chanserv/access"; }
+command { service = "ChanServ"; name = "LEVELS"; command = "chanserv/levels"; }
 
-module {
-  name = "cs_akick"
-
-  autokickmax = 32
-  autokickreason = "User has been banned from the channel"
-}
-command { service = "ChanServ"; name = "AKICK"; command = "chanserv/akick"; group = "chanserv/management"; }
+module { name = "cs_akick" }
+command { service = "ChanServ"; name = "AKICK"; command = "chanserv/akick"; }
 
 module { name = "cs_ban" }
 command { service = "ChanServ"; name = "BAN"; command = "chanserv/ban"; }
 
 module { name = "cs_clone" }
-command { service = "ChanServ"; name = "CLONE"; command = "chanserv/clone"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "CLONE"; command = "chanserv/clone"; }
 
 module { name = "cs_drop" }
 command { service = "ChanServ"; name = "DROP"; command = "chanserv/drop"; }
 
 module { name = "cs_enforce" }
-command { service = "ChanServ"; name = "ENFORCE"; command = "chanserv/enforce"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "ENFORCE"; command = "chanserv/enforce"; }
 
 module { name = "cs_entrymsg" }
-command { service = "ChanServ"; name = "ENTRYMSG"; command = "chanserv/entrymsg"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "ENTRYMSG"; command = "chanserv/entrymsg"; }
 
 module { name = "cs_flags" }
-command { service = "ChanServ"; name = "FLAGS"; command = "chanserv/flags"; group = "chanserv/access"; }
+command { service = "ChanServ"; name = "FLAGS"; command = "chanserv/flags"; }
 
 module { name = "cs_getkey" }
 command { service = "ChanServ"; name = "GETKEY"; command = "chanserv/getkey"; }
@@ -380,47 +92,30 @@ command { service = "ChanServ"; name = "INVITE"; command = "chanserv/invite"; }
 module { name = "cs_kick" }
 command { service = "ChanServ"; name = "KICK"; command = "chanserv/kick"; }
 
-module {
-  name = "cs_list"
-  listmax = 50
-}
+module { name = "cs_list" }
 command { service = "ChanServ"; name = "LIST"; command = "chanserv/list"; }
-
 command { service = "ChanServ"; name = "SET PRIVATE"; command = "chanserv/set/private"; }
 
-
 module { name = "cs_log" }
-command { service = "ChanServ"; name = "LOG"; command = "chanserv/log"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "LOG"; command = "chanserv/log"; }
 
 module { name = "cs_mode" }
-command { service = "ChanServ"; name = "MODE"; command = "chanserv/mode"; group = "chanserv/management"; }
-
-command { service = "ChanServ"; name = "OWNER"; command = "chanserv/modes"; group = "chanserv/status"; set = "OWNER" }
-command { service = "ChanServ"; name = "DEOWNER"; command = "chanserv/modes"; group = "chanserv/status"; unset = "OWNER" }
-
-command { service = "ChanServ"; name = "PROTECT"; command = "chanserv/modes"; group = "chanserv/status"; set = "PROTECT" }
-command { service = "ChanServ"; name = "DEPROTECT"; command = "chanserv/modes"; group = "chanserv/status"; unset = "PROTECT" }
-
-command { service = "ChanServ"; name = "OP"; command = "chanserv/modes"; group = "chanserv/status"; set = "OP" }
-command { service = "ChanServ"; name = "DEOP"; command = "chanserv/modes"; group = "chanserv/status"; unset = "OP" }
-
-command { service = "ChanServ"; name = "HALFOP"; command = "chanserv/modes"; group = "chanserv/status"; set = "HALFOP" }
-command { service = "ChanServ"; name = "DEHALFOP"; command = "chanserv/modes"; group = "chanserv/status"; unset = "HALFOP" }
-
-command { service = "ChanServ"; name = "VOICE"; command = "chanserv/modes"; group = "chanserv/status"; set = "VOICE" }
-command { service = "ChanServ"; name = "DEVOICE"; command = "chanserv/modes"; group = "chanserv/status"; unset = "VOICE" }
-
+command { service = "ChanServ"; name = "MODE"; command = "chanserv/mode"; }
+command { service = "ChanServ"; name = "OWNER"; command = "chanserv/modes"; set = "OWNER" }
+command { service = "ChanServ"; name = "DEOWNER"; command = "chanserv/modes"; unset = "OWNER" }
+command { service = "ChanServ"; name = "PROTECT"; command = "chanserv/modes"; set = "PROTECT" }
+command { service = "ChanServ"; name = "DEPROTECT"; command = "chanserv/modes"; unset = "PROTECT" }
+command { service = "ChanServ"; name = "OP"; command = "chanserv/modes"; set = "OP" }
+command { service = "ChanServ"; name = "DEOP"; command = "chanserv/modes"; unset = "OP" }
+command { service = "ChanServ"; name = "HALFOP"; command = "chanserv/modes"; set = "HALFOP" }
+command { service = "ChanServ"; name = "DEHALFOP"; command = "chanserv/modes"; unset = "HALFOP" }
+command { service = "ChanServ"; name = "VOICE"; command = "chanserv/modes"; set = "VOICE" }
+command { service = "ChanServ"; name = "DEVOICE"; command = "chanserv/modes"; unset = "VOICE" }
 
 module { name = "cs_register" }
 command { service = "ChanServ"; name = "REGISTER"; command = "chanserv/register"; }
 
-module {
-  name = "cs_seen"
-
-  simple = false
-  purgetime = "30d"
-  expiretimeout = "1d"
-}
+module { name = "cs_seen" }
 command { service = "OperServ"; name = "SEEN"; command = "operserv/seen"; permission = "operserv/seen"; }
 
 module {
@@ -429,7 +124,7 @@ module {
   defbantype = 2
   persist_lower_ts = true
 }
-command { service = "ChanServ"; name = "SET"; command = "chanserv/set"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SET"; command = "chanserv/set"; }
 command { service = "ChanServ"; name = "SET AUTOOP"; command = "chanserv/set/autoop"; }
 command { service = "ChanServ"; name = "SET BANTYPE"; command = "chanserv/set/bantype"; }
 command { service = "ChanServ"; name = "SET DESCRIPTION"; command = "chanserv/set/description"; }
@@ -446,39 +141,32 @@ command { service = "ChanServ"; name = "SET SIGNKICK"; command = "chanserv/set/s
 command { service = "ChanServ"; name = "SET SUCCESSOR"; command = "chanserv/set/successor"; }
 command { service = "ChanServ"; name = "SET NOEXPIRE"; command = "chanserv/saset/noexpire"; permission = "chanserv/saset/noexpire"; }
 
-module { name = "cs_set_misc" }
-command { service = "ChanServ"; name = "SET URL"; command = "chanserv/set/misc"; misc_description = _("Associate a URL with the channel"); }
-command { service = "ChanServ"; name = "SET EMAIL"; command = "chanserv/set/misc"; misc_description = _("Associate an E-mail address with the channel"); }
-
 module { name = "cs_status" }
 command { service = "ChanServ"; name = "STATUS"; command = "chanserv/status"; }
 
-module {
-  name = "cs_suspend"
-  show = "suspended, by, reason, on, expires"
-}
-command { service = "ChanServ"; name = "SUSPEND"; command = "chanserv/suspend"; permission = "chanserv/suspend"; group = "chanserv/admin"; }
-command { service = "ChanServ"; name = "UNSUSPEND"; command = "chanserv/unsuspend"; permission = "chanserv/suspend"; group = "chanserv/admin"; }
+module { name = "cs_suspend" }
+command { service = "ChanServ"; name = "SUSPEND"; command = "chanserv/suspend"; permission = "chanserv/suspend"; }
+command { service = "ChanServ"; name = "UNSUSPEND"; command = "chanserv/unsuspend"; permission = "chanserv/suspend"; }
 
 module { name = "cs_sync" }
-command { service = "ChanServ"; name = "SYNC"; command = "chanserv/sync"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SYNC"; command = "chanserv/sync"; }
 
 module { name = "cs_topic" }
-command { service = "ChanServ"; name = "TOPIC"; command = "chanserv/topic"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "TOPIC"; command = "chanserv/topic"; }
 command { service = "ChanServ"; name = "SET KEEPTOPIC"; command = "chanserv/set/keeptopic"; }
 
 module { name = "cs_unban" }
 command { service = "ChanServ"; name = "UNBAN"; command = "chanserv/unban"; }
 
 module { name = "cs_updown" }
-command { service = "ChanServ"; name = "DOWN"; command = "chanserv/down"; group = "chanserv/status"; }
-command { service = "ChanServ"; name = "UP"; command = "chanserv/up"; group = "chanserv/status"; }
+command { service = "ChanServ"; name = "DOWN"; command = "chanserv/down"; }
+command { service = "ChanServ"; name = "UP"; command = "chanserv/up"; }
 
 module { name = "cs_xop" }
-command { service = "ChanServ"; name = "QOP"; command = "chanserv/xop"; group = "chanserv/access"; }
-command { service = "ChanServ"; name = "SOP"; command = "chanserv/xop"; group = "chanserv/access"; }
-command { service = "ChanServ"; name = "AOP"; command = "chanserv/xop"; group = "chanserv/access"; }
-command { service = "ChanServ"; name = "HOP"; command = "chanserv/xop"; group = "chanserv/access"; }
-command { service = "ChanServ"; name = "VOP"; command = "chanserv/xop"; group = "chanserv/access"; }
+command { service = "ChanServ"; name = "QOP"; command = "chanserv/xop"; }
+command { service = "ChanServ"; name = "SOP"; command = "chanserv/xop"; }
+command { service = "ChanServ"; name = "AOP"; command = "chanserv/xop"; }
+command { service = "ChanServ"; name = "HOP"; command = "chanserv/xop"; }
+command { service = "ChanServ"; name = "VOP"; command = "chanserv/xop"; }
 
 module { name = "cs_statusupdate" }

--- a/modules/ocf_irc/files/anope/chanserv.conf
+++ b/modules/ocf_irc/files/anope/chanserv.conf
@@ -1,0 +1,484 @@
+# Comments trimmed for easier editing.
+# The original comments can be found on anope's wiki:
+# https://wiki.anope.org/index.php/2.0/Configuration#ChanServ
+
+service {
+	nick = "ChanServ"
+	user = "services"
+	host = "services.irc.ocf.berkeley.edu"
+	gecos = "Channel Registration Service"
+	channels = "#services"
+}
+
+module {
+	name = "chanserv"
+	client = "ChanServ"
+
+	defaults = "keeptopic peace cs_secure securefounder signkick"
+	expire = 30d
+
+	accessmax = 1024
+	inhabit = 15s
+
+	reasonmax = 200
+
+        # Signed kick messages:
+        # %n is the nick of the kicker
+        # %m is the message specified
+	signkickformat = "%m (%n)"
+
+	disallow_hostmask_access = false
+	disallow_channel_access = false
+
+	always_lower_ts = false
+}
+
+# Privileges
+privilege {
+	name = "ACCESS_CHANGE"
+	rank = 0
+	level = 10
+	flag = "f"
+	xop = "SOP"
+}
+
+privilege {
+	name = "ACCESS_LIST"
+	rank = 10
+	level = 3
+	flag = "f"
+	xop = "VOP"
+}
+
+privilege {
+	name = "AKICK"
+	rank = 250
+	level = 10
+	flag = "K"
+	xop = "SOP"
+}
+
+privilege {
+	name = "ASSIGN"
+	rank = 270
+	level = "founder"
+	flag = "s"
+	xop = "QOP"
+}
+
+privilege {
+	name = "AUTOHALFOP"
+	rank = 100
+	level = 4
+	flag = "H"
+	xop = "HOP"
+}
+
+privilege {
+	name = "AUTOOP"
+	rank = 210
+	level = 5
+	flag = "O"
+	xop = "AOP"
+}
+
+privilege {
+	name = "AUTOOWNER"
+	rank = 330
+	level = 9999
+	flag = "Q"
+	xop = "QOP"
+}
+
+privilege {
+	name = "AUTOPROTECT"
+	rank = 240
+	level = 10
+	flag = "A"
+	xop = "SOP"
+}
+
+privilege {
+	name = "AUTOVOICE"
+	rank = 50
+	level = 3
+	flag = "V"
+	xop = "VOP"
+}
+
+privilege {
+	name = "BADWORDS"
+	rank = 260
+	level = 10
+	flag = "K"
+	xop = "SOP"
+}
+
+privilege {
+	name = "BAN"
+	rank = 150
+	level = 4
+	flag = "b"
+	xop = "HOP"
+}
+
+privilege {
+	name = "FANTASIA"
+	rank = 30
+	level = 3
+	flag = "c"
+	xop = "VOP"
+}
+
+privilege {
+	name = "FOUNDER"
+	rank = 360
+	level = 10000
+	flag = "F"
+	xop = "QOP"
+}
+
+privilege {
+	name = "GETKEY"
+	rank = 180
+	level = 5
+	flag = "G"
+	xop = "AOP"
+}
+
+privilege {
+	name = "HALFOP"
+	rank = 120
+	level = 5
+	flag = "h"
+	xop = "AOP"
+}
+
+privilege {
+	name = "HALFOPME"
+	rank = 110
+	level = 4
+	flag = "h"
+	xop = "HOP"
+}
+
+privilege {
+	name = "INFO"
+	rank = 80
+	level = 9999
+	flag = "I"
+	xop = "QOP"
+}
+
+privilege {
+	name = "INVITE"
+	rank = 190
+	level = 5
+	flag = "i"
+	xop = "AOP"
+}
+
+privilege {
+	name = "KICK"
+	rank = 130
+	level = 4
+	flag = "k"
+	xop = "HOP"
+}
+
+privilege {
+	name = "MEMO"
+	rank = 280
+	level = 10
+	flag = "m"
+	xop = "SOP"
+}
+
+privilege {
+	name = "MODE"
+	rank = 170
+	level = 9999
+	flag = "s"
+	xop = "QOP"
+}
+
+privilege {
+	name = "NOKICK"
+	rank = 20
+	level = 1
+	flag = "N"
+	xop = "VOP"
+}
+
+privilege {
+	name = "OP"
+	rank = 230
+	level = 5
+	flag = "o"
+	xop = "SOP"
+}
+
+privilege {
+	name = "OPME"
+	rank = 220
+	level = 5
+	flag = "o"
+	xop = "AOP"
+}
+
+privilege {
+	name = "OWNER"
+	rank = 350
+	level = "founder"
+	flag = "q"
+	xop = "QOP"
+}
+
+privilege {
+	name = "OWNERME"
+	rank = 340
+	level = 9999
+	flag = "q"
+	xop = "QOP"
+}
+
+privilege {
+	name = "PROTECT"
+	rank = 310
+	level = 9999
+	flag = "a"
+	xop = "QOP"
+}
+
+privilege {
+	name = "PROTECTME"
+	rank = 300
+	level = 10
+	flag = "a"
+	xop = "AOP"
+}
+
+privilege {
+	name = "SAY"
+	rank = 90
+	level = 5
+	flag = "B"
+	xop = "AOP"
+}
+
+privilege {
+	name = "SET"
+	rank = 320
+	level = 9999
+	flag = "s"
+	xop = "QOP"
+}
+
+privilege {
+	name = "SIGNKICK"
+	rank = 140
+	level = 9999
+	flag = "K"
+	xop = "QOP"
+}
+
+privilege {
+	name = "TOPIC"
+	rank = 160
+	level = 5
+	flag = "t"
+	xop = "AOP"
+}
+
+privilege {
+	name = "UNBAN"
+	rank = 200
+	level = 4
+	flag = "u"
+	xop = "HOP"
+}
+
+privilege {
+	name = "VOICE"
+	rank = 70
+	level = 4
+	flag = "v"
+	xop = "HOP"
+}
+
+privilege {
+	name = "VOICEME"
+	rank = 60
+	level = 3
+	flag = "v"
+	xop = "VOP"
+}
+
+
+# Command groups
+command_group {
+	name = "chanserv/access"
+	description = _("Used to manage the list of privileged users")
+}
+
+command_group {
+	name = "chanserv/status"
+	description = _("Used to modify the channel status of you or other users")
+}
+
+command_group {
+	name = "chanserv/management"
+	description = _("Used to manage channels")
+}
+
+command_group {
+	name = "chanserv/admin"
+	description = _("Services Operator commands")
+}
+
+command { service = "ChanServ"; name = "HELP"; command = "generic/help"; }
+
+module { name = "cs_access" }
+command { service = "ChanServ"; name = "ACCESS"; command = "chanserv/access"; group = "chanserv/access"; }
+command { service = "ChanServ"; name = "LEVELS"; command = "chanserv/levels"; group = "chanserv/access"; }
+
+module {
+	name = "cs_akick"
+
+	autokickmax = 32
+	autokickreason = "User has been banned from the channel"
+}
+command { service = "ChanServ"; name = "AKICK"; command = "chanserv/akick"; group = "chanserv/management"; }
+
+module { name = "cs_ban" }
+command { service = "ChanServ"; name = "BAN"; command = "chanserv/ban"; }
+
+module { name = "cs_clone" }
+command { service = "ChanServ"; name = "CLONE"; command = "chanserv/clone"; group = "chanserv/management"; }
+
+module { name = "cs_drop" }
+command { service = "ChanServ"; name = "DROP"; command = "chanserv/drop"; }
+
+module { name = "cs_enforce" }
+command { service = "ChanServ"; name = "ENFORCE"; command = "chanserv/enforce"; group = "chanserv/management"; }
+
+module { name = "cs_entrymsg" }
+command { service = "ChanServ"; name = "ENTRYMSG"; command = "chanserv/entrymsg"; group = "chanserv/management"; }
+
+module { name = "cs_flags" }
+command { service = "ChanServ"; name = "FLAGS"; command = "chanserv/flags"; group = "chanserv/access"; }
+
+module { name = "cs_getkey" }
+command { service = "ChanServ"; name = "GETKEY"; command = "chanserv/getkey"; }
+
+module { name = "cs_info" }
+command { service = "ChanServ"; name = "INFO"; command = "chanserv/info"; }
+
+module { name = "cs_invite" }
+command { service = "ChanServ"; name = "INVITE"; command = "chanserv/invite"; }
+
+module { name = "cs_kick" }
+command { service = "ChanServ"; name = "KICK"; command = "chanserv/kick"; }
+
+module {
+	name = "cs_list"
+	listmax = 50
+}
+command { service = "ChanServ"; name = "LIST"; command = "chanserv/list"; }
+
+command { service = "ChanServ"; name = "SET PRIVATE"; command = "chanserv/set/private"; }
+
+
+module { name = "cs_log" }
+command { service = "ChanServ"; name = "LOG"; command = "chanserv/log"; group = "chanserv/management"; }
+
+module { name = "cs_mode" }
+command { service = "ChanServ"; name = "MODE"; command = "chanserv/mode"; group = "chanserv/management"; }
+
+command { service = "ChanServ"; name = "OWNER"; command = "chanserv/modes"; group = "chanserv/status"; set = "OWNER" }
+command { service = "ChanServ"; name = "DEOWNER"; command = "chanserv/modes"; group = "chanserv/status"; unset = "OWNER" }
+
+command { service = "ChanServ"; name = "PROTECT"; command = "chanserv/modes"; group = "chanserv/status"; set = "PROTECT" }
+command { service = "ChanServ"; name = "DEPROTECT"; command = "chanserv/modes"; group = "chanserv/status"; unset = "PROTECT" }
+
+command { service = "ChanServ"; name = "OP"; command = "chanserv/modes"; group = "chanserv/status"; set = "OP" }
+command { service = "ChanServ"; name = "DEOP"; command = "chanserv/modes"; group = "chanserv/status"; unset = "OP" }
+
+command { service = "ChanServ"; name = "HALFOP"; command = "chanserv/modes"; group = "chanserv/status"; set = "HALFOP" }
+command { service = "ChanServ"; name = "DEHALFOP"; command = "chanserv/modes"; group = "chanserv/status"; unset = "HALFOP" }
+
+command { service = "ChanServ"; name = "VOICE"; command = "chanserv/modes"; group = "chanserv/status"; set = "VOICE" }
+command { service = "ChanServ"; name = "DEVOICE"; command = "chanserv/modes"; group = "chanserv/status"; unset = "VOICE" }
+
+
+module { name = "cs_register" }
+command { service = "ChanServ"; name = "REGISTER"; command = "chanserv/register"; }
+
+module {
+	name = "cs_seen"
+
+	simple = false
+	purgetime = "30d"
+	expiretimeout = "1d"
+}
+command { service = "OperServ"; name = "SEEN"; command = "operserv/seen"; permission = "operserv/seen"; }
+
+module {
+	name = "cs_set"
+
+	defbantype = 2
+	persist_lower_ts = true
+}
+command { service = "ChanServ"; name = "SET"; command = "chanserv/set"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SET AUTOOP"; command = "chanserv/set/autoop"; }
+command { service = "ChanServ"; name = "SET BANTYPE"; command = "chanserv/set/bantype"; }
+command { service = "ChanServ"; name = "SET DESCRIPTION"; command = "chanserv/set/description"; }
+command { service = "ChanServ"; name = "SET DESC"; command = "chanserv/set/description"; hide = yes; }
+command { service = "ChanServ"; name = "SET FOUNDER"; command = "chanserv/set/founder"; }
+command { service = "ChanServ"; name = "SET KEEPMODES"; command = "chanserv/set/keepmodes"; }
+command { service = "ChanServ"; name = "SET PEACE"; command = "chanserv/set/peace"; }
+command { service = "ChanServ"; name = "SET PERSIST"; command = "chanserv/set/persist"; }
+command { service = "ChanServ"; name = "SET RESTRICTED"; command = "chanserv/set/restricted"; }
+command { service = "ChanServ"; name = "SET SECURE"; command = "chanserv/set/secure"; }
+command { service = "ChanServ"; name = "SET SECUREFOUNDER"; command = "chanserv/set/securefounder"; }
+command { service = "ChanServ"; name = "SET SECUREOPS"; command = "chanserv/set/secureops"; }
+command { service = "ChanServ"; name = "SET SIGNKICK"; command = "chanserv/set/signkick"; }
+command { service = "ChanServ"; name = "SET SUCCESSOR"; command = "chanserv/set/successor"; }
+command { service = "ChanServ"; name = "SET NOEXPIRE"; command = "chanserv/saset/noexpire"; permission = "chanserv/saset/noexpire"; }
+
+module { name = "cs_set_misc" }
+command { service = "ChanServ"; name = "SET URL"; command = "chanserv/set/misc"; misc_description = _("Associate a URL with the channel"); }
+command { service = "ChanServ"; name = "SET EMAIL"; command = "chanserv/set/misc"; misc_description = _("Associate an E-mail address with the channel"); }
+
+module { name = "cs_status" }
+command { service = "ChanServ"; name = "STATUS"; command = "chanserv/status"; }
+
+module {
+	name = "cs_suspend"
+	show = "suspended, by, reason, on, expires"
+}
+command { service = "ChanServ"; name = "SUSPEND"; command = "chanserv/suspend"; permission = "chanserv/suspend"; group = "chanserv/admin"; }
+command { service = "ChanServ"; name = "UNSUSPEND"; command = "chanserv/unsuspend"; permission = "chanserv/suspend"; group = "chanserv/admin"; }
+
+module { name = "cs_sync" }
+command { service = "ChanServ"; name = "SYNC"; command = "chanserv/sync"; group = "chanserv/management"; }
+
+module { name = "cs_topic" }
+command { service = "ChanServ"; name = "TOPIC"; command = "chanserv/topic"; group = "chanserv/management"; }
+command { service = "ChanServ"; name = "SET KEEPTOPIC"; command = "chanserv/set/keeptopic"; }
+
+module { name = "cs_unban" }
+command { service = "ChanServ"; name = "UNBAN"; command = "chanserv/unban"; }
+
+module { name = "cs_updown" }
+command { service = "ChanServ"; name = "DOWN"; command = "chanserv/down"; group = "chanserv/status"; }
+command { service = "ChanServ"; name = "UP"; command = "chanserv/up"; group = "chanserv/status"; }
+
+module { name = "cs_xop" }
+command { service = "ChanServ"; name = "QOP"; command = "chanserv/xop"; group = "chanserv/access"; }
+command { service = "ChanServ"; name = "SOP"; command = "chanserv/xop"; group = "chanserv/access"; }
+command { service = "ChanServ"; name = "AOP"; command = "chanserv/xop"; group = "chanserv/access"; }
+command { service = "ChanServ"; name = "HOP"; command = "chanserv/xop"; group = "chanserv/access"; }
+command { service = "ChanServ"; name = "VOP"; command = "chanserv/xop"; group = "chanserv/access"; }
+
+module { name = "cs_statusupdate" }

--- a/modules/ocf_irc/files/anope/global.conf
+++ b/modules/ocf_irc/files/anope/global.conf
@@ -1,0 +1,24 @@
+# Most comments have been stripped for easier editing
+# The original comments can be found on anope's wiki:
+# https://wiki.anope.org/index.php/2.0/Configuration#Global
+
+service {
+	nick = "Global"
+	user = "services"
+	host = "services.irc.ocf.berkeley.edu"
+	gecos = "Global Noticer"
+	channels = "#services"
+}
+
+module {
+	name = "global"
+	client = "Global"
+	globaloncycledown = "Services are restarting, they will be back shortly"
+	globaloncycleup = "Services are now back online!"
+}
+
+command { service = "Global"; name = "HELP"; command = "generic/help"; }
+
+# Used to send messages to every user
+module { name = "gl_global" }
+command { service = "Global"; name = "GLOBAL"; command = "global/global"; permission = "global/global"; }

--- a/modules/ocf_irc/files/anope/global.conf
+++ b/modules/ocf_irc/files/anope/global.conf
@@ -3,18 +3,18 @@
 # https://wiki.anope.org/index.php/2.0/Configuration#Global
 
 service {
-	nick = "Global"
-	user = "services"
-	host = "services.irc.ocf.berkeley.edu"
-	gecos = "Global Noticer"
-	channels = "#services"
+  nick = "Global"
+  user = "services"
+  host = "services.irc.ocf.berkeley.edu"
+  gecos = "Global Noticer"
+  channels = "#services"
 }
 
 module {
-	name = "global"
-	client = "Global"
-	globaloncycledown = "Services are restarting, they will be back shortly"
-	globaloncycleup = "Services are now back online!"
+  name = "global"
+  client = "Global"
+  globaloncycledown = "Services are restarting, they will be back shortly"
+  globaloncycleup = "Services are now back online!"
 }
 
 command { service = "Global"; name = "HELP"; command = "generic/help"; }

--- a/modules/ocf_irc/files/anope/hostserv.conf
+++ b/modules/ocf_irc/files/anope/hostserv.conf
@@ -1,0 +1,36 @@
+# Comments trimmed for easier editing.
+# The original comments can be found on anope's wiki:
+# https://wiki.anope.org/index.php/2.0/Configuration#HostServ
+
+service {
+  nick = "HostServ"
+  user = "services"
+  host = "services.ocf.berkeley.edu"
+  gecos = "vHost Service"
+  channels = "#services"
+}
+
+module {
+  name = "hostserv"
+  client = "HostServ"
+  activate_on_set = true
+}
+
+command { service = "HostServ"; name = "HELP"; command = "generic/help"; }
+
+module { name = "hs_del" }
+command { service = "HostServ"; name = "DEL"; command = "hostserv/del"; permission = "hostserv/del"; }
+command { service = "HostServ"; name = "DELALL"; command = "hostserv/delall"; permission = "hostserv/del"; }
+
+module { name = "hs_list" }
+command { service = "HostServ"; name = "LIST"; command = "hostserv/list"; permission = "hostserv/list"; }
+
+module { name = "hs_off" }
+command { service = "HostServ"; name = "OFF"; command = "hostserv/off"; }
+
+module { name = "hs_on" }
+command { service = "HostServ"; name = "ON"; command = "hostserv/on"; }
+
+module { name = "hs_set" }
+command { service = "HostServ"; name = "SET"; command = "hostserv/set"; permission = "hostserv/set"; }
+command { service = "HostServ"; name = "SETALL"; command = "hostserv/setall"; permission = "hostserv/set"; }

--- a/modules/ocf_irc/files/anope/nickserv.conf
+++ b/modules/ocf_irc/files/anope/nickserv.conf
@@ -3,38 +3,37 @@
 # https://wiki.anope.org/index.php/2.0/Configuration#NickServ
 
 service {
-    nick = "NickServ"
-    user = "services"
-    host = "services.irc.ocf.berkeley.edu"
-    gecos = "Nickname Registration Service"
-    channels = "#services"
+  nick = "NickServ"
+  user = "services"
+  host = "services.irc.ocf.berkeley.edu"
+  gecos = "Nickname Registration Service"
+  channels = "#services"
 }
 
 module {
-    name = "nickserv"
-    client = "NickServ"
+  name = "nickserv"
+  client = "NickServ"
 
-    forceemail = yes
-    confirmemailchanges = no
+  defaults = "killprotect kill_quick ns_secure ns_private hide_email hide_mask autoop"
 
-    defaults = "killprotect kill_quick ns_secure ns_private hide_email hide_mask autoop"
+  regdelay = 30s
+  expire = 120d
 
-    regdelay = 60s
-    expire = 120d
+  secureadmins = yes
+  modeonid = yes
 
-    secureadmins = yes
-    modeonid = yes
-    hidenetsplitquit = no
+  killquick = 20s
+  kill = 60s
 
-    killquick = 20s
-    kill = 60s
+  restrictopernicks = yes
 
-    enforceruser = "enforcer"
-    enforcerhost = "services.irc.ocf.berkeley.edu"
+  enforceruser = "enforcer"
+  enforcerhost = "services.irc.ocf.berkeley.edu"
 
-    # Set a very high maximum password length (default is 32, and we want unlimited)
-    passlen = 999
+  # Set a very high maximum password length (default is 32, and we want unlimited)
+  passlen = 999
 }
+
 
 command { service = "NickServ"; name = "HELP"; command = "generic/help"; }
 
@@ -81,8 +80,8 @@ command { service = "NickServ"; name = "RECOVER"; command = "nickserv/recover"; 
 command { service = "NickServ"; name = "RELEASE"; command = "nickserv/recover"; }
 
 module {
-    name = "ns_register"
-    registration = "none"
+  name = "ns_register"
+  registration = "none"
 }
 command { service = "NickServ"; name = "CONFIRM"; command = "nickserv/confirm"; }
 command { service = "NickServ"; name = "REGISTER"; command = "nickserv/register"; }
@@ -132,6 +131,6 @@ module { name = "ns_update" }
 command { service = "NickServ"; name = "UPDATE"; command = "nickserv/update"; }
 
 module {
-    name = "ns_maxemail"
-    maxemails = 1
+  name = "ns_maxemail"
+  maxemails = 1
 }

--- a/modules/ocf_irc/files/anope/nickserv.conf
+++ b/modules/ocf_irc/files/anope/nickserv.conf
@@ -1,0 +1,138 @@
+# Comments trimmed for easier editing.
+# The original comments can be found on anope's wiki:
+# https://wiki.anope.org/index.php/2.0/Configuration#NickServ
+
+service {
+    nick = "NickServ"
+    user = "services"
+    host = "services.irc.ocf.berkeley.edu"
+    gecos = "Nickname Registration Service"
+    channels = "#services"
+}
+
+module {
+    name = "nickserv"
+    client = "NickServ"
+
+    forceemail = yes
+    confirmemailchanges = no
+    registration = "none"
+
+    defaults = "killprotect kill_quick ns_secure ns_private hide_email hide_mask autoop"
+
+    regdelay = 60s
+    expire = 60d
+
+    secureadmins = yes
+    modeonid = yes
+    hidenetsplitquit = no
+
+    killquick = 20s
+    kill = 60s
+
+    enforceruser = "enforcer"
+    enforcerhost = "services.irc.ocf.berkeley.edu"
+
+    # Set a very high maximum password length (default is 32, and we want unlimited)
+    passlen = 999
+}
+
+command { service = "NickServ"; name = "HELP"; command = "generic/help"; }
+
+module { name = "ns_access" }
+command { service = "NickServ"; name = "ACCESS"; command = "nickserv/access"; }
+
+module { name = "ns_ajoin" }
+command { service = "NickServ"; name = "AJOIN"; command = "nickserv/ajoin"; }
+
+module { name = "ns_alist" }
+command { service = "NickServ"; name = "ALIST"; command = "nickserv/alist"; }
+
+module { name = "ns_cert" }
+command { service = "NickServ"; name = "CERT"; command = "nickserv/cert"; }
+
+module { name = "ns_drop" }
+command { service = "NickServ"; name = "DROP"; command = "nickserv/drop"; }
+
+module { name = "ns_getemail" }
+command { service = "NickServ"; name = "GETEMAIL"; command = "nickserv/getemail"; permission = "nickserv/getemail"; }
+
+module { name = "ns_group" }
+command { service = "NickServ"; name = "GLIST"; command = "nickserv/glist"; }
+command { service = "NickServ"; name = "GROUP"; command = "nickserv/group"; }
+command { service = "NickServ"; name = "UNGROUP"; command = "nickserv/ungroup"; }
+
+module { name = "ns_identify" }
+command { service = "NickServ"; name = "ID"; command = "nickserv/identify"; }
+command { service = "NickServ"; name = "IDENTIFY"; command = "nickserv/identify"; }
+
+module { name = "ns_info" }
+command { service = "NickServ"; name = "INFO"; command = "nickserv/info"; }
+
+module { name = "ns_list" }
+command { service = "NickServ"; name = "LIST"; command = "nickserv/list"; }
+command { service = "NickServ"; name = "SET PRIVATE"; command = "nickserv/set/private"; }
+command { service = "NickServ"; name = "SASET PRIVATE"; command = "nickserv/saset/private"; permission = "nickserv/saset/private"; }
+
+module { name = "ns_logout" }
+command { service = "NickServ"; name = "LOGOUT"; command = "nickserv/logout"; }
+
+module { name = "ns_recover" }
+command { service = "NickServ"; name = "RECOVER"; command = "nickserv/recover"; }
+command { service = "NickServ"; name = "RELEASE"; command = "nickserv/recover"; }
+
+module {
+    name = "ns_register"
+    registration = "none"
+}
+command { service = "NickServ"; name = "CONFIRM"; command = "nickserv/confirm"; }
+command { service = "NickServ"; name = "REGISTER"; command = "nickserv/register"; }
+command { service = "NickServ"; name = "RESEND"; command = "nickserv/resend"; }
+
+module { name = "ns_resetpass" }
+command { service = "NickServ"; name = "RESETPASS"; command = "nickserv/resetpass"; }
+
+module { name = "ns_set" }
+command { service = "NickServ"; name = "SET"; command = "nickserv/set"; }
+command { service = "NickServ"; name = "SASET"; command = "nickserv/saset"; permission = "nickserv/saset/"; }
+
+command { service = "NickServ"; name = "SET AUTOOP"; command = "nickserv/set/autoop"; }
+command { service = "NickServ"; name = "SASET AUTOOP"; command = "nickserv/saset/autoop"; permission = "nickserv/saset/autoop"; }
+
+command { service = "NickServ"; name = "SET DISPLAY"; command = "nickserv/set/display"; }
+command { service = "NickServ"; name = "SASET DISPLAY"; command = "nickserv/saset/display"; permission = "nickserv/saset/display"; }
+
+command { service = "NickServ"; name = "SET EMAIL"; command = "nickserv/set/email"; }
+command { service = "NickServ"; name = "SASET EMAIL"; command = "nickserv/saset/email"; permission = "nickserv/saset/email"; }
+
+command { service = "NickServ"; name = "SET KEEPMODES"; command = "nickserv/set/keepmodes"; }
+command { service = "NickServ"; name = "SASET KEEPMODES"; command = "nickserv/saset/keepmodes"; permission = "nickserv/saset/keepmodes"; }
+
+command { service = "NickServ"; name = "SET KILL"; command = "nickserv/set/kill"; }
+command { service = "NickServ"; name = "SASET KILL"; command = "nickserv/saset/kill"; permission = "nickserv/saset/kill"; }
+
+command { service = "NickServ"; name = "SET MESSAGE"; command = "nickserv/set/message"; }
+command { service = "NickServ"; name = "SASET MESSAGE"; command = "nickserv/saset/message"; permission = "nickserv/saset/message"; }
+
+command { service = "NickServ"; name = "SET PASSWORD"; command = "nickserv/set/password"; }
+command { service = "NickServ"; name = "SASET PASSWORD"; command = "nickserv/saset/password"; permission = "nickserv/saset/password"; }
+
+command { service = "NickServ"; name = "SET SECURE"; command = "nickserv/set/secure"; }
+command { service = "NickServ"; name = "SASET SECURE"; command = "nickserv/saset/secure"; permission = "nickserv/saset/secure"; }
+
+command { service = "NickServ"; name = "SASET NOEXPIRE"; command = "nickserv/saset/noexpire"; permission = "nickserv/saset/noexpire"; }
+
+module { name = "ns_status" }
+command { service = "NickServ"; name = "STATUS"; command = "nickserv/status"; }
+
+module { name = "ns_suspend" }
+command { service = "NickServ"; name = "SUSPEND"; command = "nickserv/suspend"; permission = "nickserv/suspend"; }
+command { service = "NickServ"; name = "UNSUSPEND"; command = "nickserv/unsuspend"; permission = "nickserv/suspend"; }
+
+module { name = "ns_update" }
+command { service = "NickServ"; name = "UPDATE"; command = "nickserv/update"; }
+
+module {
+    name = "ns_maxemail"
+    maxemails = 1
+}

--- a/modules/ocf_irc/files/anope/nickserv.conf
+++ b/modules/ocf_irc/files/anope/nickserv.conf
@@ -20,7 +20,7 @@ module {
     defaults = "killprotect kill_quick ns_secure ns_private hide_email hide_mask autoop"
 
     regdelay = 60s
-    expire = 60d
+    expire = 120d
 
     secureadmins = yes
     modeonid = yes

--- a/modules/ocf_irc/files/anope/nickserv.conf
+++ b/modules/ocf_irc/files/anope/nickserv.conf
@@ -16,7 +16,6 @@ module {
 
     forceemail = yes
     confirmemailchanges = no
-    registration = "none"
 
     defaults = "killprotect kill_quick ns_secure ns_private hide_email hide_mask autoop"
 

--- a/modules/ocf_irc/files/anope/operserv.conf
+++ b/modules/ocf_irc/files/anope/operserv.conf
@@ -3,29 +3,29 @@
 # https://wiki.anope.org/index.php/2.0/Configuration#OperServ
 
 service {
-	nick = "OperServ"
-	user = "services"
-	host = "services.irc.ocf.berkeley.edu"
-	gecos = "Operator Service"
-	channels = "#services"
+  nick = "OperServ"
+  user = "services"
+  host = "services.irc.ocf.berkeley.edu"
+  gecos = "Operator Service"
+  channels = "#services"
 }
 
 module {
-	name = "operserv"
-	client = "OperServ"
+  name = "operserv"
+  client = "OperServ"
 
-	autokillexpiry = 30d
-	chankillexpiry = 30d
-	snlineexpiry = 30d
-	sqlineexpiry = 30d
+  autokillexpiry = 30d
+  chankillexpiry = 30d
+  snlineexpiry = 30d
+  sqlineexpiry = 30d
 
-	akillonadd = yes
-	killonsnline = yes
-	killonsqline = yes
-	addakiller = yes
-	akillids = yes
+  akillonadd = yes
+  killonsnline = yes
+  killonsqline = yes
+  addakiller = yes
+  akillids = yes
 
-	opersonly = no
+  opersonly = no
 }
 
 command { service = "OperServ"; name = "HELP"; command = "generic/help"; }
@@ -66,8 +66,8 @@ command { service = "OperServ"; name = "LOGIN"; command = "operserv/login"; }
 command { service = "OperServ"; name = "LOGOUT"; command = "operserv/logout"; }
 
 module {
-	name = "os_logsearch"
-	logname = "services.log"
+  name = "os_logsearch"
+  logname = "services.log"
 }
 command { service = "OperServ"; name = "LOGSEARCH"; command = "operserv/logsearch"; permission = "operserv/logsearch"; }
 
@@ -85,10 +85,10 @@ command { service = "OperServ"; name = "MODRELOAD"; command = "operserv/modreloa
 command { service = "OperServ"; name = "MODUNLOAD"; command = "operserv/modunload"; permission = "operserv/modload"; }
 
 module {
-	name = "os_news"
+  name = "os_news"
 
-	announcer = "Global"
-	oper_announcer = "OperServ"
+  announcer = "Global"
+  oper_announcer = "OperServ"
 }
 command { service = "OperServ"; name = "LOGONNEWS"; command = "operserv/logonnews"; permission = "operserv/news"; }
 command { service = "OperServ"; name = "OPERNEWS"; command = "operserv/opernews"; permission = "operserv/news"; }

--- a/modules/ocf_irc/files/anope/operserv.conf
+++ b/modules/ocf_irc/files/anope/operserv.conf
@@ -24,8 +24,6 @@ module {
   killonsqline = yes
   addakiller = yes
   akillids = yes
-
-  opersonly = no
 }
 
 command { service = "OperServ"; name = "HELP"; command = "generic/help"; }
@@ -36,20 +34,8 @@ command { service = "OperServ"; name = "AKILL"; command = "operserv/akill"; perm
 module { name = "os_chankill" }
 command { service = "OperServ"; name = "CHANKILL"; command = "operserv/chankill"; permission = "operserv/chankill"; }
 
-module { name = "os_config" }
-command { service = "OperServ"; name = "CONFIG"; command = "operserv/config"; permission = "operserv/config"; }
-
 module { name = "os_forbid" }
 command { service = "OperServ"; name = "FORBID"; command = "operserv/forbid"; permission = "operserv/forbid"; }
-
-module { name = "os_ignore" }
-command { service = "OperServ"; name = "IGNORE"; command = "operserv/ignore"; permission = "operserv/ignore"; }
-
-module { name = "os_info" }
-command { service = "OperServ"; name = "INFO"; command = "operserv/info"; permission = "operserv/info"; }
-
-module { name = "os_jupe" }
-command { service = "OperServ"; name = "JUPE"; command = "operserv/jupe"; permission = "operserv/jupe"; }
 
 module { name = "os_kick" }
 command { service = "OperServ"; name = "KICK"; command = "operserv/kick"; permission = "operserv/kick"; }
@@ -61,10 +47,6 @@ module { name = "os_list" }
 command { service = "OperServ"; name = "CHANLIST"; command = "operserv/chanlist"; permission = "operserv/chanlist"; }
 command { service = "OperServ"; name = "USERLIST"; command = "operserv/userlist"; permission = "operserv/userlist"; }
 
-module { name = "os_login" }
-command { service = "OperServ"; name = "LOGIN"; command = "operserv/login"; }
-command { service = "OperServ"; name = "LOGOUT"; command = "operserv/logout"; }
-
 module {
   name = "os_logsearch"
   logname = "services.log"
@@ -74,31 +56,6 @@ command { service = "OperServ"; name = "LOGSEARCH"; command = "operserv/logsearc
 module { name = "os_mode" }
 command { service = "OperServ"; name = "UMODE"; command = "operserv/umode"; permission = "operserv/umode"; }
 command { service = "OperServ"; name = "MODE"; command = "operserv/mode"; permission = "operserv/mode"; }
-
-module { name = "os_modinfo" }
-command { service = "OperServ"; name = "MODINFO"; command = "operserv/modinfo"; permission = "operserv/modinfo"; }
-command { service = "OperServ"; name = "MODLIST"; command = "operserv/modlist"; permission = "operserv/modinfo"; }
-
-module { name = "os_module" }
-command { service = "OperServ"; name = "MODLOAD"; command = "operserv/modload"; permission = "operserv/modload"; }
-command { service = "OperServ"; name = "MODRELOAD"; command = "operserv/modreload"; permission = "operserv/modload"; }
-command { service = "OperServ"; name = "MODUNLOAD"; command = "operserv/modunload"; permission = "operserv/modload"; }
-
-module {
-  name = "os_news"
-
-  announcer = "Global"
-  oper_announcer = "OperServ"
-}
-command { service = "OperServ"; name = "LOGONNEWS"; command = "operserv/logonnews"; permission = "operserv/news"; }
-command { service = "OperServ"; name = "OPERNEWS"; command = "operserv/opernews"; permission = "operserv/news"; }
-command { service = "OperServ"; name = "RANDOMNEWS"; command = "operserv/randomnews"; permission = "operserv/news"; }
-
-module { name = "os_noop" }
-command { service = "OperServ"; name = "NOOP"; command = "operserv/noop"; permission = "operserv/noop"; }
-
-module { name = "os_oline" }
-command { service = "OperServ"; name = "OLINE"; command = "operserv/oline"; permission = "operserv/oline"; }
 
 module { name = "os_oper" }
 command { service = "OperServ"; name = "OPER"; command = "operserv/oper"; permission = "operserv/oper"; }
@@ -125,6 +82,3 @@ command { service = "OperServ"; name = "SVSPART"; command = "operserv/svspart"; 
 module { name = "os_sxline" }
 command { service = "OperServ"; name = "SNLINE"; command = "operserv/snline"; permission = "operserv/snline"; }
 command { service = "OperServ"; name = "SQLINE"; command = "operserv/sqline"; permission = "operserv/sqline"; }
-
-module { name = "os_update" }
-command { service = "OperServ"; name = "UPDATE"; command = "operserv/update"; permission = "operserv/update"; }

--- a/modules/ocf_irc/files/anope/operserv.conf
+++ b/modules/ocf_irc/files/anope/operserv.conf
@@ -1,0 +1,148 @@
+# Comments trimmed for easier editing.
+# The original comments can be found on anope's wiki:
+# https://wiki.anope.org/index.php/2.0/Configuration#OperServ
+
+service {
+	nick = "OperServ"
+	user = "services"
+	host = "services.irc.ocf.berkeley.edu"
+	gecos = "Operator Service"
+	channels = "#services"
+}
+
+module {
+	name = "operserv"
+	client = "OperServ"
+
+	autokillexpiry = 30d
+	chankillexpiry = 30d
+	snlineexpiry = 30d
+	sqlineexpiry = 30d
+
+	akillonadd = yes
+	killonsnline = yes
+	killonsqline = yes
+	addakiller = yes
+	akillids = yes
+
+	opersonly = no
+}
+
+command { service = "OperServ"; name = "HELP"; command = "generic/help"; }
+
+module { name = "os_akill" }
+command { service = "OperServ"; name = "AKILL"; command = "operserv/akill"; permission = "operserv/akill"; }
+
+module { name = "os_chankill" }
+command { service = "OperServ"; name = "CHANKILL"; command = "operserv/chankill"; permission = "operserv/chankill"; }
+
+module { name = "os_config" }
+command { service = "OperServ"; name = "CONFIG"; command = "operserv/config"; permission = "operserv/config"; }
+
+module { name = "os_forbid" }
+command { service = "OperServ"; name = "FORBID"; command = "operserv/forbid"; permission = "operserv/forbid"; }
+
+module { name = "os_ignore" }
+command { service = "OperServ"; name = "IGNORE"; command = "operserv/ignore"; permission = "operserv/ignore"; }
+
+module { name = "os_info" }
+command { service = "OperServ"; name = "INFO"; command = "operserv/info"; permission = "operserv/info"; }
+
+module { name = "os_jupe" }
+command { service = "OperServ"; name = "JUPE"; command = "operserv/jupe"; permission = "operserv/jupe"; }
+
+module { name = "os_kick" }
+command { service = "OperServ"; name = "KICK"; command = "operserv/kick"; permission = "operserv/kick"; }
+
+module { name = "os_kill" }
+command { service = "OperServ"; name = "KILL"; command = "operserv/kill"; permission = "operserv/kill"; }
+
+module { name = "os_list" }
+command { service = "OperServ"; name = "CHANLIST"; command = "operserv/chanlist"; permission = "operserv/chanlist"; }
+command { service = "OperServ"; name = "USERLIST"; command = "operserv/userlist"; permission = "operserv/userlist"; }
+
+module { name = "os_login" }
+command { service = "OperServ"; name = "LOGIN"; command = "operserv/login"; }
+command { service = "OperServ"; name = "LOGOUT"; command = "operserv/logout"; }
+
+module {
+	name = "os_logsearch"
+	logname = "services.log"
+}
+command { service = "OperServ"; name = "LOGSEARCH"; command = "operserv/logsearch"; permission = "operserv/logsearch"; }
+
+module { name = "os_mode" }
+command { service = "OperServ"; name = "UMODE"; command = "operserv/umode"; permission = "operserv/umode"; }
+command { service = "OperServ"; name = "MODE"; command = "operserv/mode"; permission = "operserv/mode"; }
+
+module { name = "os_modinfo" }
+command { service = "OperServ"; name = "MODINFO"; command = "operserv/modinfo"; permission = "operserv/modinfo"; }
+command { service = "OperServ"; name = "MODLIST"; command = "operserv/modlist"; permission = "operserv/modinfo"; }
+
+module { name = "os_module" }
+command { service = "OperServ"; name = "MODLOAD"; command = "operserv/modload"; permission = "operserv/modload"; }
+command { service = "OperServ"; name = "MODRELOAD"; command = "operserv/modreload"; permission = "operserv/modload"; }
+command { service = "OperServ"; name = "MODUNLOAD"; command = "operserv/modunload"; permission = "operserv/modload"; }
+
+module {
+	name = "os_news"
+
+	announcer = "Global"
+	oper_announcer = "OperServ"
+}
+command { service = "OperServ"; name = "LOGONNEWS"; command = "operserv/logonnews"; permission = "operserv/news"; }
+command { service = "OperServ"; name = "OPERNEWS"; command = "operserv/opernews"; permission = "operserv/news"; }
+command { service = "OperServ"; name = "RANDOMNEWS"; command = "operserv/randomnews"; permission = "operserv/news"; }
+
+module { name = "os_noop" }
+command { service = "OperServ"; name = "NOOP"; command = "operserv/noop"; permission = "operserv/noop"; }
+
+module { name = "os_oline" }
+command { service = "OperServ"; name = "OLINE"; command = "operserv/oline"; permission = "operserv/oline"; }
+
+module { name = "os_oper" }
+command { service = "OperServ"; name = "OPER"; command = "operserv/oper"; permission = "operserv/oper"; }
+
+module { name = "os_reload" }
+command { service = "OperServ"; name = "RELOAD"; command = "operserv/reload"; permission = "operserv/reload"; }
+
+module {
+	name = "os_session"
+
+        # Set practically no session limit, since many Slack bots join from a single IP.
+	defaultsessionlimit = 1000
+	maxsessionlimit = 10000
+	exceptionexpiry = 1d
+	sessionlimitexceeded = "The session limit for your IP %IP% has been exceeded."
+
+	maxsessionkill = 15
+	sessionautokillexpiry = 30m
+
+	session_ipv4_cidr = 32
+	session_ipv6_cidr = 128
+}
+command { service = "OperServ"; name = "EXCEPTION"; command = "operserv/exception"; permission = "operserv/exception"; }
+command { service = "OperServ"; name = "SESSION"; command = "operserv/session"; permission = "operserv/session"; }
+
+module { name = "os_set" }
+command { service = "OperServ"; name = "SET"; command = "operserv/set"; permission = "operserv/set"; }
+
+module { name = "os_shutdown" }
+command { service = "OperServ"; name = "QUIT"; command = "operserv/quit"; permission = "operserv/quit"; }
+command { service = "OperServ"; name = "RESTART"; command = "operserv/restart"; permission = "operserv/restart"; }
+command { service = "OperServ"; name = "SHUTDOWN"; command = "operserv/shutdown"; permission = "operserv/shutdown"; }
+
+module { name = "os_stats" }
+command { service = "OperServ"; name = "STATS"; command = "operserv/stats"; permission = "operserv/stats"; }
+
+module { name = "os_svs" }
+command { service = "OperServ"; name = "SVSNICK"; command = "operserv/svsnick"; permission = "operserv/svs"; }
+command { service = "OperServ"; name = "SVSJOIN"; command = "operserv/svsjoin"; permission = "operserv/svs"; }
+command { service = "OperServ"; name = "SVSPART"; command = "operserv/svspart"; permission = "operserv/svs"; }
+
+module { name = "os_sxline" }
+command { service = "OperServ"; name = "SNLINE"; command = "operserv/snline"; permission = "operserv/snline"; }
+command { service = "OperServ"; name = "SQLINE"; command = "operserv/sqline"; permission = "operserv/sqline"; }
+
+module { name = "os_update" }
+command { service = "OperServ"; name = "UPDATE"; command = "operserv/update"; permission = "operserv/update"; }

--- a/modules/ocf_irc/files/anope/operserv.conf
+++ b/modules/ocf_irc/files/anope/operserv.conf
@@ -106,24 +106,6 @@ command { service = "OperServ"; name = "OPER"; command = "operserv/oper"; permis
 module { name = "os_reload" }
 command { service = "OperServ"; name = "RELOAD"; command = "operserv/reload"; permission = "operserv/reload"; }
 
-module {
-	name = "os_session"
-
-        # Set practically no session limit, since many Slack bots join from a single IP.
-	defaultsessionlimit = 1000
-	maxsessionlimit = 10000
-	exceptionexpiry = 1d
-	sessionlimitexceeded = "The session limit for your IP %IP% has been exceeded."
-
-	maxsessionkill = 15
-	sessionautokillexpiry = 30m
-
-	session_ipv4_cidr = 32
-	session_ipv6_cidr = 128
-}
-command { service = "OperServ"; name = "EXCEPTION"; command = "operserv/exception"; permission = "operserv/exception"; }
-command { service = "OperServ"; name = "SESSION"; command = "operserv/session"; permission = "operserv/session"; }
-
 module { name = "os_set" }
 command { service = "OperServ"; name = "SET"; command = "operserv/set"; permission = "operserv/set"; }
 

--- a/modules/ocf_irc/files/ircd.motd
+++ b/modules/ocf_irc/files/ircd.motd
@@ -1,0 +1,9 @@
+Welcome to the OCF's irc server at irc.ocf.berkeley.edu.
+This server listens on ports 6661-6669.  The SSL port is 6697.
+
+IRC is a privilege, not a right. If it is abused, you will be
+removed from this server.
+
+Don't be a hoser ;-)
+
+Contact help@ocf.berkeley.edu if you have any questions/comments.

--- a/modules/ocf_irc/manifests/init.pp
+++ b/modules/ocf_irc/manifests/init.pp
@@ -1,4 +1,114 @@
 class ocf_irc {
   include ocf_ssl
   include ocf_irc::slack
+
+  package {
+    [
+      'anope',
+      'inspircd',
+    ]:;
+  }
+
+  # Need to run these for users to restore their options after import:
+  # `/ns saset autoop <nick> on`, `/ns saset kill <nick> quick`,
+  # `/ns saset secure <nick> on`, `/ns saset private <nick> on`
+  # Options set for users on existing IRC: Protection, Security, Private, Auto-op
+  #
+  # Also need to enable these options for all channels:
+  # `/cs set keeptopic #<channel> on`, `/cs set peace #<channel> on`,
+  # `/cs set signkick #<channel> on`, `/cs set secure #<channel> on`,
+  # `/cs set securefounder #<channel> on`, `/cs set noexpire #<channel> on`
+  # Needed options: Topic Retention, Peace, Secure, Secure Founder, Signed kicks, No expire
+  #
+  # Also fix the AOP lists, they are wrong. Same likely with the SOP lists, etc.
+
+  # TODO: Make the Slack channel purposes update when the IRC topic updates!
+  # API: https://api.slack.com/methods/channels.setTopic
+
+  service { 'anope':
+    ensure  => 'running',
+    require => [Package['anope'], Service['inspircd']],
+  }
+
+  service { 'inspircd':
+    ensure  => 'running',
+    restart => 'service inspircd reload',
+    require => Package['inspircd'],
+  }
+
+  user { 'irc':
+    groups => 'ssl-cert',
+  }
+
+  # TODO: Restrict permissions on config files with passwords!
+  $irc_passwords = parsejson(file("/opt/puppet/shares/private/${::hostname}/irc-passwords"))
+
+  file {
+    # Core InspIRCd files
+    '/etc/default/inspircd':
+      content => 'INSPIRCD_ENABLED=1',
+      require => Package['inspircd'],
+      notify  => Service['inspircd'];
+
+    '/etc/inspircd/inspircd.conf':
+      content => template('ocf_irc/inspircd.conf.erb'),
+      mode    => '0640',
+      owner   => 'irc',
+      group   => 'irc',
+      require => Package['inspircd'],
+      notify  => Service['inspircd'];
+
+    '/etc/inspircd/inspircd.motd':
+      source  => 'puppet:///modules/ocf_irc/ircd.motd',
+      owner   => 'irc',
+      group   => 'irc',
+      require => Package['inspircd'],
+      notify  => Service['inspircd'];
+
+
+    # Core anope files
+    '/etc/default/anope':
+      content => 'START=yes',
+      require => Package['anope'],
+      notify  => Service['anope'];
+
+    '/etc/anope/services.conf':
+      content => template('ocf_irc/services.conf.erb'),
+      mode    => '0640',
+      group   => 'irc',
+      require => Package['anope'],
+      notify  => Service['anope'];
+
+    '/etc/anope/services.motd':
+      content => 'Welcome to OCF IRC Services!',
+      group   => 'irc',
+      require => Package['anope'],
+      notify  => Service['anope'];
+
+
+    # Anope service files
+    '/etc/anope/chanserv.conf':
+      source  => 'puppet:///modules/ocf_irc/anope/chanserv.conf',
+      group   => 'irc',
+      require => Package['anope'],
+      notify  => Service['anope'];
+
+    '/etc/anope/global.conf':
+      source  => 'puppet:///modules/ocf_irc/anope/global.conf',
+      group   => 'irc',
+      require => Package['anope'],
+      notify  => Service['anope'];
+
+    '/etc/anope/nickserv.conf':
+      source  => 'puppet:///modules/ocf_irc/anope/nickserv.conf',
+      group   => 'irc',
+      require => Package['anope'],
+      notify  => Service['anope'];
+
+    '/etc/anope/operserv.conf':
+      source  => 'puppet:///modules/ocf_irc/anope/operserv.conf',
+      group   => 'irc',
+      require => Package['anope'],
+      notify  => Service['anope'];
+  }
 }

--- a/modules/ocf_irc/manifests/init.pp
+++ b/modules/ocf_irc/manifests/init.pp
@@ -6,6 +6,7 @@ class ocf_irc {
 
   # Make the irc user able to read the certs for running the IRCd with SSL
   user { 'irc':
-    groups => 'ssl-cert',
+    groups  => 'ssl-cert',
+    require => Package['inspircd'],
   }
 }

--- a/modules/ocf_irc/manifests/init.pp
+++ b/modules/ocf_irc/manifests/init.pp
@@ -1,114 +1,11 @@
 class ocf_irc {
   include ocf_ssl
+  include ocf_irc::ircd
+  include ocf_irc::services
   include ocf_irc::slack
 
-  package {
-    [
-      'anope',
-      'inspircd',
-    ]:;
-  }
-
-  # Need to run these for users to restore their options after import:
-  # `/ns saset autoop <nick> on`, `/ns saset kill <nick> quick`,
-  # `/ns saset secure <nick> on`, `/ns saset private <nick> on`
-  # Options set for users on existing IRC: Protection, Security, Private, Auto-op
-  #
-  # Also need to enable these options for all channels:
-  # `/cs set keeptopic #<channel> on`, `/cs set peace #<channel> on`,
-  # `/cs set signkick #<channel> on`, `/cs set secure #<channel> on`,
-  # `/cs set securefounder #<channel> on`, `/cs set noexpire #<channel> on`
-  # Needed options: Topic Retention, Peace, Secure, Secure Founder, Signed kicks, No expire
-  #
-  # Also fix the AOP lists, they are wrong. Same likely with the SOP lists, etc.
-
-  # TODO: Make the Slack channel purposes update when the IRC topic updates!
-  # API: https://api.slack.com/methods/channels.setTopic
-
-  service { 'anope':
-    ensure  => 'running',
-    require => [Package['anope'], Service['inspircd']],
-  }
-
-  service { 'inspircd':
-    ensure  => 'running',
-    restart => 'service inspircd reload',
-    require => Package['inspircd'],
-  }
-
+  # Make the irc user able to read the certs for running the IRCd with SSL
   user { 'irc':
     groups => 'ssl-cert',
-  }
-
-  # TODO: Restrict permissions on config files with passwords!
-  $irc_passwords = parsejson(file("/opt/puppet/shares/private/${::hostname}/irc-passwords"))
-
-  file {
-    # Core InspIRCd files
-    '/etc/default/inspircd':
-      content => 'INSPIRCD_ENABLED=1',
-      require => Package['inspircd'],
-      notify  => Service['inspircd'];
-
-    '/etc/inspircd/inspircd.conf':
-      content => template('ocf_irc/inspircd.conf.erb'),
-      mode    => '0640',
-      owner   => 'irc',
-      group   => 'irc',
-      require => Package['inspircd'],
-      notify  => Service['inspircd'];
-
-    '/etc/inspircd/inspircd.motd':
-      source  => 'puppet:///modules/ocf_irc/ircd.motd',
-      owner   => 'irc',
-      group   => 'irc',
-      require => Package['inspircd'],
-      notify  => Service['inspircd'];
-
-
-    # Core anope files
-    '/etc/default/anope':
-      content => 'START=yes',
-      require => Package['anope'],
-      notify  => Service['anope'];
-
-    '/etc/anope/services.conf':
-      content => template('ocf_irc/services.conf.erb'),
-      mode    => '0640',
-      group   => 'irc',
-      require => Package['anope'],
-      notify  => Service['anope'];
-
-    '/etc/anope/services.motd':
-      content => 'Welcome to OCF IRC Services!',
-      group   => 'irc',
-      require => Package['anope'],
-      notify  => Service['anope'];
-
-
-    # Anope service files
-    '/etc/anope/chanserv.conf':
-      source  => 'puppet:///modules/ocf_irc/anope/chanserv.conf',
-      group   => 'irc',
-      require => Package['anope'],
-      notify  => Service['anope'];
-
-    '/etc/anope/global.conf':
-      source  => 'puppet:///modules/ocf_irc/anope/global.conf',
-      group   => 'irc',
-      require => Package['anope'],
-      notify  => Service['anope'];
-
-    '/etc/anope/nickserv.conf':
-      source  => 'puppet:///modules/ocf_irc/anope/nickserv.conf',
-      group   => 'irc',
-      require => Package['anope'],
-      notify  => Service['anope'];
-
-    '/etc/anope/operserv.conf':
-      source  => 'puppet:///modules/ocf_irc/anope/operserv.conf',
-      group   => 'irc',
-      require => Package['anope'],
-      notify  => Service['anope'];
   }
 }

--- a/modules/ocf_irc/manifests/ircd.pp
+++ b/modules/ocf_irc/manifests/ircd.pp
@@ -1,0 +1,32 @@
+class ocf_irc::ircd {
+  package { 'inspircd':; }
+
+  service { 'inspircd':
+    ensure  => 'running',
+    restart => 'service inspircd reload',
+    require => Package['inspircd'],
+  }
+
+  $passwords = parsejson(file("/opt/puppet/shares/private/${::hostname}/ircd-passwords"))
+
+  File {
+    require => Package['inspircd'],
+    notify  => Service['inspircd'],
+    owner   => 'irc',
+    group   => 'irc',
+  }
+
+  file {
+    '/etc/default/inspircd':
+      content => 'INSPIRCD_ENABLED=1',
+      owner   => 'root',
+      group   => 'root';
+
+    '/etc/inspircd/inspircd.conf':
+      content => template('ocf_irc/inspircd.conf.erb'),
+      mode    => '0640';
+
+    '/etc/inspircd/inspircd.motd':
+      source  => 'puppet:///modules/ocf_irc/ircd.motd';
+  }
+}

--- a/modules/ocf_irc/manifests/ircd.pp
+++ b/modules/ocf_irc/manifests/ircd.pp
@@ -2,7 +2,6 @@ class ocf_irc::ircd {
   package { 'inspircd':; }
 
   service { 'inspircd':
-    ensure  => 'running',
     restart => 'service inspircd reload',
     require => Package['inspircd'],
   }
@@ -12,15 +11,15 @@ class ocf_irc::ircd {
   File {
     require => Package['inspircd'],
     notify  => Service['inspircd'],
-    owner   => 'irc',
-    group   => 'irc',
+    owner   => irc,
+    group   => irc,
   }
 
   file {
     '/etc/default/inspircd':
       content => 'INSPIRCD_ENABLED=1',
-      owner   => 'root',
-      group   => 'root';
+      owner   => root,
+      group   => root;
 
     '/etc/inspircd/inspircd.conf':
       content => template('ocf_irc/inspircd.conf.erb'),

--- a/modules/ocf_irc/manifests/ircd.pp
+++ b/modules/ocf_irc/manifests/ircd.pp
@@ -17,7 +17,7 @@ class ocf_irc::ircd {
 
   file {
     '/etc/default/inspircd':
-      content => 'INSPIRCD_ENABLED=1',
+      content => "INSPIRCD_ENABLED=1\n",
       owner   => root,
       group   => root;
 

--- a/modules/ocf_irc/manifests/services.pp
+++ b/modules/ocf_irc/manifests/services.pp
@@ -28,7 +28,6 @@ class ocf_irc::services {
     '/etc/anope/services.motd':
       content => 'Welcome to OCF IRC Services!';
 
-    # Service files
     '/etc/anope':
       ensure  => directory,
       recurse => true,

--- a/modules/ocf_irc/manifests/services.pp
+++ b/modules/ocf_irc/manifests/services.pp
@@ -1,0 +1,37 @@
+class ocf_irc::services {
+  package { 'anope':; }
+
+  service { 'anope':
+    ensure  => 'running',
+    require => [Package['anope'], Service['inspircd']],
+  }
+
+  $passwords = parsejson(file("/opt/puppet/shares/private/${::hostname}/services-passwords"))
+
+  File {
+    require => Package['anope'],
+    notify  => Service['anope'],
+    owner   => 'irc',
+    group   => 'irc',
+  }
+
+  file {
+    '/etc/default/anope':
+      content => 'START=yes',
+      owner   => 'root',
+      group   => 'root';
+
+    '/etc/anope/services.conf':
+      content => template('ocf_irc/services.conf.erb'),
+      mode    => '0640';
+
+    '/etc/anope/services.motd':
+      content => 'Welcome to OCF IRC Services!';
+
+    # Service files
+    '/etc/anope':
+      ensure  => directory,
+      recurse => true,
+      source  => 'puppet:///modules/ocf_irc/anope';
+  }
+}

--- a/modules/ocf_irc/manifests/services.pp
+++ b/modules/ocf_irc/manifests/services.pp
@@ -11,22 +11,22 @@ class ocf_irc::services {
   File {
     require => Package['anope'],
     notify  => Service['anope'],
-    owner   => 'irc',
-    group   => 'irc',
+    owner   => irc,
+    group   => irc,
   }
 
   file {
     '/etc/default/anope':
-      content => 'START=yes',
-      owner   => 'root',
-      group   => 'root';
+      content => "START=yes\n",
+      owner   => root,
+      group   => root;
 
     '/etc/anope/services.conf':
       content => template('ocf_irc/services.conf.erb'),
       mode    => '0640';
 
     '/etc/anope/services.motd':
-      content => 'Welcome to OCF IRC Services!';
+      content => "Welcome to OCF IRC Services!\n";
 
     '/etc/anope':
       ensure  => directory,

--- a/modules/ocf_irc/manifests/services.pp
+++ b/modules/ocf_irc/manifests/services.pp
@@ -2,7 +2,6 @@ class ocf_irc::services {
   package { 'anope':; }
 
   service { 'anope':
-    ensure  => 'running',
     require => [Package['anope'], Service['inspircd']],
   }
 

--- a/modules/ocf_irc/manifests/services.pp
+++ b/modules/ocf_irc/manifests/services.pp
@@ -7,6 +7,8 @@ class ocf_irc::services {
 
   $passwords = parsejson(file("/opt/puppet/shares/private/${::hostname}/services-passwords"))
 
+  $root_nicks = ['waf', 'nattofriends', 'ckuehl', 'jvperrin', 'mattmcal']
+
   File {
     require => Package['anope'],
     notify  => Service['anope'],

--- a/modules/ocf_irc/manifests/slack.pp
+++ b/modules/ocf_irc/manifests/slack.pp
@@ -1,4 +1,9 @@
 class ocf_irc::slack {
+  # TODO:
+  #  - Update Slack channel topic when IRC changes and vice versa:
+  #      API: https://api.slack.com/methods/channels.setTopic
+  #  - Add Slack bots for users when they join, without requiring a restart
+
   package {
     [
       'nodejs',

--- a/modules/ocf_irc/manifests/slack.pp
+++ b/modules/ocf_irc/manifests/slack.pp
@@ -1,6 +1,7 @@
 class ocf_irc::slack {
   package {
     [
+      'nodejs',
       'nodejs-legacy',
       'slack-irc',
     ]:;

--- a/modules/ocf_irc/templates/inspircd.conf.erb
+++ b/modules/ocf_irc/templates/inspircd.conf.erb
@@ -4,10 +4,11 @@
 # Extra modules
 <module name="m_cloaking.so">
 <module name="m_conn_umodes.so">
-<module name="m_ldapoper.so">
 <module name="m_md5.so">
+<module name="m_mysql.so">
 <module name="m_override.so">
 <module name="m_sha256.so">
+<module name="m_sqloper.so">
 <module name="m_ssl_gnutls.so">
 
 # Required/Recommended modules for anope
@@ -95,18 +96,15 @@
       vhost="ocf.gods"
       override="KICK MODEOP MODEDEOP MODEVOICE MODEDEVOICE MODEHALFOP MODEDEHALFOP OTHERMODE">
 
-# Allow oper authentication using LDAP
-<ldapoper baserdn="ou=People,dc=OCF,dc=Berkeley,dc=EDU"
-          server="ldaps://ldap.ocf.berkeley.edu"
-          searchscope="subtree"
-          attribute="uid">
+# Store oper credentials in mysql
+<database name="ocfirc"
+          user="ocfirc"
+          pass="<%= @passwords['ocfirc-mysql'] -%>"
+          host="mysql.ocf.berkeley.edu"
+          port="3306"
+          id="irc">
 
-# List of allowed opers
-<oper name="waf"          password="uid=waf"      host="*@*" type="NetAdmin" hash="ldap">
-<oper name="nattofriends" password="uid=tzhu"     host="*@*" type="NetAdmin" hash="ldap">
-<oper name="ckuehl"       password="uid=ckuehl"   host="*@*" type="NetAdmin" hash="ldap">
-<oper name="jvperrin"     password="uid=jvperrin" host="*@*" type="NetAdmin" hash="ldap">
-<oper name="mattmcal"     password="uid=mattmcal" host="*@*" type="NetAdmin" hash="ldap">
+<sqloper dbid="irc" hash="sha256">
 
 
 <files motd="/etc/inspircd/inspircd.motd"

--- a/modules/ocf_irc/templates/inspircd.conf.erb
+++ b/modules/ocf_irc/templates/inspircd.conf.erb
@@ -1,0 +1,200 @@
+# Comments removed for easier editing
+# See the examples in /usr/share/doc/inspircd/examples/ for more information
+
+# Extra modules
+<module name="m_cloaking.so">
+<module name="m_conn_umodes.so">
+<module name="m_ldapoper.so">
+<module name="m_md5.so">
+<module name="m_override.so">
+<module name="m_sha256.so">
+<module name="m_ssl_gnutls.so">
+
+# Required/Recommended modules for anope
+<module name="m_alias.so">
+<module name="m_chghost.so">
+<module name="m_customprefix.so">
+<module name="m_hidechans.so">
+<module name="m_services_account.so">
+<module name="m_spanningtree.so">
+<module name="m_svshold.so">
+
+
+<server name="irc.ocf.berkeley.edu"
+        description="Open Computing Facility IRC Server"
+        network="OCF">
+
+<admin name="OCF Staff Members"
+       nick="ocf"
+       email="help@ocf.berkeley.edu">
+
+<gnutls certfile="/etc/ssl/private/<%= @fqdn -%>.bundle"
+        keyfile="/etc/ssl/private/<%= @fqdn -%>.key"
+        priority="NORMAL:-MD5">
+
+# Allow non-SSL connections from 6661 to 6669 and SSL on 6697
+# Port 25580 is localhost-only for anope services to connect
+<bind address="" port="6661-6669" type="clients">
+<bind address="" port="6697" type="clients" ssl="gnutls">
+<bind address="127.0.0.1" port="25580" type="servers">
+
+# Link to the anope server, only allow local connections
+<link name="services.irc.ocf.berkeley.edu"
+      ipaddr="localhost"
+      port="25580"
+      allowmask="127.0.0.0/8"
+      sendpass="<%= @irc_passwords['anope-link'] -%>"
+      recvpass="<%= @irc_passwords['anope-link'] -%>">
+
+<uline server="services.irc.ocf.berkeley.edu" silent="yes">
+
+
+# Passwords needed to kill/restart the IRCd while connected to it
+<power diepass="<%= @irc_passwords['diepass'] -%>"
+       restartpass="<%= @irc_passwords['restartpass'] -%>"
+       pause="5">
+
+
+# Users connecting from inside the OCF subnet have less restrictions and have
+# their host cloaked (+x mode)
+<connect allow="169.229.226.0/24"
+         timeout="60" flood="20" localmax="1000" globalmax="1000"
+         limit="1000" modes="+x">
+
+<connect allow="2607:f140:8801::/64"
+         timeout="60" flood="20" localmax="1000" globalmax="1000"
+         limit="1000" modes="+x">
+
+<connect allow="*"
+         timeout="60" flood="20" threshold="20" fakelag="on"
+         pingfreq="120" sendq="262144" recvq="8192"
+         useident="no" localmax="5" globalmax="5">
+
+# Cloaking for the OCF subnet
+<cloak mode="full" key="<%= @irc_passwords['cloak-key'] -%>" prefix="OCF-">
+
+
+# Allow overrides when users are opers
+<override noisy="yes" requirekey="no">
+
+# Create different classes for allowing access to groups of commands
+<class name="Shutdown"
+       commands="DIE RESTART REHASH LOADMODULE UNLOADMODULE RELOAD">
+<class name="ServerLink"
+       commands="CONNECT SQUIT RCONNECT MKPASSWD MKSHA256">
+<class name="BanControl"
+       commands="KILL GLINE KLINE ZLINE QLINE ELINE">
+<class name="OperChat"
+       commands="WALLOPS GLOBOPS SETIDLE SPYLIST SPYNAMES">
+<class name="HostCloak"
+       commands="SETHOST SETIDENT SETNAME CHGHOST CHGIDENT">
+
+# NetAdmins can pretty much do everything
+<type name="NetAdmin"
+      classes="OperChat BanControl HostCloak Shutdown ServerLink"
+      vhost="ocf.gods"
+      override="KICK MODEOP MODEDEOP MODEVOICE MODEDEVOICE MODEHALFOP MODEDEHALFOP OTHERMODE">
+
+# Allow oper authentication using LDAP
+<ldapoper baserdn="ou=People,dc=OCF,dc=Berkeley,dc=EDU"
+          server="ldaps://ldap.ocf.berkeley.edu"
+          searchscope="subtree"
+          attribute="uid">
+
+# List of allowed opers
+<oper name="ckuehl"   password="uid=ckuehl"   host="*@*" type="NetAdmin" hash="ldap">
+<oper name="jvperrin" password="uid=jvperrin" host="*@*" type="NetAdmin" hash="ldap">
+<oper name="mattmcal" password="uid=mattmcal" host="*@*" type="NetAdmin" hash="ldap">
+
+
+<files motd="/etc/inspircd/inspircd.motd"
+       rules="/etc/inspircd/inspircd.rules">
+
+# Max numbers of channels able to join
+<channels users="20"
+          opers="60">
+
+<pid file="/var/run/inspircd.pid">
+
+<options prefixquit="Quit: "
+         noservices="no"
+         qaprefixes="no"
+         deprotectself="no"
+         deprotectothers="no"
+         flatlinks="no"
+         hideulines="no"
+         syntaxhints="yes"
+         cyclehosts="yes"
+         ircumsgprefix="no"
+         announcets="yes"
+         disablehmac="no"
+         hostintopic="yes"
+         quietbursts="yes"
+         pingwarning="15"
+         allowhalfop="yes"
+	       exemptchanops="">
+
+<security hidewhois=""
+          userstats="Pu"
+          customversion=""
+          hidesplits="no"
+          hidebans="no"
+          operspywhois="no"
+          hidemodes="eI"
+          maxtargets="20"
+          hideulines="yes">
+
+<performance nouserdns="no"
+             maxwho="128"
+             softlimit="1024"
+             somaxconn="128"
+             netbuffersize="10240">
+
+<limits maxnick="32"
+        maxchan="64"
+        maxmodes="20"
+        maxident="11"
+        maxquit="255"
+        maxtopic="307"
+        maxkick="255"
+        maxgecos="128"
+        maxaway="200">
+
+<log method="file"
+     type="* -USERINPUT -USEROUTPUT"
+     level="default"
+     target="/var/log/inspircd.log">
+
+<whowas groupsize="10"
+        maxgroups="100000"
+        maxkeep="3d">
+
+<timesync enable="no" master="no">
+
+<badnick nick="ChanServ" reason="Reserved For Services">
+<badnick nick="NickServ" reason="Reserved For Services">
+<badnick nick="OperServ" reason="Reserved For Services">
+<badnick nick="MemoServ" reason="Reserved For Services">
+
+# Allow slack bots to connect with no limits
+<exception host="*@flood.ocf.berkeley.edu" reason="IRC server hostname">
+<exception host="*@dev-flood.ocf.berkeley.edu" reason="Dev IRC server hostname">
+
+
+# Anope aliases
+<alias text="NICKSERV" replace="PRIVMSG NickServ :$2-" requires="NickServ" uline="yes">
+<alias text="CHANSERV" replace="PRIVMSG ChanServ :$2-" requires="ChanServ" uline="yes">
+<alias text="OPERSERV" replace="PRIVMSG OperServ :$2-" requires="OperServ" uline="yes">
+<alias text="MEMOSERV" replace="PRIVMSG MemoServ :$2-" requires="MemoServ" uline="yes">
+<alias text="HOSTSERV" replace="PRIVMSG HostServ :$2-" requires="HostServ" uline="yes">
+<alias text="BOTSERV" replace="PRIVMSG BotServ :$2-" requires="BotServ" uline="yes">
+
+<alias text="NS" replace="PRIVMSG NickServ :$2-" requires="NickServ" uline="yes">
+<alias text="CS" replace="PRIVMSG ChanServ :$2-" requires="ChanServ" uline="yes">
+<alias text="OS" replace="PRIVMSG OperServ :$2-" requires="OperServ" uline="yes">
+<alias text="MS" replace="PRIVMSG MemoServ :$2-" requires="MemoServ" uline="yes">
+<alias text="HS" replace="PRIVMSG HostServ :$2-" requires="HostServ" uline="yes">
+<alias text="BS" replace="PRIVMSG BotServ :$2-" requires="BotServ" uline="yes">
+
+<alias text="ID" format="*" replace="PRIVMSG NickServ :IDENTIFY $2-" requires="NickServ" uline="yes">
+<alias text="IDENTIFY" format="*" replace="PRIVMSG NickServ :IDENTIFY $2-" requires="NickServ" uline="yes">

--- a/modules/ocf_irc/templates/inspircd.conf.erb
+++ b/modules/ocf_irc/templates/inspircd.conf.erb
@@ -43,15 +43,15 @@
       ipaddr="localhost"
       port="25580"
       allowmask="127.0.0.0/8"
-      sendpass="<%= @irc_passwords['anope-link'] -%>"
-      recvpass="<%= @irc_passwords['anope-link'] -%>">
+      sendpass="<%= @passwords['anope-link'] -%>"
+      recvpass="<%= @passwords['anope-link'] -%>">
 
 <uline server="services.irc.ocf.berkeley.edu" silent="yes">
 
 
 # Passwords needed to kill/restart the IRCd while connected to it
-<power diepass="<%= @irc_passwords['diepass'] -%>"
-       restartpass="<%= @irc_passwords['restartpass'] -%>"
+<power diepass="<%= @passwords['diepass'] -%>"
+       restartpass="<%= @passwords['restartpass'] -%>"
        pause="5">
 
 
@@ -71,7 +71,7 @@
          useident="no" localmax="5" globalmax="5">
 
 # Cloaking for the OCF subnet
-<cloak mode="full" key="<%= @irc_passwords['cloak-key'] -%>" prefix="OCF-">
+<cloak mode="full" key="<%= @passwords['cloak-key'] -%>" prefix="OCF-">
 
 
 # Allow overrides when users are opers

--- a/modules/ocf_irc/templates/inspircd.conf.erb
+++ b/modules/ocf_irc/templates/inspircd.conf.erb
@@ -110,45 +110,15 @@
 <files motd="/etc/inspircd/inspircd.motd"
        rules="/etc/inspircd/inspircd.rules">
 
-# Max numbers of channels able to join
-<channels users="20"
-          opers="60">
-
 <pid file="/var/run/inspircd.pid">
 
 <options prefixquit="Quit: "
-         noservices="no"
-         qaprefixes="no"
-         deprotectself="no"
-         deprotectothers="no"
-         flatlinks="no"
-         hideulines="no"
-         syntaxhints="yes"
-         cyclehosts="yes"
-         ircumsgprefix="no"
-         announcets="yes"
-         disablehmac="no"
-         hostintopic="yes"
-         quietbursts="yes"
-         pingwarning="15"
-         allowhalfop="yes"
-         exemptchanops="">
+         syntaxhints="yes">
 
-<security hidewhois=""
-          userstats="Pu"
-          customversion=""
-          hidesplits="no"
-          hidebans="no"
-          operspywhois="no"
-          hidemodes="eI"
-          maxtargets="20"
-          hideulines="yes">
+<security hidewhois="*.ocf.berkeley.edu"
+          operspywhois="yes">
 
-<performance nouserdns="no"
-             maxwho="128"
-             softlimit="1024"
-             somaxconn="128"
-             netbuffersize="10240">
+<performance netbuffersize="10240">
 
 <limits maxnick="32"
         maxchan="64"
@@ -161,20 +131,13 @@
         maxaway="200">
 
 <log method="file"
-     type="* -USERINPUT -USEROUTPUT"
+     type="* -USERINPUT -USEROUTPUT -m_spanningtree"
      level="default"
      target="/var/log/inspircd.log">
 
-<whowas groupsize="10"
-        maxgroups="100000"
-        maxkeep="3d">
 
-<timesync enable="no" master="no">
-
-<badnick nick="ChanServ" reason="Reserved For Services">
-<badnick nick="NickServ" reason="Reserved For Services">
-<badnick nick="OperServ" reason="Reserved For Services">
-<badnick nick="MemoServ" reason="Reserved For Services">
+<badnick nick="Global" reason="Reserved For Services">
+<badnick nick="*Serv" reason="Reserved For Services">
 
 # Allow slack bots to connect with no limits
 <exception host="*@flood.ocf.berkeley.edu" reason="IRC server hostname">
@@ -187,14 +150,12 @@
 <alias text="OPERSERV" replace="PRIVMSG OperServ :$2-" requires="OperServ" uline="yes">
 <alias text="MEMOSERV" replace="PRIVMSG MemoServ :$2-" requires="MemoServ" uline="yes">
 <alias text="HOSTSERV" replace="PRIVMSG HostServ :$2-" requires="HostServ" uline="yes">
-<alias text="BOTSERV" replace="PRIVMSG BotServ :$2-" requires="BotServ" uline="yes">
 
 <alias text="NS" replace="PRIVMSG NickServ :$2-" requires="NickServ" uline="yes">
 <alias text="CS" replace="PRIVMSG ChanServ :$2-" requires="ChanServ" uline="yes">
 <alias text="OS" replace="PRIVMSG OperServ :$2-" requires="OperServ" uline="yes">
 <alias text="MS" replace="PRIVMSG MemoServ :$2-" requires="MemoServ" uline="yes">
 <alias text="HS" replace="PRIVMSG HostServ :$2-" requires="HostServ" uline="yes">
-<alias text="BS" replace="PRIVMSG BotServ :$2-" requires="BotServ" uline="yes">
 
 <alias text="ID" format="*" replace="PRIVMSG NickServ :IDENTIFY $2-" requires="NickServ" uline="yes">
 <alias text="IDENTIFY" format="*" replace="PRIVMSG NickServ :IDENTIFY $2-" requires="NickServ" uline="yes">

--- a/modules/ocf_irc/templates/inspircd.conf.erb
+++ b/modules/ocf_irc/templates/inspircd.conf.erb
@@ -102,9 +102,11 @@
           attribute="uid">
 
 # List of allowed opers
-<oper name="ckuehl"   password="uid=ckuehl"   host="*@*" type="NetAdmin" hash="ldap">
-<oper name="jvperrin" password="uid=jvperrin" host="*@*" type="NetAdmin" hash="ldap">
-<oper name="mattmcal" password="uid=mattmcal" host="*@*" type="NetAdmin" hash="ldap">
+<oper name="waf"          password="uid=waf"      host="*@*" type="NetAdmin" hash="ldap">
+<oper name="nattofriends" password="uid=tzhu"     host="*@*" type="NetAdmin" hash="ldap">
+<oper name="ckuehl"       password="uid=ckuehl"   host="*@*" type="NetAdmin" hash="ldap">
+<oper name="jvperrin"     password="uid=jvperrin" host="*@*" type="NetAdmin" hash="ldap">
+<oper name="mattmcal"     password="uid=mattmcal" host="*@*" type="NetAdmin" hash="ldap">
 
 
 <files motd="/etc/inspircd/inspircd.motd"
@@ -132,7 +134,7 @@
          quietbursts="yes"
          pingwarning="15"
          allowhalfop="yes"
-	       exemptchanops="">
+         exemptchanops="">
 
 <security hidewhois=""
           userstats="Pu"

--- a/modules/ocf_irc/templates/services.conf.erb
+++ b/modules/ocf_irc/templates/services.conf.erb
@@ -14,7 +14,7 @@ uplink {
 
     port = 25580
 
-    password = "<%= @irc_passwords['anope-link'] -%>"
+    password = "<%= @passwords['anope-link'] -%>"
 }
 
 serverinfo {
@@ -48,7 +48,7 @@ networkinfo {
 
 options {
     casemap = "rfc1459"
-    seed = <%= @irc_passwords['anope-seed'] %>
+    seed = <%= @passwords['seed'] %>
 
     strictpasswords = yes
     badpasslimit = 5
@@ -240,7 +240,7 @@ module {
         database = "ocfanope"
         server = "mysql.ocf.berkeley.edu"
         username = "ocfanope"
-        password = "<%= @irc_passwords['ocfanope-mysql'] -%>"
+        password = "<%= @passwords['ocfanope-mysql'] -%>"
         port = 3306
     }
 }

--- a/modules/ocf_irc/templates/services.conf.erb
+++ b/modules/ocf_irc/templates/services.conf.erb
@@ -137,30 +137,12 @@ opertype {
 
 
 # Services opers
+<% @root_nicks.each do |nick| -%>
 oper {
-    name = "waf"
+    name = "<%= nick -%>"
     type = "Services Root"
 }
-
-oper {
-    name = "nattofriends"
-    type = "Services Root"
-}
-
-oper {
-    name = "ckuehl"
-    type = "Services Root"
-}
-
-oper {
-    name = "jvperrin"
-    type = "Services Root"
-}
-
-oper {
-    name = "mattmcal"
-    type = "Services Root"
-}
+<% end -%>
 
 
 # NickServ email registration/password reset settings

--- a/modules/ocf_irc/templates/services.conf.erb
+++ b/modules/ocf_irc/templates/services.conf.erb
@@ -135,6 +135,8 @@ opertype {
     modes = "+Nq"
 }
 
+
+# Services opers
 oper {
     name = "waf"
     type = "Services Root"
@@ -211,24 +213,13 @@ mail {
                     %t"
 }
 
-#module {
-#    name = "db_flatfile"
-#    database = "anope.db"
-#    keepbackups = 3
-#    fork = no
-#}
-
 # Use mysql for data instead of the flat file default
 module {
-    #name = "db_sql"
     name = "db_sql_live"
-
     engine = "mysql/main"
 
     # We don't want anope_db_ to preceded the database table names (default)
     prefix = ""
-
-    #import = true
 }
 
 # MySQL connection credentials

--- a/modules/ocf_irc/templates/services.conf.erb
+++ b/modules/ocf_irc/templates/services.conf.erb
@@ -228,10 +228,10 @@ module {
 
     mysql {
         name = "mysql/main"
-        database = "ocfanope"
+        database = "ocfirc"
         server = "mysql.ocf.berkeley.edu"
-        username = "ocfanope"
-        password = "<%= @passwords['ocfanope-mysql'] -%>"
+        username = "ocfirc"
+        password = "<%= @passwords['ocfirc-mysql'] -%>"
         port = 3306
     }
 }

--- a/modules/ocf_irc/templates/services.conf.erb
+++ b/modules/ocf_irc/templates/services.conf.erb
@@ -4,7 +4,7 @@
 
 define {
     name = "services.host"
-    value = "irc.ocf.berkeley.edu"
+    value = "services.irc.ocf.berkeley.edu"
 }
 
 uplink {
@@ -20,7 +20,6 @@ uplink {
 serverinfo {
     name = "services.irc.ocf.berkeley.edu"
     description = "OCF IRC Services"
-    id = "20S"
 
     pid = "/var/run/anope/anope.pid"
     motd = "/etc/anope/services.motd"
@@ -59,35 +58,21 @@ options {
     readtimeout = 5s
     warningtimeout = 4h
     timeoutcheck = 3s
-    retrywait = 60s
+    retrywait = 15s
 
-    hideprivilegedcommands = no
-    hideregisteredcommands = no
+    hideprivilegedcommands = yes
+    hideregisteredcommands = yes
 
     regexengine = "regex/posix"
 }
 
 
 # Load services config files
-include {
-    type = "file"
-    name = "chanserv.conf"
-}
-
-include {
-    type = "file"
-    name = "global.conf"
-}
-
-include {
-    type = "file"
-    name = "nickserv.conf"
-}
-
-include {
-    type = "file"
-    name = "operserv.conf"
-}
+include { type = "file"; name = "chanserv.conf"; }
+include { type = "file"; name = "global.conf"; }
+include { type = "file"; name = "hostserv.conf"; }
+include { type = "file"; name = "nickserv.conf"; }
+include { type = "file"; name = "operserv.conf"; }
 
 
 # Log information to file and to the #services channel
@@ -97,37 +82,25 @@ log {
     logage = 60
 
     admin = "*"
-    override = "chanserv/* nickserv/* memoserv/set ~botserv/set botserv/*"
+    override = "*"
     commands = "*"
     servers = "*"
-    users = "connect disconnect nick"
+    users = "connect disconnect nick mode oper"
     other = "*"
-    rawio = yes
-    debug = yes
+    rawio = no
+    debug = no
 }
 
+# Log some useful information to ops
 log {
     target = "globops"
-    admin = "global/* operserv/mode operserv/kick operserv/akill operserv/s*line operserv/noop operserv/jupe operserv/oline operserv/set operserv/svsnick operserv/svsjoin operserv/svspart nickserv/getpass */drop"
-    servers = "squit"
+    admin = "global/* operserv/* */drop"
     users = "oper"
     other = "expire/* bados akill/*"
 }
 
 
-# Define different types of operators
-opertype {
-    name = "Services Operator"
-    commands = "chanserv/list chanserv/suspend chanserv/topic memoserv/staff nickserv/list nickserv/resetpass nickserv/suspend operserv/mode operserv/chankill operserv/szline operserv/akill operserv/session operserv/modlist operserv/sqline operserv/oper operserv/kick operserv/ignore operserv/snline"
-    privs = "chanserv/auspex chanserv/no-register-limit memoserv/* nickserv/auspex nickserv/confirm"
-}
-
-opertype {
-    name = "Services Administrator"
-    inherits = "Services Operator"
-    commands = "chanserv/access/list chanserv/drop chanserv/getkey chanserv/saset/noexpire memoserv/sendall nickserv/saset/* nickserv/getemail operserv/news operserv/jupe operserv/svsnick operserv/stats operserv/oline operserv/noop operserv/forbid global/*"
-}
-
+# Define different types of operators (we currently only use one type)
 opertype {
     name = "Services Root"
     commands = "*"
@@ -151,8 +124,6 @@ mail {
 
     sendmailpath = "/usr/sbin/sendmail -t -f help@ocf.berkeley.edu"
     sendfrom = "help@ocf.berkeley.edu"
-
-    restrict = yes
 
     delay = 5m
 
@@ -185,12 +156,11 @@ mail {
 
                     %N IRC administrators."
 
+    # We don't even use this one, but still need it here because otherwise mailing breaks
     memo_subject = "New memo"
     memo_message = "Hi %n,
 
-                    You've just received a new memo from %s. This is memo number %d.
-
-                    Memo text:
+                    You've just received a new memo from %s:
 
                     %t"
 }
@@ -218,7 +188,7 @@ module {
     }
 }
 
-# Load the SHA256 module for password encryption
+# Load the SHA256 module for NickServ password encryption
 module { name = "enc_sha256" }
 
 # Provide the generic/help command

--- a/modules/ocf_irc/templates/services.conf.erb
+++ b/modules/ocf_irc/templates/services.conf.erb
@@ -1,0 +1,252 @@
+# Comments trimmed for easier editing.
+# The original comments can be found on anope's wiki:
+# https://wiki.anope.org/index.php/2.0/Configuration#Example_Conf
+
+define {
+    name = "services.host"
+    value = "irc.ocf.berkeley.edu"
+}
+
+uplink {
+    host = "127.0.0.1"
+    ipv6 = no
+    ssl = no
+
+    port = 25580
+
+    password = "<%= @irc_passwords['anope-link'] -%>"
+}
+
+serverinfo {
+    name = "services.irc.ocf.berkeley.edu"
+    description = "OCF IRC Services"
+    id = "20S"
+
+    pid = "/var/run/anope/anope.pid"
+    motd = "/etc/anope/services.motd"
+}
+
+module {
+    name = "inspircd20"
+    use_server_side_mlock = yes
+    use_server_side_topiclock = yes
+}
+
+networkinfo {
+    networkname = "OCF"
+
+    nicklen = 32
+    userlen = 10
+    hostlen = 64
+    chanlen = 32
+
+    modelistsize = 100
+    vhost_chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-"
+    allow_undotted_vhosts = false
+    disallow_start_or_end = ".-"
+}
+
+options {
+    casemap = "rfc1459"
+    seed = <%= @irc_passwords['anope-seed'] %>
+
+    strictpasswords = yes
+    badpasslimit = 5
+    badpasstimeout = 1h
+
+    updatetimeout = 5m
+    expiretimeout = 30m
+    readtimeout = 5s
+    warningtimeout = 4h
+    timeoutcheck = 3s
+    retrywait = 60s
+
+    hideprivilegedcommands = no
+    hideregisteredcommands = no
+
+    regexengine = "regex/posix"
+}
+
+
+# Load services config files
+include {
+    type = "file"
+    name = "chanserv.conf"
+}
+
+include {
+    type = "file"
+    name = "global.conf"
+}
+
+include {
+    type = "file"
+    name = "nickserv.conf"
+}
+
+include {
+    type = "file"
+    name = "operserv.conf"
+}
+
+
+# Log information to file and to the #services channel
+log {
+    target = "services.log #services"
+    bot = "Global"
+    logage = 60
+
+    admin = "*"
+    override = "chanserv/* nickserv/* memoserv/set ~botserv/set botserv/*"
+    commands = "*"
+    servers = "*"
+    users = "connect disconnect nick"
+    other = "*"
+    rawio = yes
+    debug = yes
+}
+
+log {
+    target = "globops"
+    admin = "global/* operserv/mode operserv/kick operserv/akill operserv/s*line operserv/noop operserv/jupe operserv/oline operserv/set operserv/svsnick operserv/svsjoin operserv/svspart nickserv/getpass */drop"
+    servers = "squit"
+    users = "oper"
+    other = "expire/* bados akill/*"
+}
+
+
+# Define different types of operators
+opertype {
+    name = "Services Operator"
+    commands = "chanserv/list chanserv/suspend chanserv/topic memoserv/staff nickserv/list nickserv/resetpass nickserv/suspend operserv/mode operserv/chankill operserv/szline operserv/akill operserv/session operserv/modlist operserv/sqline operserv/oper operserv/kick operserv/ignore operserv/snline"
+    privs = "chanserv/auspex chanserv/no-register-limit memoserv/* nickserv/auspex nickserv/confirm"
+}
+
+opertype {
+    name = "Services Administrator"
+    inherits = "Services Operator"
+    commands = "chanserv/access/list chanserv/drop chanserv/getkey chanserv/saset/noexpire memoserv/sendall nickserv/saset/* nickserv/getemail operserv/news operserv/jupe operserv/svsnick operserv/stats operserv/oline operserv/noop operserv/forbid global/*"
+}
+
+opertype {
+    name = "Services Root"
+    commands = "*"
+    privs = "*"
+    modes = "+Nq"
+}
+
+oper {
+    name = "waf"
+    type = "Services Root"
+}
+
+oper {
+    name = "nattofriends"
+    type = "Services Root"
+}
+
+oper {
+    name = "ckuehl"
+    type = "Services Root"
+}
+
+oper {
+    name = "jvperrin"
+    type = "Services Root"
+}
+
+oper {
+    name = "mattmcal"
+    type = "Services Root"
+}
+
+
+# NickServ email registration/password reset settings
+mail {
+    usemail = yes
+
+    sendmailpath = "/usr/sbin/sendmail -t -f help@ocf.berkeley.edu"
+    sendfrom = "help@ocf.berkeley.edu"
+
+    restrict = yes
+
+    delay = 5m
+
+    registration_subject = "Nickname Registration for %n"
+    registration_message = "Hi,
+
+                            You have requested to register the nickname %n on %N.
+                            Please type \" /msg NickServ CONFIRM %c \" to complete registration.
+                            If you don't know why this mail was sent to you, please ignore it.
+
+                            %N IRC administrators."
+
+    reset_subject = "Reset password request for %n"
+    reset_message = "Hi,
+
+                    You have requested to have the password for %n reset.
+                    To reset your password, type \" /msg NickServ CONFIRM %n %c \"
+
+                    If you don't know why this mail was sent to you, please ignore it.
+
+                    %N IRC administrators."
+
+    emailchange_subject = "Email confirmation"
+    emailchange_message = "Hi,
+
+                    You have requested to change your email address from %e to %E.
+                    Please type \" /msg NickServ CONFIRM %c \" to confirm this change.
+
+                    If you don't know why this mail was sent to you, please ignore it.
+
+                    %N IRC administrators."
+
+    memo_subject = "New memo"
+    memo_message = "Hi %n,
+
+                    You've just received a new memo from %s. This is memo number %d.
+
+                    Memo text:
+
+                    %t"
+}
+
+#module {
+#    name = "db_flatfile"
+#    database = "anope.db"
+#    keepbackups = 3
+#    fork = no
+#}
+
+# Use mysql for data instead of the flat file default
+module {
+    #name = "db_sql"
+    name = "db_sql_live"
+
+    engine = "mysql/main"
+
+    # We don't want anope_db_ to preceded the database table names (default)
+    prefix = ""
+
+    #import = true
+}
+
+# MySQL connection credentials
+module {
+    name = "m_mysql"
+
+    mysql {
+        name = "mysql/main"
+        database = "ocfanope"
+        server = "mysql.ocf.berkeley.edu"
+        username = "ocfanope"
+        password = "<%= @irc_passwords['ocfanope-mysql'] -%>"
+        port = 3306
+    }
+}
+
+# Load the SHA256 module for password encryption
+module { name = "enc_sha256" }
+
+# Provide the generic/help command
+module { name = "help" }


### PR DESCRIPTION
Pretty much done now, it just needs testing! There's a test IRC server at `dev-irc.ocf.berkeley.edu` for testing, so I'd like to see if any features are missing or things are broken over there before merging this. I've already imported data from the old IRCd into mysql, so all NickServ credentials should work the same as before. Opers for the IRCd use LDAP for authentication, so they will use regular OCF credentials, but [only specified users](https://github.com/ocf/puppet/pull/55/files#diff-9cf5ceb409581fa83aab5a486c77e8e5R98) can authenticate to become opers, and IRCd opers aren't especially useful for much besides being able to access more anope commands, as far as I can tell. Maybe they would be more useful if we weren't using services for most things. Auto-op in channels should work fine as usual after authenticating with NickServ, since it is stored in mysql, so hopefully everything already works there.