### PR TITLE
Add test for resource defaults

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,11 @@
     hooks:
     -   id: reorder-python-imports
         language_version: python3
+-   repo: local
+    hooks:
+    -   id: no-resource-defaults
+        language: pcre
+        name: No resource defaults are used (see https://github.com/ocf/puppet/pull/58)
+        entry: ^\s*[A-Z][A-Za-z0-9:]+\s*{
+        types: [puppet]
+        exclude: ^manifests/

--- a/modules/ocf_docker/manifests/init.pp
+++ b/modules/ocf_docker/manifests/init.pp
@@ -12,33 +12,6 @@ class ocf_docker {
     members => ['127.0.0.1:5000'];
   }
 
-  Nginx::Resource::Vhost {
-    listen_port => 443,
-
-    ssl         => true,
-    ssl_cert    => "/etc/ssl/private/${::fqdn}.bundle",
-    ssl_key     => "/etc/ssl/private/${::fqdn}.key",
-    ssl_dhparam => '/etc/ssl/dhparam.pem',
-
-    add_header  => {
-      'Strict-Transport-Security' => 'max-age=31536000',
-    },
-
-    proxy            => 'http://docker-registry',
-    proxy_set_header => [
-      'X-Forwarded-Proto $scheme',
-      'X-Forwarded-For $proxy_add_x_forwarded_for',
-      'Host $http_host'
-    ],
-
-    vhost_cfg_append => {
-      # Enable large uploads/downloads
-      # https://docs.docker.com/registry/recipes/nginx/
-      'chunked_transfer_encoding' => 'on',
-      'client_max_body_size'      => 0,
-    },
-  }
-
   # Docker registries currently must be entirely unauthenticated (including
   # write access), or entirely authenticated (including read access).
   #
@@ -51,6 +24,32 @@ class ocf_docker {
   # Jenkins should push to docker-push.ocf and others should pull from
   # docker.ocf.
   nginx::resource::vhost {
+    default:
+      listen_port => 443,
+
+      ssl         => true,
+      ssl_cert    => "/etc/ssl/private/${::fqdn}.bundle",
+      ssl_key     => "/etc/ssl/private/${::fqdn}.key",
+      ssl_dhparam => '/etc/ssl/dhparam.pem',
+
+      add_header  => {
+        'Strict-Transport-Security' => 'max-age=31536000',
+      },
+
+      proxy            => 'http://docker-registry',
+      proxy_set_header => [
+        'X-Forwarded-Proto $scheme',
+        'X-Forwarded-For $proxy_add_x_forwarded_for',
+        'Host $http_host'
+      ],
+
+      vhost_cfg_append => {
+        # Enable large uploads/downloads
+        # https://docs.docker.com/registry/recipes/nginx/
+        'chunked_transfer_encoding' => 'on',
+        'client_max_body_size'      => 0,
+      };
+
     'docker-ro':
       server_name    => ['docker.ocf.berkeley.edu', 'docker', $::hostname, $::fqdn],
 

--- a/modules/ocf_mesos/manifests/master/webui.pp
+++ b/modules/ocf_mesos/manifests/master/webui.pp
@@ -33,19 +33,18 @@ class ocf_mesos::master::webui(
       members => ['localhost:8080'];
   }
 
-  Nginx::Resource::Vhost {
-    ssl_cert    => "/etc/ssl/private/${::fqdn}.bundle",
-    ssl_key     => "/etc/ssl/private/${::fqdn}.key",
-    ssl_dhparam => '/etc/ssl/dhparam.pem',
-    add_header  => {
-      'Strict-Transport-Security' => 'max-age=31536000',
-    },
-  }
-
   $mesos_auth_header = base64('encode', "ocf:${mesos_http_password}", 'strict')
   $marathon_auth_header = base64('encode', "marathon:${marathon_http_password}", 'strict')
 
   nginx::resource::vhost {
+    default:
+      ssl_cert    => "/etc/ssl/private/${::fqdn}.bundle",
+      ssl_key     => "/etc/ssl/private/${::fqdn}.key",
+      ssl_dhparam => '/etc/ssl/dhparam.pem',
+      add_header  => {
+        'Strict-Transport-Security' => 'max-age=31536000',
+      };
+
     # mesos
     'mesos':
       server_name => [$mesos_fqdn],

--- a/modules/ocf_www/manifests/site/vhost.pp
+++ b/modules/ocf_www/manifests/site/vhost.pp
@@ -1,7 +1,6 @@
 # A single virtual host.
 define ocf_www::site::vhost(Hash $vhost) {
-  # Common config for all <VirtualHost> blocks for this vhost.
-  Apache::Vhost {
+  $vhost_common = {
     vhost_name      => '*',
     serveradmin     => "${vhost[username]}@ocf.berkeley.edu",
     docroot         => $vhost[full_docroot],
@@ -34,6 +33,7 @@ define ocf_www::site::vhost(Hash $vhost) {
   }
 
   apache::vhost { "vhost-${vhost[domain]}":
+    *                 => $vhost_common,
     servername        => $vhost[domain],
 
     ssl               => $vhost[use_ssl],
@@ -96,6 +96,7 @@ define ocf_www::site::vhost(Hash $vhost) {
 
   unless empty($vhost[http_aliases]) {
     apache::vhost { "vhost-${vhost[domain]}-redirect":
+      *               => $vhost_common,
       servername      => "${vhost[domain]}-redirect",
       serveraliases   => $vhost[http_aliases],
 


### PR DESCRIPTION
@jvperrin removed most of these in a5f23f88e34ddbc49ce8ec9251653daa5bdba3f6, this ensures we don't regress.

Here is `make test` before Jason's change:

```
ckuehl@lightning:/opt/puppet/env/ckuehl$ make test
pre-commit run --all-files
Validate Puppet manifests............................................................Passed
Validate ERB templates...............................................................Passed
puppet-lint..........................................................................Passed
autopep8 wrapper.....................................................................Passed
Flake8...............................................................................Passed
Check for added large files..........................................................Passed
Check docstring is first.............................................................Passed
Check JSON......................................................(no files to check) Skipped
Check for merge conflicts............................................................Passed
Check Xml............................................................................Passed
Check Yaml...........................................................................Passed
Debug Statements (Python)............................................................Passed
Fix double quoted strings............................................................Passed
Detect Private Key...................................................................Passed
Fix End of Files.....................................................................Passed
Trim Trailing Whitespace.............................................................Passed
Reorder python imports...............................................................Passed
No resource defaults are used (see https://github.com/ocf/puppet/pull/58)............Failed
hookid: no-resource-defaults

modules/ocf_printhost/manifests/cups.pp:7:  File {
modules/ocf_mirrors/manifests/ftpsync.pp:19:  File {
modules/ocf_csgo/manifests/init.pp:11:  File {
modules/ocf_admin/manifests/create/app.pp:32:  File {
modules/ocf_backups/manifests/rsnapshot.pp:33:  Cron {
modules/ocf_stats/manifests/labstats.pp:14:  File {
modules/ocf_www/manifests/site/vhost.pp:4:  Apache::Vhost {
modules/ocf_mesos/manifests/master/webui.pp:36:  Nginx::Resource::Vhost {
modules/ocf_mirrors/manifests/finnix.pp:2:  File {
modules/ocf_ssl/manifests/init.pp:7:  File {
modules/ocf/manifests/autologout.pp:7:  File { mode => '0755' }
modules/ocf/manifests/munin/plugin.pp:14:  File {
modules/ocf_docker/manifests/init.pp:15:  Nginx::Resource::Vhost {
modules/ocf_irc/manifests/services.pp:13:  File {
modules/ocf_apt/manifests/init.pp:13:  File {
modules/ocf_irc/manifests/ircd.pp:12:  File {
modules/ocf_mesos/manifests/master/zookeeper.pp:4:  File {

Makefile:6: recipe for target 'test' failed
make: *** [test] Error 1
```

...and here it is after:

```
ckuehl@lightning:/opt/puppet/env/ckuehl$ make test
pre-commit run --all-files
Validate Puppet manifests............................................................Passed
Validate ERB templates...............................................................Passed
puppet-lint..........................................................................Passed
autopep8 wrapper.....................................................................Passed
Flake8...............................................................................Passed
Check for added large files..........................................................Passed
Check docstring is first.............................................................Passed
Check JSON......................................................(no files to check) Skipped
Check for merge conflicts............................................................Passed
Check Xml............................................................................Passed
Check Yaml...........................................................................Passed
Debug Statements (Python)............................................................Passed
Fix double quoted strings............................................................Passed
Detect Private Key...................................................................Passed
Fix End of Files.....................................................................Passed
Trim Trailing Whitespace.............................................................Passed
Reorder python imports...............................................................Passed
No resource defaults are used (see https://github.com/ocf/puppet/pull/58)............Failed
hookid: no-resource-defaults

modules/ocf_www/manifests/site/vhost.pp:4:  Apache::Vhost {
modules/ocf_mesos/manifests/master/webui.pp:36:  Nginx::Resource::Vhost {
modules/ocf_docker/manifests/init.pp:15:  Nginx::Resource::Vhost {

Makefile:6: recipe for target 'test' failed
make: *** [test] Error 1
```