### PR TITLE
ocf_desktop: show staff some lab close warnings

### DIFF
--- a/modules/ocf_desktop/files/xsession/lab-close-notify
+++ b/modules/ocf_desktop/files/xsession/lab-close-notify
@@ -8,17 +8,17 @@ from ocflib.account.utils import is_staff
 from ocflib.lab.hours import Day
 from ocflib.misc.whoami import current_user
 
-# 0 minutes, 2 minute, 5 minutes, 10 minutes, 15 minutes
-WARNING_DURATIONS = [0, 120, 300, 600, 900]
 
-
-def notify_user(seconds_left):
+def notify_user(seconds_left, staff):
     title = 'Lab closure'
     if seconds_left != 0:
         msg = 'Lab closing in {0:g} minutes'.format(seconds_left / 60)
         icon = 'appointment-soon'
     else:
-        msg = 'The lab is now closed. Please log out and leave right away.'
+        if staff:
+            msg = 'The lab is now closed.'
+        else:
+            msg = 'The lab is now closed. Please log out and leave right away.'
         icon = 'appointment-missed'
 
     notif = Notify.Notification.new(title, msg, icon)
@@ -26,8 +26,13 @@ def notify_user(seconds_left):
 
 
 def main():
-    if is_staff(current_user()):
-        return
+    staff = is_staff(current_user())
+    if staff:
+        # 0 minutes, 15 minutes
+        warning_durations = [0, 900]
+    else:
+        # 0 minutes, 2 minute, 5 minutes, 10 minutes, 15 minutes
+        warning_durations = [0, 120, 300, 600, 900]
 
     today = datetime.datetime.today()
     closing_times = [
@@ -38,9 +43,9 @@ def main():
     s = sched.scheduler(time.time)
 
     for t in closing_times:
-        for d in WARNING_DURATIONS:
+        for d in warning_durations:
             if t - d > today.timestamp():
-                s.enterabs(t - d, 0, notify_user, argument=(d,))
+                s.enterabs(t - d, 0, notify_user, argument=(d, staff))
 
     Notify.init('OCF')
     s.run()


### PR DESCRIPTION
This gives staff some warning that the lab is going to be closing soon, but doesn't spam messages designed to shoo visitors out.