### PR TITLE
Improve backports by giving updates to apt-dater (rt#3106)

### DIFF
--- a/modules/ocf/manifests/auth.pp
+++ b/modules/ocf/manifests/auth.pp
@@ -6,7 +6,8 @@ class ocf::auth($glogin = [], $ulogin = [[]], $gsudo = [], $usudo = [], $nopassw
   # NSS user/group identification
   ocf::repackage {
     # LDAP nameservice provider
-    'libnss-ldap':;
+    'libnss-ldap':
+      recommends => false;
   }
 
   package {

--- a/modules/ocf/manifests/auth.pp
+++ b/modules/ocf/manifests/auth.pp
@@ -6,8 +6,7 @@ class ocf::auth($glogin = [], $ulogin = [[]], $gsudo = [], $usudo = [], $nopassw
   # NSS user/group identification
   ocf::repackage {
     # LDAP nameservice provider
-    'libnss-ldap':
-      recommends => false;
+    'libnss-ldap':;
   }
 
   package {
@@ -35,7 +34,7 @@ class ocf::auth($glogin = [], $ulogin = [[]], $gsudo = [], $usudo = [], $nopassw
       ensure  => symlink,
       links   => manage,
       target  => '/etc/ldap.conf',
-      require => Package['libnss-ldap'];
+      require => Ocf::Repackage['libnss-ldap'];
   }
 
   # nameservice configuration
@@ -47,13 +46,13 @@ class ocf::auth($glogin = [], $ulogin = [[]], $gsudo = [], $usudo = [], $nopassw
     # from ldap, but ldap isn't needed constantly)
     file { '/etc/nsswitch.conf':
       source  => 'puppet:///modules/ocf/auth/nss/nsswitch-noldap.conf',
-      require => [Package['libnss-ldap'], File['/etc/libnss-ldap.conf']];
+      require => [Ocf::Repackage['libnss-ldap'], File['/etc/libnss-ldap.conf']];
     }
   } else {
     # use LDAP but failover to local copy
     file { '/etc/nsswitch.conf':
       source  => 'puppet:///modules/ocf/auth/nss/nsswitch.conf',
-      require => [Package['libnss-ldap'], File['/etc/libnss-ldap.conf']];
+      require => [Ocf::Repackage['libnss-ldap'], File['/etc/libnss-ldap.conf']];
     }
   }
   # restart NSCD

--- a/modules/ocf/manifests/packages/grub.pp
+++ b/modules/ocf/manifests/packages/grub.pp
@@ -8,7 +8,9 @@ class ocf::packages::grub {
   #
   # This is (currently unresolved) Debian bug#788062
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=788062
-  ocf::repackage { 'grub-pc':; }
+  ocf::repackage { 'grub-pc':
+    recommends => false;
+  }
   package { 'os-prober':
     ensure => purged;
   }

--- a/modules/ocf/manifests/packages/grub.pp
+++ b/modules/ocf/manifests/packages/grub.pp
@@ -8,9 +8,7 @@ class ocf::packages::grub {
   #
   # This is (currently unresolved) Debian bug#788062
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=788062
-  ocf::repackage { 'grub-pc':
-    recommends => false;
-  }
+  ocf::repackage { 'grub-pc':; }
   package { 'os-prober':
     ensure => purged;
   }

--- a/modules/ocf/manifests/repackage.pp
+++ b/modules/ocf/manifests/repackage.pp
@@ -1,6 +1,6 @@
 define ocf::repackage(
     $package     = $title,
-    $recommends  = false,
+    $recommends  = true,
     $backport_on = undef,
     $dist        = $::lsbdistcodename,
   ) {

--- a/modules/ocf/manifests/repackage.pp
+++ b/modules/ocf/manifests/repackage.pp
@@ -1,37 +1,29 @@
 define ocf::repackage(
     $package     = $title,
-    $recommends  = true,
+    $recommends  = false,
     $backport_on = undef,
     $dist        = $::lsbdistcodename,
   ) {
   $install_options = $recommends ? {
-    true    => ['--no-install-recommends'],
+    false   => ['--no-install-recommends'],
     default => []
   }
 
   if $backport_on and $dist == $backport_on {
-    #    apt::pin { "bpo-${package}":
-    #      release  => "${dist}-backports",
-    #      priority => 600,
-    #      packages => [$package];
-    #    }
-
-    package { $package:
-      # in case the non-backported package is already present
-      ensure          => latest,
-
-      # even though we've pinned the package, we still need -t dist-backports
-      # so that dependencies don't hold it back
-      install_options => concat($install_options, ['-t', "${dist}-backports"]);
-      #      require         => Apt::Pin["bpo-${package}"];
+    # We can't pin packages, because it won't install required dependencies that
+    # way, so we instead upgrade the package once (as long as it isn't a
+    # backport version already), and then future upgrades are done the normal
+    # way with apt-dater. It would be best if apt-dater did everything,
+    # including the original upgrade, but then a package and all its
+    # dependencies would need to be pinned, which is excessive and prone to
+    # breaking if a package's dependencies change.
+    exec { "/usr/bin/apt-get -y -o Dpkg::Options::=--force-confold ${install_options[0]} -t ${dist}-backports install ${package}":
+      logoutput => on_failure,
+      unless  => "dpkg-query -W ${package} | grep \~bpo";
     }
   } else {
     package { $package:
       install_options => $install_options;
     }
-
-    #    apt::pin { "bpo-${package}":
-    #      ensure => absent;
-    #    }
   }
 }

--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -47,10 +47,15 @@ class ocf_desktop::packages {
 
   # install packages without recommends
   ocf::repackage {
-    'brasero':;
-    'gedit':;
-    ['libreoffice-calc', 'libreoffice-draw', 'libreoffice-gnome', 'libreoffice-impress', 'libreoffice-writer', 'ure']:;
-    'thunar':;
-    ['virt-manager', 'virt-viewer']:;
+    'brasero':
+      recommends => false;
+    'gedit':
+      recommends => false;
+    ['libreoffice-calc', 'libreoffice-draw', 'libreoffice-gnome', 'libreoffice-impress', 'libreoffice-writer', 'ure']:
+      recommends => false;
+    'thunar':
+      recommends => false;
+    ['virt-manager', 'virt-viewer']:
+      recommends => false;
   }
 }

--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -47,15 +47,10 @@ class ocf_desktop::packages {
 
   # install packages without recommends
   ocf::repackage {
-    'brasero':
-      recommends  => false;
-    'gedit':
-      recommends  => false;
-    ['libreoffice-calc', 'libreoffice-draw', 'libreoffice-gnome', 'libreoffice-impress', 'libreoffice-writer', 'ure']:
-      recommends  => false;
-    'thunar':
-      recommends  => false;
-    ['virt-manager', 'virt-viewer']:
-      recommends  => false;
+    'brasero':;
+    'gedit':;
+    ['libreoffice-calc', 'libreoffice-draw', 'libreoffice-gnome', 'libreoffice-impress', 'libreoffice-writer', 'ure']:;
+    'thunar':;
+    ['virt-manager', 'virt-viewer']:;
   }
 }

--- a/modules/ocf_desktop/manifests/pulse.pp
+++ b/modules/ocf_desktop/manifests/pulse.pp
@@ -2,14 +2,10 @@ class ocf_desktop::pulse {
 
   ocf::repackage {
     # PulseAudio without recommends
-    'pulseaudio':
-      recommends => false,
-    ;
+    'pulseaudio':;
     # PulseAudio graphical interfaces
     [ 'paprefs', 'pavucontrol' ]:
-      recommends => false,
-      require    => Ocf::Repackage['pulseaudio'],
-    ;
+      require    => Ocf::Repackage['pulseaudio'];
   }
 
   # ALSA ultilities and PulseAudio plugin

--- a/modules/ocf_desktop/manifests/pulse.pp
+++ b/modules/ocf_desktop/manifests/pulse.pp
@@ -2,9 +2,11 @@ class ocf_desktop::pulse {
 
   ocf::repackage {
     # PulseAudio without recommends
-    'pulseaudio':;
+    'pulseaudio':
+      recommends => false;
     # PulseAudio graphical interfaces
     [ 'paprefs', 'pavucontrol' ]:
+      recommends => false,
       require    => Ocf::Repackage['pulseaudio'];
   }
 

--- a/modules/ocf_desktop/manifests/xfce.pp
+++ b/modules/ocf_desktop/manifests/xfce.pp
@@ -3,12 +3,6 @@ class ocf_desktop::xfce {
     recommends => false;
   }
 
-  # xfce4-power-manager asks for admin authentication on login in order to
-  # "change laptop display brightness"
-  package { 'xfce4-power-manager':
-    ensure => absent;
-  }
-
   file {
     # enable kiosk mode (disables shutdown, etc.)
     '/etc/xdg/xfce4/kiosk':

--- a/modules/ocf_desktop/manifests/xfce.pp
+++ b/modules/ocf_desktop/manifests/xfce.pp
@@ -1,7 +1,5 @@
 class ocf_desktop::xfce {
-  ocf::repackage { ['xfce4', 'xfce4-goodies', 'xfce4-notifyd']:
-    recommends => false;
-  }
+  ocf::repackage { ['xfce4', 'xfce4-goodies', 'xfce4-notifyd']:; }
 
   # TODO: figure out why this gets installed anyway on new systems
   # xfce4-power-manager asks for admin authentication on login in order to

--- a/modules/ocf_desktop/manifests/xfce.pp
+++ b/modules/ocf_desktop/manifests/xfce.pp
@@ -1,7 +1,8 @@
 class ocf_desktop::xfce {
-  ocf::repackage { ['xfce4', 'xfce4-goodies', 'xfce4-notifyd']:; }
+  ocf::repackage { ['xfce4', 'xfce4-goodies', 'xfce4-notifyd']:
+    recommends => false;
+  }
 
-  # TODO: figure out why this gets installed anyway on new systems
   # xfce4-power-manager asks for admin authentication on login in order to
   # "change laptop display brightness"
   package { 'xfce4-power-manager':


### PR DESCRIPTION
Updates for backported packages were previously done only by puppet, but it's better for apt-dater to perform these updates and only do the first package upgrade (normal -> backported) with puppet.

Also installing without recommends should work as intended now, before the behaviour was reversed, but now the default is to not install any recommends when using `ocf::repackage`.

One issue with changing this is that doing something like `require => Package['blah']` will only work if the package isn't being backported, since otherwise an `exec` is used instead of `package`, so the requirement breaks. I think the best behavior there would be to just require the parent `ocf::repackage` instead, which should work fine.