### PR TITLE
Always set HSTS header

### DIFF
--- a/modules/ocf_rt/manifests/apache.pp
+++ b/modules/ocf_rt/manifests/apache.pp
@@ -32,7 +32,7 @@ class ocf_rt::apache {
     ssl_cert   => "/etc/ssl/private/${::fqdn}.crt",
     ssl_chain  => '/etc/ssl/certs/incommon-intermediate.crt',
 
-    headers    => 'set Strict-Transport-Security "max-age=31536000"',
+    headers    => 'always set Strict-Transport-Security "max-age=31536000"',
 
     rewrites => [{
       rewrite_rule => '^/t/(\d+) /Ticket/Display.html?id=$1 [R,L]'

--- a/modules/ocf_stats/manifests/munin.pp
+++ b/modules/ocf_stats/manifests/munin.pp
@@ -48,7 +48,7 @@ class ocf_stats::munin {
       ssl_cert      => "/etc/ssl/private/${::fqdn}.crt",
       ssl_chain     => '/etc/ssl/certs/incommon-intermediate.crt',
 
-      headers       => ['set Strict-Transport-Security max-age=31536000'],
+      headers       => ['always set Strict-Transport-Security max-age=31536000'],
 
       rewrites => [
         {

--- a/modules/ocf_www/manifests/site/ocfweb_redirects.pp
+++ b/modules/ocf_www/manifests/site/ocfweb_redirects.pp
@@ -25,7 +25,7 @@ class ocf_www::site::ocfweb_redirects {
       {rewrite_rule => '^/request-vhost(/.*)?$ https://www.ocf.berkeley.edu/account/vhost/ [R=301,L]'},
       {rewrite_rule => '^.*$ https://www.ocf.berkeley.edu/'},
     ],
-    headers       => ['set Strict-Transport-Security max-age=31536000'],
+    headers       => ['always set Strict-Transport-Security max-age=31536000'],
   }
 
   apache::vhost { 'accounts-http-redirect':
@@ -62,7 +62,7 @@ class ocf_www::site::ocfweb_redirects {
     rewrites      => [
       {rewrite_rule => '^/(.*)$ https://www.ocf.berkeley.edu/docs/$1 [R=301]'},
     ],
-    headers       => ['set Strict-Transport-Security max-age=31536000'],
+    headers       => ['always set Strict-Transport-Security max-age=31536000'],
   }
 
   apache::vhost { 'wiki-http-redirect':
@@ -104,7 +104,7 @@ class ocf_www::site::ocfweb_redirects {
       {rewrite_rule => '^/lab.html$ https://www.ocf.berkeley.edu/about/lab/open-source [R=301,L]'},
       {rewrite_rule => '^.*$ https://www.ocf.berkeley.edu/about/staff [R=301]'},
     ],
-    headers       => ['set Strict-Transport-Security max-age=31536000'],
+    headers       => ['always set Strict-Transport-Security max-age=31536000'],
   }
 
   apache::vhost { 'hello-http-redirect':

--- a/modules/ocf_www/manifests/site/shorturl.pp
+++ b/modules/ocf_www/manifests/site/shorturl.pp
@@ -73,7 +73,7 @@ class ocf_www::site::shorturl {
       {rewrite_rule => '^/~?([a-z]{3,16}(?:/.*)?)$ https://www.ocf.berkeley.edu/~$1 [R]'},
     ],
 
-    headers       => ['set Strict-Transport-Security max-age=31536000'],
+    headers       => ['always set Strict-Transport-Security max-age=31536000'],
   }
 
   # canonical redirects

--- a/modules/ocf_www/manifests/site/vhost.pp
+++ b/modules/ocf_www/manifests/site/vhost.pp
@@ -13,7 +13,7 @@ define ocf_www::site::vhost(Hash $vhost) {
 
   # The <VirtualHost> that actually serves their website.
   $headers = $vhost[use_hsts] ? {
-    true    => ["set Strict-Transport-Security 'max-age=31536000'"],
+    true    => ["always set Strict-Transport-Security 'max-age=31536000'"],
     default => [],
   }
   $primary_port = $vhost[use_ssl] ? {

--- a/modules/ocf_www/manifests/site/www.pp
+++ b/modules/ocf_www/manifests/site/www.pp
@@ -35,7 +35,7 @@ class ocf_www::site::www {
     ssl_cert        => "/etc/ssl/private/${::fqdn}.crt",
     ssl_chain       => '/etc/ssl/certs/incommon-intermediate.crt',
 
-    headers         => ['set Strict-Transport-Security max-age=31536000'],
+    headers         => ['always set Strict-Transport-Security max-age=31536000'],
 
     rewrites        => [
       {


### PR DESCRIPTION
This fixes HSTS on Apache sites that only redirect, like ocf.io.

We should eventually do this on Nginx 1.7.5+ (jessie-backports, stretch).