### PR TITLE
ocf_www: Move Apache DocumentRoot under /services

### DIFF
--- a/modules/ocf_www/manifests/site/www.pp
+++ b/modules/ocf_www/manifests/site/www.pp
@@ -28,7 +28,7 @@ class ocf_www::site::www {
     servername      => 'www.ocf.berkeley.edu',
     serveraliases   => ['dev-www.ocf.berkeley.edu'],
     port            => 443,
-    docroot         => '/var/www/html',
+    docroot         => '/services/http/users',
 
     ssl             => true,
     ssl_key         => "/etc/ssl/private/${::fqdn}.key",


### PR DESCRIPTION
Setting the default DocumentRoot to /services/http/users causes per-directory
PHP config files (.user.ini) to be inherited in subdirectories.

See http://php.net/manual/en/configuration.file.per-user.php.

Test this on your website at dev-death.ocf.berkeley.edu! I don't see any obvious reason this should break anything.