### PR TITLE
Add virtual host support to mail server

### DIFF
--- a/manifests/nodes.pp
+++ b/manifests/nodes.pp
@@ -7,7 +7,7 @@ node default {
   include ocf
 
   case $::hostname {
-    anthrax, sandstorm: {}
+    anthrax, sandstorm, dev-anthrax: {}
     default: { include ocf::packages::postfix }
   }
 
@@ -23,7 +23,6 @@ node default {
 
   case $type {
     'server': {
-
       if $owner == undef {
         case $::hostname {
           tsunami:    { class { 'ocf::auth': glogin => [ ['ocf', 'ALL'], ['sorry', 'ALL'] ] } }

--- a/modules/ocf_mail/files/site_vhost/pam
+++ b/modules/ocf_mail/files/site_vhost/pam
@@ -1,0 +1,2 @@
+auth       optional     pam_mysql.so config_file=/etc/pam-mysql.conf
+account    required     pam_mysql.so config_file=/etc/pam-mysql.conf

--- a/modules/ocf_mail/files/site_vhost/sasl_smtp.conf
+++ b/modules/ocf_mail/files/site_vhost/sasl_smtp.conf
@@ -1,0 +1,3 @@
+pwcheck_method: saslauthd
+mech_list: PLAIN LOGIN
+saslauthd_path: saslauthd/mux

--- a/modules/ocf_mail/files/site_vhost/trivial-table
+++ b/modules/ocf_mail/files/site_vhost/trivial-table
@@ -1,0 +1,4 @@
+# A trivial regexp table that always returns its key as the value.
+# This is used as the SASL [email] => [username] lookup table, since the
+# username always matches the email.
+/^(.*)$/ $1

--- a/modules/ocf_mail/manifests/init.pp
+++ b/modules/ocf_mail/manifests/init.pp
@@ -1,3 +1,36 @@
 class ocf_mail {
   include ocf_ssl
+
+  include ocf_mail::spam
+  include ocf_mail::site_ocf
+  include ocf_mail::site_vhost
+
+  package { ['postfix']:; }
+
+  service { 'postfix':
+    require => Package['postfix'],
+  }
+  user { 'ocfmail':
+    ensure  => present,
+    name    => ocfmail,
+    gid     => ocfmail,
+    groups  => [sys],
+    home    => '/var/mail',
+    shell   => '/bin/false',
+    system  => true,
+    require => Group['ocfmail'],
+  }
+
+  group { 'ocfmail':
+    ensure  => present,
+    name    => ocfmail,
+    system  => true,
+  }
+
+  file { '/etc/postfix/main.cf':
+    mode    => '0644',
+    content => template('ocf_mail/postfix/main.cf.erb'),
+    notify  => Service['postfix'],
+    require => Package['postfix'],
+  }
 }

--- a/modules/ocf_mail/manifests/logging.pp
+++ b/modules/ocf_mail/manifests/logging.pp
@@ -1,0 +1,18 @@
+class ocf_mail::logging {
+  file {
+    # outgoing nomail logging
+    '/var/mail/nomail':
+      ensure  => directory,
+      mode    => '0755',
+      owner   => ocfmail,
+      group   => ocfmail;
+    '/etc/logrotate.d/nomail':
+      ensure  => file,
+      source  => 'puppet:///modules/ocf_mail/site_ocf/logrotate/nomail';
+  }
+
+  ocf::munin::plugin { 'mails-past-hour':
+    source => 'puppet:///modules/ocf_mail/site_ocf/munin/mails-past-hour',
+    user   => root,
+  }
+}

--- a/modules/ocf_mail/manifests/site_ocf.pp
+++ b/modules/ocf_mail/manifests/site_ocf.pp
@@ -2,32 +2,7 @@
 # including LDAP users and internal mail (and mailing lists).
 
 class ocf_mail::site_ocf {
-  include ocf_mail::spam
-
-  package {
-    ['postfix', 'postfix-ldap', 'rt4-clients']:;
-  }
-
-  service { 'postfix':
-    require => [Package['postfix'], Package['rt4-clients']],
-  }
-
-  user { 'ocfmail':
-    ensure  => present,
-    name    => 'ocfmail',
-    gid     => 'ocfmail',
-    groups  => ['sys'],
-    home    => '/var/mail',
-    shell   => '/bin/false',
-    system  => true,
-    require => Group['ocfmail'],
-  }
-
-  group { 'ocfmail':
-    ensure  => present,
-    name    => 'ocfmail',
-    system  => true,
-  }
+  package { ['postfix-ldap', 'rt4-clients']:; }
 
   exec { 'newaliases':
     refreshonly => true,
@@ -83,12 +58,6 @@ class ocf_mail::site_ocf {
       source  => 'puppet:///private/smtp-krb5.keytab',
       require => Package['postfix'];
 
-    # postfix config
-    '/etc/postfix/main.cf':
-      mode    => '0644',
-      source  => 'puppet:///modules/ocf_mail/site_ocf/postfix/main.cf',
-      notify  => Service['postfix'],
-      require => Package['postfix'];
     '/etc/postfix/ldap-aliases.cf':
       mode    => '0644',
       source  => 'puppet:///modules/ocf_mail/site_ocf/postfix/ldap-aliases.cf',
@@ -118,20 +87,5 @@ class ocf_mail::site_ocf {
     '/usr/local/sbin/update-cred-cache':
       mode    => '0755',
       source  => 'puppet:///modules/ocf_mail/site_ocf/update-cred-cache';
-
-    # outgoing nomail logging
-    '/var/mail/nomail':
-      ensure  => directory,
-      mode    => '0755',
-      owner   => ocfmail,
-      group   => ocfmail;
-    '/etc/logrotate.d/nomail':
-      ensure  => file,
-      source  => 'puppet:///modules/ocf_mail/site_ocf/logrotate/nomail';
-  }
-
-  ocf::munin::plugin { 'mails-past-hour':
-    source => 'puppet:///modules/ocf_mail/site_ocf/munin/mails-past-hour',
-    user   => root,
   }
 }

--- a/modules/ocf_mail/manifests/site_vhost.pp
+++ b/modules/ocf_mail/manifests/site_vhost.pp
@@ -1,0 +1,92 @@
+# The ocf_mail::site_vhost class configures postfix to serve the virtual hosts,
+# both mail forwarding (receiving) and mail submission (sending).
+class ocf_mail::site_vhost {
+  # Configure an "smtp" PAM service that authenticates against MySQL.
+  # To test this, you can install pamtester and try:
+  # $ pamtester smtp ckuehl@dev-vhost.ocf.berkeley.edu authenticate
+  package { 'libpam-mysql':; }
+
+  $mysql_ro_password = file('/opt/puppet/shares/private/ocfmail/mysql-ro-password')
+
+  file {
+    '/etc/pam-mysql.conf':
+      content   => template('ocf_mail/site_vhost/pam-mysql.conf.erb'),
+      mode      => '0600',
+      show_diff => false,
+      require   => Package['libpam-mysql'];
+
+    '/etc/pam.d/smtp':
+      source    => 'puppet:///modules/ocf_mail/site_vhost/pam',
+      require   => Package['libpam-mysql'];
+  }
+
+  # Configure the saslauthd instance used by Postfix.
+  # To test this, you can use:  (warning: password will be logged)
+  # $ /usr/sbin/testsaslauthd -s smtp -u ckuehl@dev-vhost.ocf.berkeley.edu -p password
+  package { 'sasl2-bin':; }
+
+  service { 'saslauthd':
+    require => Package['sasl2-bin'],
+  }
+
+  file { '/var/spool/postfix/saslauthd':
+    ensure  => directory,
+    require => Package['postfix'],
+  }
+
+  augeas { '/etc/default/saslauthd':
+    lens    => 'Shellvars.lns',
+    incl    => '/etc/default/saslauthd',
+    changes =>  [
+      'set START yes',
+      'set DESC \'"OCF mail virtual host authentication"\'',
+      'set MECHANISMS pam',
+      'set OPTIONS \'"-r -c -m /var/spool/postfix/saslauthd"\'',
+    ],
+    notify  => Service['saslauthd'],
+    require => Package['sasl2-bin'];
+  }
+
+  # Postfix config to talk to SASL
+  # To test this, you can use:  (warning: password will be logged)
+  # $ echo -ne '\000ckuehl@dev-vhost.ocf.berkeley.edu\000password' | openssl base64
+  # $ openssl s_client -connect localhost:25 -starttls smtp
+  # EHLO localhost
+  # AUTH PLAIN [string from openssl]
+  package { 'postfix-mysql':; }
+
+  file {
+    '/etc/postfix/sasl/smtp.conf':
+      source  => 'puppet:///modules/ocf_mail/site_vhost/sasl_smtp.conf',
+      notify  => Service['postfix'],
+      require => Package['postfix'];
+
+    '/etc/postfix/vhost':
+      ensure  => directory,
+      notify  => Service['postfix'],
+      require => Package['postfix'];
+
+    '/etc/postfix/vhost/trivial-table':
+      source  => 'puppet:///modules/ocf_mail/site_vhost/trivial-table',
+      notify  => Service['postfix'],
+      require => Package['postfix'];
+
+    # Test with:
+    # $ postmap -q 'dev-vhost.ocf.berkeley.edu' mysql:/etc/postfix/vhost/mysql-alias-domains
+    '/etc/postfix/vhost/mysql-alias-domains':
+      content   => template('ocf_mail/site_vhost/mysql-alias-domains.erb'),
+      mode      => '0600',
+      show_diff => false,
+      notify    => Service['postfix'],
+      require   => Package['postfix'];
+
+    # Test with:
+    # $ postmap -q 'ckuehl@dev-vhost.ocf.berkeley.edu' mysql:/etc/postfix/vhost/mysql-alias-map
+    '/etc/postfix/vhost/mysql-alias-map':
+      content   => template('ocf_mail/site_vhost/mysql-alias-map.erb'),
+      mode      => '0600',
+      show_diff => false,
+      notify    => Service['postfix'],
+      require   => Package['postfix'];
+  }
+}

--- a/modules/ocf_mail/templates/postfix/main.cf.erb
+++ b/modules/ocf_mail/templates/postfix/main.cf.erb
@@ -15,7 +15,7 @@ mydestination = int.ocf.berkeley.edu
 virtual_mailbox_domains =
 virtual_alias_domains =
     ocf.berkeley.edu,
-    mysql:/etc/postfix/vhost/mysql-alias-domains
+    mysql:/etc/postfix/vhost/mysql-alias-domains,
 
 # logging
 always_bcc = ocflog
@@ -23,8 +23,8 @@ always_bcc = ocflog
 # aliases
 virtual_alias_maps =
     hash:/etc/postfix/ocf/aliases-local,
-	proxy:ldap:/etc/postfix/ldap-aliases.cf,
-    mysql:/etc/postfix/vhost/mysql-alias-map
+    proxy:ldap:/etc/postfix/ldap-aliases.cf,
+    mysql:/etc/postfix/vhost/mysql-alias-map,
 alias_maps =
     hash:/etc/aliases,
     hash:/etc/aliases-group,
@@ -39,7 +39,7 @@ virtual_alias_recursion_limit = 2
 
 # environment variables for LDAP GSSAPI bind
 import_environment = MAIL_CONFIG MAIL_DEBUG MAIL_LOGTAG TZ XAUTHORITY DISPLAY
-	LANG=C KRB5CCNAME=FILE:/var/spool/postfix/krb5-cred
+    LANG=C KRB5CCNAME=FILE:/var/spool/postfix/krb5-cred
 
 # postmaster notifications
 notify_classes = resource, software
@@ -96,7 +96,7 @@ smtpd_client_restrictions =
     permit_dnswl_client list.dnswl.org,
     check_policy_service inet:127.0.0.1:10023,
     sleep 5,
-    permit
+    permit,
 
 # restrictions on HELO hostname
 # reject invalid HELO hostnames
@@ -105,7 +105,7 @@ smtpd_helo_restrictions =
     permit_sasl_authenticated,
     reject_invalid_helo_hostname,
     reject_non_fqdn_helo_hostname,
-    check_helo_access texthash:/etc/postfix/ocf/helo_access
+    check_helo_access texthash:/etc/postfix/ocf/helo_access,
 
 # restrictions on sender addresses
 # reject bad users/auth, non-existant domains, policyd-weight
@@ -117,7 +117,7 @@ smtpd_sender_restrictions =
     reject_authenticated_sender_login_mismatch,
     permit_mynetworks,
     permit_sasl_authenticated,
-    check_policy_service inet:127.0.0.1:12525
+    check_policy_service inet:127.0.0.1:12525,
 
 # restrictions on recipient addresses
 # reject bad users/auth, non-existant domains, open relay
@@ -128,19 +128,19 @@ smtpd_recipient_restrictions =
     reject_non_fqdn_recipient,
     reject_unknown_recipient_domain,
     permit_mynetworks,
-    reject_unauth_destination
+    reject_unauth_destination,
 
 # restrictions before DATA command
 # MAILER-DAEMON should not have multiple recipients, do not speak too early
 smtpd_data_restrictions =
     permit_mynetworks,
-    reject_multi_recipient_bounce
+    reject_multi_recipient_bounce,
 
 # restrictions after DATA command
 # do not speak too early
 smtpd_end_of_data_restrictions =
     permit_mynetworks,
-    reject_unauth_pipelining
+    reject_unauth_pipelining,
 
 # add spamass and clamav milters
 smtpd_milters = unix:/spamass/spamass.sock, unix:/clamav/clamav-milter.ctl

--- a/modules/ocf_mail/templates/postfix/main.cf.erb
+++ b/modules/ocf_mail/templates/postfix/main.cf.erb
@@ -13,15 +13,21 @@ myorigin = $mydomain
 # only forward mail (no local delivery), except for special aliases
 mydestination = int.ocf.berkeley.edu
 virtual_mailbox_domains =
-virtual_alias_domains = ocf.berkeley.edu
+virtual_alias_domains =
+    ocf.berkeley.edu,
+    mysql:/etc/postfix/vhost/mysql-alias-domains
 
 # logging
 always_bcc = ocflog
 
 # aliases
-virtual_alias_maps = hash:/etc/postfix/ocf/aliases-local,
-	proxy:ldap:/etc/postfix/ldap-aliases.cf
-alias_maps = hash:/etc/aliases, hash:/etc/aliases-group
+virtual_alias_maps =
+    hash:/etc/postfix/ocf/aliases-local,
+	proxy:ldap:/etc/postfix/ldap-aliases.cf,
+    mysql:/etc/postfix/vhost/mysql-alias-map
+alias_maps =
+    hash:/etc/aliases,
+    hash:/etc/aliases-group,
 alias_database = hash:/etc/aliases
 
 # user used for delivering mail to files specified in aliases
@@ -44,10 +50,18 @@ masquerade_classes = envelope_sender, envelope_recipient, header_sender,
 	header_recipient
 local_header_rewrite_clients = permit_mynetworks
 
+# submission via SASL (for virtual hosts only)
+smtpd_sasl_auth_enable = yes
+broken_sasl_auth_clients = yes
+smtpd_sasl_path = smtp
+smtpd_sasl_security_options = noanonymous
+smtpd_tls_auth_only = yes
+smtpd_sasl_authenticated_header = yes
+smtpd_sender_login_maps = regexp:/etc/postfix/vhost/trivial-table
+
 # tls
-# TODO: Don't hardcode certificate FQDN
-smtpd_tls_cert_file=/etc/ssl/private/anthrax.ocf.berkeley.edu.bundle
-smtpd_tls_key_file=/etc/ssl/private/anthrax.ocf.berkeley.edu.key
+smtpd_tls_cert_file=/etc/ssl/private/<%= @fqdn %>.bundle
+smtpd_tls_key_file=/etc/ssl/private/<%= @fqdn %>.key
 smtpd_use_tls=yes
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
@@ -77,6 +91,7 @@ propagate_unmatched_extensions = canonical
 # skip OCF, reject if no reverse DNS, greylist if not whitelisted
 smtpd_client_restrictions =
     permit_mynetworks,
+    permit_sasl_authenticated,
     reject_unknown_client_hostname,
     permit_dnswl_client list.dnswl.org,
     check_policy_service inet:127.0.0.1:10023,
@@ -87,6 +102,7 @@ smtpd_client_restrictions =
 # reject invalid HELO hostnames
 smtpd_helo_restrictions =
     permit_mynetworks,
+    permit_sasl_authenticated,
     reject_invalid_helo_hostname,
     reject_non_fqdn_helo_hostname,
     check_helo_access texthash:/etc/postfix/ocf/helo_access
@@ -98,7 +114,9 @@ smtpd_sender_restrictions =
     check_sender_access hash:/etc/postfix/ocf/nomail-out-postfix,
     reject_non_fqdn_sender,
     reject_unknown_sender_domain,
+    reject_authenticated_sender_login_mismatch,
     permit_mynetworks,
+    permit_sasl_authenticated,
     check_policy_service inet:127.0.0.1:12525
 
 # restrictions on recipient addresses
@@ -106,6 +124,7 @@ smtpd_sender_restrictions =
 smtpd_recipient_restrictions =
     check_recipient_access hash:/etc/postfix/ocf/sorry-postfix,
     check_recipient_access hash:/etc/postfix/ocf/nomail-in-postfix,
+    permit_sasl_authenticated,
     reject_non_fqdn_recipient,
     reject_unknown_recipient_domain,
     permit_mynetworks,
@@ -130,3 +149,5 @@ milter_default_action = tempfail
 # send client IP address and hostname to spamass-milter
 # necessary for parsing Received headers and relay path
 milter_connect_macros = j {daemon_name} v {if_name} _
+
+# vim: ft=pfmain

--- a/modules/ocf_mail/templates/site_vhost/mysql-alias-domains.erb
+++ b/modules/ocf_mail/templates/site_vhost/mysql-alias-domains.erb
@@ -1,0 +1,8 @@
+hosts = mysql
+user = ocfmail-ro
+password = <%= @mysql_ro_password %>
+dbname = ocfmail
+query = SELECT domain FROM domains WHERE domain = '%s'
+
+# sanity check
+expansion_limit = 1

--- a/modules/ocf_mail/templates/site_vhost/mysql-alias-map.erb
+++ b/modules/ocf_mail/templates/site_vhost/mysql-alias-map.erb
@@ -1,0 +1,8 @@
+hosts = mysql
+user = ocfmail-ro
+password = <%= @mysql_ro_password %>
+dbname = ocfmail
+query = SELECT forward_to FROM addresses WHERE address = '%s'
+
+# sanity check
+expansion_limit = 1

--- a/modules/ocf_mail/templates/site_vhost/pam-mysql.conf.erb
+++ b/modules/ocf_mail/templates/site_vhost/pam-mysql.conf.erb
@@ -1,0 +1,13 @@
+users.host              = mysql
+users.database          = ocfmail
+users.db_user           = ocfmail-ro
+users.db_passwd         = <%= @mysql_ro_password %>
+users.table             = addresses
+users.user_column       = address
+users.password_column   = password
+
+# 1 means use crypt(3) and insert the result into the MySQL query.
+# We prefer this because otherwise the plaintext password will be in the query
+# (as ENCRYPT('password'), or similar), and this could easily end up in
+# slow-query logs, etc.
+users.password_crypt    = 1

--- a/modules/sandstorm/manifests/init.pp
+++ b/modules/sandstorm/manifests/init.pp
@@ -1,5 +1,0 @@
-class sandstorm {
-  include ocf_ssl
-  include ocf::acct
-  include ocf::limits
-}

--- a/modules/sandstorm/manifests/init.pp
+++ b/modules/sandstorm/manifests/init.pp
@@ -1,0 +1,5 @@
+class sandstorm {
+  include ocf_ssl
+  include ocf::acct
+  include ocf::limits
+}


### PR DESCRIPTION
This adds support to the mail server for serving virtual host mail.

We don't support storing mail (and thus don't have IMAP or webmail or anything); we think people won't really like this anyway. Instead, we provide mail *forwarding* and *sending* (submission).

We'll provide really good instructions on our website about how to configure Gmail to send via our SMTP server for that address. The idea is that people will forward to Gmail, and then use Gmail to send the reply mail (or compose new mail), which will be sent via our SMTP server. (Obviously you can use whatever forwarding address and SMTP client you want, but everyone uses Gmail anyway.)

Information goes into a new MySQL table:
```
MariaDB [ocfmail]> select * from addresses;
+------------------------------------+------------+--------------------------+---------------------+
| address                            | password   | forward_to               | last_updated        |
+------------------------------------+------------+--------------------------+---------------------+
| @derp.com                          | ...        | ckuehl@berkeley.edu      | 2016-08-14 20:40:48 |
| ckuehl2@dev-vhost.ocf.berkeley.edu | ...        | ckuehl+test@berkeley.edu | 2016-08-13 14:15:23 |
| ckuehl@dev-vhost.ocf.berkeley.edu  | ...        | ckuehl+test@berkeley.edu | 2016-08-13 14:15:23 |
| ckuehl@dev-vhost2.ocf.berkeley.edu | ...        | ckuehl+test@berkeley.edu | 2016-08-13 14:15:23 |
+------------------------------------+------------+--------------------------+---------------------+
4 rows in set (0.00 sec)
```

The passwords are salted and hashed using `crypt(3)`. Any `crypt`-format password will work on the verification side, but we'll generate them using [the same strong settings we use for our root password](https://github.com/ocf/utils/blob/ed9418d5eac922a1ead4e2c5c8a7241edafb0f75/staff/puppet/gen-rootpw#L2-L3).

This PR is enough to get the anthrax config totally working. The next part is writing functions in ocflib for querying and updating this database, and then adding a nice UI in ocfweb (this is why I added sessions/logins more prominently a few weeks ago).

For now we won't touch sandstorm, but once everything is in place, it will be easy to import existing `.forward` files, and then we can email groups about the changes.