### PR TITLE
ocf_mail: tag mail sent by vhost users with group uid (rt#5376)

### DIFF
--- a/modules/ocf_mail/files/spam/logging/log-mail
+++ b/modules/ocf_mail/files/spam/logging/log-mail
@@ -9,26 +9,53 @@ import email
 import email.utils
 import io
 import json
+import pwd
 import re
 import sys
 from datetime import datetime
 
+from ocflib.vhost.mail import get_mail_vhosts
+
+
 LOG_FILE = '/var/log/ocfmail.log'
 
 
-def parse_received(header):
+def parse_received_for_uid(header):
     """Attempt to parse relay host and sender uid from Received header.
 
     This header can be faked by the message sender if they don't send via local
     MTA to blame other users, so we rely on this being prevented via firewall
-    rules."""
-
+    rules.
+    """
     match = re.match(
         'by ([a-zA-Z\\-\\.]*) \\(Postfix, from userid ([0-9]*)\\)',
-        header)
-
+        header,
+    )
     if match:
         return {'relay': match.group(1), 'uid': match.group(2)}
+
+
+def parse_received_for_auth(header):
+    """Attempt to parse sender UID for authenticated SMTP mails.
+
+    These come from student groups with mail virtual hosting sending via SMTP.
+    We look up which group owns that domain and mark this mail as belonging to
+    them in our logs.
+    """
+    match = re.search(
+        r'\n\t\(Authenticated sender: [^@]+@([^\)]+)\)\n',
+        header,
+        re.MULTILINE,
+    )
+    if match:
+        domain = match.group(1).lower()
+        user, = [
+            vhost.user
+            for vhost in get_mail_vhosts()
+            if vhost.domain == domain
+        ]
+        # TODO: uids should be ints...
+        return {'uid': str(pwd.getpwnam(user).pw_uid)}
 
 
 def clean_addr(addr):
@@ -54,7 +81,13 @@ if __name__ == '__main__':
     parsed = {}
     received = message.get_all('Received')
     if received:
-        parsed = parse_received(received[-1]) or {}
+        parsed = (
+            # received header with uid comes from the first relay
+            parse_received_for_uid(received[-1]) or
+            # received header with smtp username comes from the last (*this* smtp server)
+            parse_received_for_auth(received[0]) or
+            {}
+        )
 
     info = {
         'relay': parsed.get('relay'),
@@ -62,7 +95,7 @@ if __name__ == '__main__':
         'from': clean_addr(message['From']),
         'to': clean_addr(message['To']),
         'subject': message['Subject'],
-        'date': datetime.now().isoformat()
+        'date': datetime.now().isoformat(),
     }
 
     with open(LOG_FILE, 'a') as f:


### PR DESCRIPTION
@jvperrin @matthew-mcallister @dkess thoughts?

Context: we keep a log of mail messages that we send so that we can easily spot trouble users (usually hijacked users sending thousands of mails per day). Each time a message is sent, we call this script (`log-mail`), which parses some metadata from the headers and then adds a line to the end of the file `/var/log/ocfmail.log`.

We then have a cronjob that runs each morning which parses that file and looks for problems (sending too much mail, sending mail claiming to be from other users, etc).

Right now for mail sent by vhost users using SMTP, we don't tag the messages with any `uid`, so we wouldn't notice if a group was sending spam mail this way.