### PR TITLE
Add xclip to desktops

### DIFF
--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -27,7 +27,7 @@ class ocf_desktop::packages {
     # performance improvements
     ['preload', 'readahead-fedora']:;
     # Xorg
-    ['xserver-xorg', 'xscreensaver','xclip']:;
+    ['xserver-xorg', 'xscreensaver', 'xclip']:;
     # FUSE
     ['fuse', 'exfat-fuse']:
   }

--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -27,7 +27,7 @@ class ocf_desktop::packages {
     # performance improvements
     ['preload', 'readahead-fedora']:;
     # Xorg
-    ['xserver-xorg', 'xscreensaver']:;
+    ['xserver-xorg', 'xscreensaver','xclip']:;
     # FUSE
     ['fuse', 'exfat-fuse']:
   }


### PR DESCRIPTION
Added `xclip` to the xorg section. 

An [SO answer](http://stackoverflow.com/a/15971506) suggests this one might be a little more featureful, and that the extra dependency (libxmu6) over `xsel` is already used by `xterm` (confirmed) and other x-* applications.