### PR TITLE
Automatically clean docker cruft

### DIFF
--- a/modules/ocf/manifests/packages/docker.pp
+++ b/modules/ocf/manifests/packages/docker.pp
@@ -45,7 +45,9 @@ class ocf::packages::docker($admin_group = 'docker') {
       minute  => 3;
 
     'clean-docker-images':
-      command => 'docker images -q --filter dangling=true | chronic xargs -r docker rmi',
+      # Chronic doesn't work well here because docker rmi likes to raise errors
+      # about images still linked to containers
+      command => 'docker images -q --filter dangling=true | xargs -r docker rmi > /dev/null 2>&1',
       hour    => 1,
       minute  => 17;
 

--- a/modules/ocf/manifests/packages/docker.pp
+++ b/modules/ocf/manifests/packages/docker.pp
@@ -40,7 +40,7 @@ class ocf::packages::docker($admin_group = 'docker') {
 
   cron {
     'clean-old-docker-containers':
-      command => "docker ps -a --filter status=exited | grep -E '(weeks?|months?|years?) ago' | awk '{print \$1}' | chronic xargs -r docker rm",
+      command => "docker ps -a --filter status=exited | grep -E 'Exited \\([0-9]+\\) [0-9]+ (weeks?|months?|years?) ago' | awk '{print \$1}' | chronic xargs -r docker rm",
       hour    => 1,
       minute  => 3;
 


### PR DESCRIPTION
This sets up cronjobs to remove containers older than 2 weeks, dangling images, and dangling volumes.