### PR TITLE
Fix dependency cycles with apt sources (mostly mesos)

### DIFF
--- a/modules/ocf/manifests/apt.pp
+++ b/modules/ocf/manifests/apt.pp
@@ -78,21 +78,6 @@ class ocf::apt {
     require  => Apt::Key['mesosphere'],
   }
 
-  apt::key { 'docker':
-    id     => '58118E89F3A912897C070ADBF76221572C52609D',
-    server => 'keyserver.ubuntu.com',
-  }
-
-  apt::source { 'docker':
-    location    => 'http://apt.dockerproject.org/repo',
-    release     => 'debian-jessie',
-    repos       => 'main',
-    include   => {
-      src => false
-    },
-    require     => Apt::Key['docker'];
-  }
-
   file { '/etc/cron.daily/ocf-apt':
     mode    => '0755',
     content => template('ocf/apt/ocf-apt.erb'),

--- a/modules/ocf/manifests/apt.pp
+++ b/modules/ocf/manifests/apt.pp
@@ -66,18 +66,6 @@ class ocf::apt {
     source => 'https://apt.ocf.berkeley.edu/pubkey.gpg';
   }
 
-  apt::key { 'mesosphere':
-    id     => '81026D0004C44CF7EF55ADF8DF7D54CBE56151BF',
-    server => 'keyserver.ubuntu.com',
-  }
-
-  apt::source { 'mesosphere':
-    location => 'http://repos.mesosphere.io/debian/',
-    release  => $::lsbdistcodename,
-    repos    => 'main',
-    require  => Apt::Key['mesosphere'],
-  }
-
   file { '/etc/cron.daily/ocf-apt':
     mode    => '0755',
     content => template('ocf/apt/ocf-apt.erb'),

--- a/modules/ocf/manifests/packages/docker.pp
+++ b/modules/ocf/manifests/packages/docker.pp
@@ -12,6 +12,10 @@
 # more use out of them, but that requires quite a bit of work first.
 #
 class ocf::packages::docker($admin_group = 'docker') {
+  class { 'ocf::packages::docker::apt':
+    stage => first,
+  }
+
   package {
     'docker.io':
       ensure  => purged;

--- a/modules/ocf/manifests/packages/docker/apt.pp
+++ b/modules/ocf/manifests/packages/docker/apt.pp
@@ -12,6 +12,6 @@ class ocf::packages::docker::apt {
     include   => {
       src => false
     },
-    require     => Apt::Key['docker'];
+    require     => Apt::Key['docker'],
   }
 }

--- a/modules/ocf/manifests/packages/docker/apt.pp
+++ b/modules/ocf/manifests/packages/docker/apt.pp
@@ -1,0 +1,17 @@
+# Include Docker apt repo.
+class ocf::packages::docker::apt {
+  apt::key { 'docker':
+    id     => '58118E89F3A912897C070ADBF76221572C52609D',
+    server => 'keyserver.ubuntu.com',
+  }
+
+  apt::source { 'docker':
+    location    => 'http://apt.dockerproject.org/repo',
+    release     => 'debian-jessie',
+    repos       => 'main',
+    include   => {
+      src => false
+    },
+    require     => Apt::Key['docker'];
+  }
+}

--- a/modules/ocf_mesos/manifests/master/mesos.pp
+++ b/modules/ocf_mesos/manifests/master/mesos.pp
@@ -1,47 +1,57 @@
 class ocf_mesos::master::mesos($mesos_hostname) {
   include ocf_mesos::package
 
-  File {
-    notify  => Service['mesos-master'],
-    require => Package['mesos'],
-  }
-
   $ocf_mesos_password = 'hunter2'
 
   file {
     '/etc/mesos-master':
       ensure  => directory,
       recurse => true,
-      purge   => true;
+      purge   => true,
+      notify  => Service['mesos-master'],
+      require => Package['mesos'];
 
     '/etc/mesos-master/hostname':
-      content => "${mesos_hostname}\n";
+      content => "${mesos_hostname}\n",
+      notify  => Service['mesos-master'],
+      require => Package['mesos'];
 
     # We have 3 servers, so 2 is a quorum.
     '/etc/mesos-master/quorum':
-      content => "2\n";
+      content => "2\n",
+      notify  => Service['mesos-master'],
+      require => Package['mesos'];
 
     '/etc/mesos-master/work_dir':
-      content => "/var/lib/mesos\n";
+      content => "/var/lib/mesos\n",
+      notify  => Service['mesos-master'],
+      require => Package['mesos'];
 
     [
       '/etc/mesos-master/authenticate',
       '/etc/mesos-master/authenticate_slaves',
       '/etc/mesos-master/authenticate_http',
     ]:
-      content => "true\n";
+      content => "true\n",
+      notify  => Service['mesos-master'],
+      require => Package['mesos'];
 
     '/etc/mesos-master/authenticators':
-      content => "crammd5\n";
+      content => "crammd5\n",
+      notify  => Service['mesos-master'],
+      require => Package['mesos'];
 
     '/etc/mesos-master/credentials':
       content => "/opt/share/mesos/master/credentials.json\n",
-      require => File['/opt/share/mesos/master/credentials.json'];
+      require => [Package['mesos'], File['/opt/share/mesos/master/credentials.json']],
+      notify  => Service['mesos-master'];
 
     '/opt/share/mesos/master/credentials.json':
       content   => template('ocf_mesos/master/mesos/credentials.json.erb'),
       mode      => '0400',
-      show_diff => false;
+      show_diff => false,
+      notify  => Service['mesos-master'],
+      require => Package['mesos'];
   }
 
   augeas { '/etc/default/mesos-master':

--- a/modules/ocf_mesos/manifests/package.pp
+++ b/modules/ocf_mesos/manifests/package.pp
@@ -1,23 +1,26 @@
 class ocf_mesos::package {
+  class { 'ocf_mesos::package::first_stage':
+    stage => first,
+  }
+
   # We need Java 8 to be the default java.
   include ocf::packages::java
   package { ['mesos', 'zookeeper']:; }
-
-  Service {
-    require => Package['mesos'],
-  }
 
   $is_master = tagged('ocf_mesos::master')
   $is_slave = tagged('ocf_mesos::slave')
   service {
     'mesos-master':
       ensure => $is_master,
-      enable => $is_master;
+      enable => $is_master,
+      require => Package['mesos'];
     'zookeeper':
       ensure => $is_master,
-      enable => $is_master;
+      enable => $is_master,
+      require => Package['mesos'];
     'mesos-slave':
       ensure => $is_slave,
-      enable => $is_slave;
+      enable => $is_slave,
+      require => Package['mesos'];
   }
 }

--- a/modules/ocf_mesos/manifests/package/first_stage.pp
+++ b/modules/ocf_mesos/manifests/package/first_stage.pp
@@ -1,0 +1,13 @@
+class ocf_mesos::package::first_stage {
+  apt::key { 'mesosphere':
+    id     => '81026D0004C44CF7EF55ADF8DF7D54CBE56151BF',
+    server => 'keyserver.ubuntu.com',
+  }
+
+  apt::source { 'mesosphere':
+    location => 'http://repos.mesosphere.io/debian/',
+    release  => $::lsbdistcodename,
+    repos    => 'main',
+    require  => Apt::Key['mesosphere'],
+  }
+}

--- a/modules/ocf_mesos/manifests/slave.pp
+++ b/modules/ocf_mesos/manifests/slave.pp
@@ -14,45 +14,56 @@ class ocf_mesos::slave {
     require => Package['mesos'];
   }
 
-  File {
-    notify  => Service['mesos-slave'],
-    require => Package['mesos'],
-  }
-
   $ocf_mesos_password = 'hunter2'
 
+  # TODO: when on Puppet 4, use per-expression defaults
+  # https://docs.puppet.com/puppet/latest/reference/lang_resources_advanced.html#local-resource-defaults
   file {
     '/opt/share/mesos/slave':
-      ensure => directory;
+      ensure => directory,
+      notify  => Service['mesos-slave'],
+      require => Package['mesos'];
 
     '/etc/mesos-slave':
       ensure  => directory,
       recurse => true,
-      purge   => true;
+      purge   => true,
+      notify  => Service['mesos-slave'],
+      require => Package['mesos'];
 
     '/etc/mesos-slave/containerizers':
-      content => "docker\n";
+      content => "docker\n",
+      notify  => Service['mesos-slave'],
+      require => Package['mesos'];
 
     # increase executor timeout in case we need to pull a Docker image
     '/etc/mesos-slave/executor_registration_timeout':
-      content => "5mins\n";
+      content => "5mins\n",
+      notify  => Service['mesos-slave'],
+      require => Package['mesos'];
 
     # remove old dockers as soon as we're done with them
     '/etc/mesos-slave/docker_remove_delay':
-      content => "1secs\n";
+      content => "1secs\n",
+      notify  => Service['mesos-slave'],
+      require => Package['mesos'];
 
     '/etc/mesos-slave/hostname':
-      content => "${::hostname}\n";
+      content => "${::hostname}\n",
+      notify  => Service['mesos-slave'],
+      require => Package['mesos'];
 
 
     '/etc/mesos-slave/credential':
       content => "/opt/share/mesos/slave/credential.json\n",
-      require => File['/opt/share/mesos/slave/credential.json'];
+      require => [Package['mesos'], File['/opt/share/mesos/slave/credential.json']],
+      notify  => Service['mesos-slave'];
 
     '/opt/share/mesos/slave/credential.json':
       content   => template('ocf_mesos/slave/mesos/credential.json.erb'),
       mode      => '0400',
-      show_diff => false;
-
+      show_diff => false,
+      notify  => Service['mesos-slave'],
+      require => Package['mesos'];
   }
 }


### PR DESCRIPTION
We do stuff like this pretty frequently in our code:

```puppet
File {
  notify  => Service['mesos-slave'],
  require => Package['mesos'],
}
```

We thought this was just convenient shorthand for setting defaults inside a manifest. Turns out it's [way more sinister than that](https://docs.puppet.com/puppet/latest/reference/lang_defaults.html#behavior):

> Puppet still uses dynamic scope for resource defaults, even though it no longer uses dynamic variable lookup. This means that if you use a resource default statement in a class, it has the potential to affect any classes or defined types that class declares. See here for a full description of scope rules.

The reason we had these dependency cycles was because this class happened to get evaluated first, and it included indirectly `ocf::packages::docker::first_stage` which contained the apt repo resources. This lead to files like `/etc/apt/sources.list.d/docker.list` created by the apt plugin having a `require => Package['mesos']`, which is obviously invalid (since something in stage `first` can't depend on something in stage `main`).

This seems totally broken to me, the order manifests get included is an implementation detail and shouldn't affect the final result. And we do this all over our codebase and had no idea this is what it was doing. This is pretty scary; we should audit our uses of this pattern.

When we get to Puppet 4, we can use [per-expression defaults](https://docs.puppet.com/puppet/latest/reference/lang_resources_advanced.html#advanced-examples) which are much saner.

(The benefit of using these `first_stage` classes is that we don't need to add extra apt sources on all the servers, just on the servers that actually install packages from them. This was the best solution @daradib and I could come up with to the problem.)