### PR TITLE
Adds auth section with u2f libs (per arch wiki)

### DIFF
--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -12,6 +12,8 @@ class ocf_desktop::packages {
   package {
     # applications
     ['anacron', 'arandr', 'claws-mail', 'geany', 'filezilla', 'inkscape', 'mssh', 'numlockx', 'remmina', 'simple-scan', 'vlc', 'zenmap', 'gimp', 'gparted', 'evince-gtk', 'galculator', 'hexchat', 'atom', 'rstudio']:;
+    # auth
+    ['libu2f-host']:;
     # desktop
     ['desktop-base', 'desktop-file-utils', 'eog', 'xarchiver', 'xterm', 'lightdm', 'lightdm-gtk-greeter-ocf', 'accountsservice', 'redshift', 'xfce4-whiskermenu-plugin']:;
     # fonts

--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -13,7 +13,7 @@ class ocf_desktop::packages {
     # applications
     ['anacron', 'arandr', 'claws-mail', 'geany', 'filezilla', 'inkscape', 'mssh', 'numlockx', 'remmina', 'simple-scan', 'vlc', 'zenmap', 'gimp', 'gparted', 'evince-gtk', 'galculator', 'hexchat', 'atom', 'rstudio']:;
     # auth
-    ['libu2f-host']:;
+    ['libu2f-host0']:;
     # desktop
     ['desktop-base', 'desktop-file-utils', 'eog', 'xarchiver', 'xterm', 'lightdm', 'lightdm-gtk-greeter-ocf', 'accountsservice', 'redshift', 'xfce4-whiskermenu-plugin']:;
     # fonts


### PR DESCRIPTION
In order for the U2F functionality to work with Chromium you need to install the libu2f-host library. This provides the udev rules required to enable access to the Yubikey as a user. Yubikey is by default only accessible by root, and without these rules Chromium will give an error. [Enabling browser u2f](https://wiki.archlinux.org/index.php/yubikey#Enabling_U2F_in_the_browser).
