### PR TITLE
Make mdraid-cron not flaky (rt#4153)

### DIFF
--- a/modules/ocf/files/mdraid/mdraid-cron
+++ b/modules/ocf/files/mdraid/mdraid-cron
@@ -1,11 +1,21 @@
-#!/bin/bash -eu
+#!/bin/bash
+set -euo pipefail
+
+# this must be on the same filesystem for mv to be atomic
+tmp=$(mktemp -p /var/lib mdraid.XXXXXXXXXX)
+
 (
-    echo "====== Available arrays: ======"
+    echo '====== Available arrays: ======'
     mdadm --detail --scan
 
-    echo "====== Array information: ======"
-    mdadm --detail --scan | awk '{print $2}' | while read device; do
+    echo '====== Array information: ======'
+    mdadm --detail --scan |
+            awk '{print $2}' |
+            while read device; do
         echo "=== Details for device '$device' ==="
+
+        # Normalize the output a bit; some of these values change constantly,
+        # so we grep them out.
         mdadm --detail "$device" |
             grep -v 'Events : ' |
             grep -v 'Update Time : ' |
@@ -17,11 +27,10 @@
             sed -E 's/State : (resyncing|checking)/State : /' |
             sed -E 's/State : \(DELAYED\)/State : /'
     done
-) \
-> /var/lib/mdraid.new
+) > "$tmp"
 
 if [ -f /var/lib/mdraid ]; then
-    diff -U 1000 /var/lib/mdraid /var/lib/mdraid.new || true
+    diff -U 1000 /var/lib/mdraid "$tmp" || true
 fi
 
-mv /var/lib/mdraid.new /var/lib/mdraid
+mv "$tmp" /var/lib/mdraid


### PR DESCRIPTION
Two jobs running at the same time right now often leads to cron spam:

```
diff: /var/lib/mdraid.new: No such file or directory
mv: cannot stat ‘/var/lib/mdraid.new’: No such file or directory
```

I suspect this happens often during suspends or similar, but might also happen if one gets blocked on IO for a while?

You can easily test with `for _ in {1..100}; do /usr/local/sbin/mdraid-cron &; done` while root (`sudo -i` first).