### PR TITLE
U2F

### DIFF
--- a/modules/ocf_desktop/files/70-u2f-fido.rules
+++ b/modules/ocf_desktop/files/70-u2f-fido.rules
@@ -1,0 +1,14 @@
+# From yubikey:
+# https://www.yubico.com/faq/enable-u2f-linux/
+# https://github.com/Yubico/libu2f-host/blob/master/70-u2f.rules
+
+# this udev file should be used with udev 188 and newer
+ACTION!="add|change", GOTO="u2f_end"
+
+# HS ePass FIDO
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="096e", ATTRS{idProduct}=="0850", TAG+="uaccess"
+
+# FIDO U2F Security Key -- for mcint, ?
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="4176", ATTRS{idProduct}=="288", TAG+="uaccess"
+
+LABEL="u2f_end"

--- a/modules/ocf_desktop/manifests/init.pp
+++ b/modules/ocf_desktop/manifests/init.pp
@@ -16,6 +16,7 @@ class ocf_desktop ($staff = false) {
   include ocf_desktop::steam
   include ocf_desktop::suspend
   include ocf_desktop::tmpfs
+  include ocf_desktop::udev
   include ocf_desktop::wireshark
 
   class { 'ocf_desktop::xsession': staff => $staff }

--- a/modules/ocf_desktop/manifests/udev.pp
+++ b/modules/ocf_desktop/manifests/udev.pp
@@ -1,0 +1,8 @@
+class ocf_desktop::udev {
+  package { ['u2f-host']:; }
+
+  file { '/etc/udev/rules.d/70-u2f-fido.rules':
+    source    => 'puppet:///modules/ocf_desktop/70-u2f-fido.rules',
+    mode      => '0644',
+  }
+}


### PR DESCRIPTION
This diff enables u2f usage on desktops, per https://www.yubico.com/faq/enable-u2f-linux/

It is based on rules here, which is ahead of (but included in) the u2f-host deb package
https://github.com/Yubico/libu2f-host/blob/master/70-u2f.rules