### PR TITLE
add 60s timeout for all print jobs

### DIFF
--- a/modules/ocf_printhost/templates/cups/cupsd.conf.erb
+++ b/modules/ocf_printhost/templates/cups/cupsd.conf.erb
@@ -39,6 +39,9 @@ HostNameLookups On
 ServerAlias *
 DefaultAuthType Basic
 
+# Kill jobs after a certain time (stuck)
+MaxJobTime 60
+
 <Location />
   # Allow shared printing and remote administration...
   Order allow,deny

--- a/modules/ocf_printhost/templates/cups/cupsd.conf.erb
+++ b/modules/ocf_printhost/templates/cups/cupsd.conf.erb
@@ -41,6 +41,7 @@ DefaultAuthType Basic
 
 # Kill jobs after a certain time (stuck)
 MaxJobTime 60
+ErrorPolicy abort-job
 
 <Location />
   # Allow shared printing and remote administration...


### PR DESCRIPTION
http://man7.org/linux/man-pages/man5/cupsd.conf.5.html

note that the default is 3 hours before killing a job...

We also have the option to limit the size of jobs submitted to the printer (see LimitRequestBody), but I think for now we should start with just killing jobs that are taking too long. We might be able to fix handling larger (~4MB) submitted jobs to the printer at a later time anyway.

Need to test somehow if possible.
