### PR TITLE
Refactor ocf_ssl to allow providing additional bundles

### DIFF
--- a/hieradata/nodes/fireball.yaml
+++ b/hieradata/nodes/fireball.yaml
@@ -1,6 +1,6 @@
 classes:
     - ocf::packages::docker
     - ocf_ocfweb::dev_config
-    - ocf_ssl
+    - ocf_ssl::default_bundle
 
 owner: jvperrin

--- a/hieradata/nodes/meltdown.yaml
+++ b/hieradata/nodes/meltdown.yaml
@@ -1,4 +1,4 @@
 classes:
-    - ocf_ssl
+    - ocf_ssl::default_bundle
 
 owner: mattmcal

--- a/hieradata/nodes/nuke.yaml
+++ b/hieradata/nodes/nuke.yaml
@@ -1,4 +1,4 @@
 classes:
-    - ocf_ssl
+    - ocf_ssl::default_bundle
 
 owner: asai

--- a/hieradata/nodes/raptors.yaml
+++ b/hieradata/nodes/raptors.yaml
@@ -1,4 +1,4 @@
 classes:
-    - ocf_ssl
+    - ocf_ssl::default_bundle
 
 owner: ckuehl

--- a/hieradata/nodes/snowstorm.yaml
+++ b/hieradata/nodes/snowstorm.yaml
@@ -1,4 +1,4 @@
 classes:
-    - ocf_ssl
+    - ocf_ssl::default_bundle
 
 owner: tianrui

--- a/hieradata/nodes/vampires.yaml
+++ b/hieradata/nodes/vampires.yaml
@@ -1,4 +1,4 @@
 classes:
-    - ocf_ssl
+    - ocf_ssl::default_bundle
 
 owner: slobo

--- a/modules/ocf_apphost/manifests/ssl.pp
+++ b/modules/ocf_apphost/manifests/ssl.pp
@@ -13,7 +13,7 @@
 # ...and not have to do the manual concatenation.
 
 class ocf_apphost::ssl {
-  include ocf_ssl
+  include ocf_ssl::default_bundle
 
   file {
     '/etc/ssl/apphost':

--- a/modules/ocf_apt/manifests/init.pp
+++ b/modules/ocf_apt/manifests/init.pp
@@ -1,5 +1,5 @@
 class ocf_apt {
-  include ocf_ssl
+  include ocf_ssl::default_bundle
 
   user { 'ocfapt':
     comment => 'OCF Apt',

--- a/modules/ocf_docker/manifests/init.pp
+++ b/modules/ocf_docker/manifests/init.pp
@@ -1,6 +1,6 @@
 class ocf_docker {
   include ocf::packages::docker
-  require ocf_ssl
+  require ocf_ssl::default_bundle
 
   class { 'nginx':
     manage_repo => false,

--- a/modules/ocf_irc/manifests/init.pp
+++ b/modules/ocf_irc/manifests/init.pp
@@ -1,5 +1,5 @@
 class ocf_irc {
-  include ocf_ssl
+  include ocf_ssl::default_bundle
   include ocf_irc::ircd
   include ocf_irc::services
   include ocf_irc::nodejs::slack

--- a/modules/ocf_jenkins/manifests/init.pp
+++ b/modules/ocf_jenkins/manifests/init.pp
@@ -2,7 +2,7 @@ class ocf_jenkins {
   include ocf::extrapackages
   include ocf::packages::docker
   include ocf::tmpfs
-  include ocf_ssl
+  include ocf_ssl::default_bundle
 
   class { 'ocf_ocfweb::dev_config':
     group => 'jenkins-slave',

--- a/modules/ocf_ldap/manifests/init.pp
+++ b/modules/ocf_ldap/manifests/init.pp
@@ -1,5 +1,5 @@
 class ocf_ldap {
-  include ocf_ssl
+  include ocf_ssl::default_bundle
 
   package { 'slapd':; }
   service { 'slapd':

--- a/modules/ocf_mail/manifests/init.pp
+++ b/modules/ocf_mail/manifests/init.pp
@@ -1,5 +1,5 @@
 class ocf_mail {
-  include ocf_ssl
+  include ocf_ssl::default_bundle
 
   include ocf_mail::spam
   include ocf_mail::site_ocf

--- a/modules/ocf_mesos/manifests/master/webui.pp
+++ b/modules/ocf_mesos/manifests/master/webui.pp
@@ -4,7 +4,7 @@ class ocf_mesos::master::webui(
     $marathon_fqdn,
     $marathon_http_password,
 ) {
-  require ocf_ssl
+  require ocf_ssl::default_bundle
 
   # We limit access to ocfroot only via PAM.
   file {

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -1,5 +1,5 @@
 class ocf_mirrors {
-  include ocf_ssl
+  include ocf_ssl::default_bundle
   require ocf::packages::rsync
 
   include ocf_mirrors::ftp

--- a/modules/ocf_printhost/manifests/init.pp
+++ b/modules/ocf_printhost/manifests/init.pp
@@ -1,6 +1,6 @@
 class ocf_printhost {
   include ocf::tmpfs
-  include ocf_ssl
+  include ocf_ssl::default_bundle
 
   include ocf_printhost::cups
   include ocf_printhost::enforcer

--- a/modules/ocf_ssh/manifests/init.pp
+++ b/modules/ocf_ssh/manifests/init.pp
@@ -5,7 +5,7 @@ class ocf_ssh {
   include ocf::limits
   include ocf::packages::cups
   include ocf::packages::mysql
-  include ocf_ssl
+  include ocf_ssl::default_bundle
 
   class { 'ocf::nfs':
     cron   => true,

--- a/modules/ocf_ssl/manifests/bundle.pp
+++ b/modules/ocf_ssl/manifests/bundle.pp
@@ -1,0 +1,47 @@
+define ocf_ssl::bundle(
+  $intermediate_source = 'puppet:///modules/ocf_ssl/incommon-intermediate.crt',
+  $cert_source = "puppet:///private/ssl/${title}.crt",
+  $key_source = "puppet:///private/ssl/${title}.key",
+) {
+  require ocf_ssl
+
+  file {
+    default:
+      group   => ssl-cert;
+
+    "/etc/ssl/private/${title}.key":
+      source  => $key_source,
+      mode    => '0640';
+
+    "/etc/ssl/private/${title}.crt":
+      source  => $cert_source,
+      mode    => '0644';
+
+    "/etc/ssl/private/${title}.intermediate":
+      source  => $intermediate_source,
+      mode    => '0644';
+  }
+
+  # ssl bundle (cert + intermediates)
+  $bundle = "/etc/ssl/private/${title}.bundle"
+
+  concat { $bundle:
+    owner => root,
+    group => ssl-cert,
+    mode  => '0644',
+
+    ensure_newline => true,
+  }
+
+  concat::fragment {
+    "${title}-cert":
+      target => $bundle,
+      source => $cert_source,
+      order  => '0';
+
+    "${title}-intermediate":
+      target => $bundle,
+      source => $intermediate_source,
+      order  => '1';
+  }
+}

--- a/modules/ocf_ssl/manifests/default_bundle.pp
+++ b/modules/ocf_ssl/manifests/default_bundle.pp
@@ -1,0 +1,8 @@
+# Provides the key, certificate, and InCommon CA certificate bundle at
+# /etc/ssl/private/$cert_name.{key,crt,bundle}
+#
+# Provides the InCommon intermediate chain at
+# /etc/ssl/certs/incommon-intermediate.crt
+class ocf_ssl::default_bundle {
+  ocf_ssl::bundle { $::fqdn:; }
+}

--- a/modules/ocf_ssl/manifests/default_bundle.pp
+++ b/modules/ocf_ssl/manifests/default_bundle.pp
@@ -1,8 +1,5 @@
 # Provides the key, certificate, and InCommon CA certificate bundle at
-# /etc/ssl/private/$cert_name.{key,crt,bundle}
-#
-# Provides the InCommon intermediate chain at
-# /etc/ssl/certs/incommon-intermediate.crt
+# /etc/ssl/private/$cert_name.{key,crt,bundle,intermediate}
 class ocf_ssl::default_bundle {
   ocf_ssl::bundle { $::fqdn:; }
 }

--- a/modules/ocf_ssl/manifests/init.pp
+++ b/modules/ocf_ssl/manifests/init.pp
@@ -1,16 +1,13 @@
-# Provides the key, certificate, and InCommon CA certificate bundle at
-# /etc/ssl/private/$cert_name.{key,crt,bundle}
-#
-# Provides the InCommon intermediate chain at
-# /etc/ssl/certs/incommon-intermediate.crt
-class ocf_ssl($cert_name = $::fqdn) {
+# TODO: rename this to ocf::ssl or something
+
+# Provide the common certificates needed at the OCF.
+# To build and deploy private keys, use the `ocf_ssl::bundle` type.
+# (Or include `ocf_ssl::default_bundle` if you just want the default FQDN-based one.)
+class ocf_ssl {
   package { 'ssl-cert':; }
 
   file {
     default:
-      owner   => root,
-      group   => ssl-cert,
-
       # the ssl-cert package creates the ssl-cert group
       require => Package['ssl-cert'];
 
@@ -27,37 +24,5 @@ class ocf_ssl($cert_name = $::fqdn) {
     '/etc/ssl/dhparam.pem':
       source  => 'puppet:///modules/ocf_ssl/dhparam.pem',
       mode    => '0444';
-
-
-    # private ssl
-    "/etc/ssl/private/${cert_name}.key":
-      source  => "puppet:///private/ssl/${cert_name}.key",
-      mode    => '0640';
-    "/etc/ssl/private/${cert_name}.crt":
-      source  => "puppet:///private/ssl/${cert_name}.crt",
-      mode    => '0644';
-  }
-
-  # generate ssl bundle
-  $bundle = "/etc/ssl/private/${cert_name}.bundle"
-
-  concat { $bundle:
-    owner => root,
-    group => ssl-cert,
-    mode  => '0644',
-
-    ensure_newline => true;
-  }
-
-  concat::fragment {
-    "${cert_name}-cert":
-      target => $bundle,
-      source => "puppet:///private/ssl/${cert_name}.crt",
-      order  => '0';
-
-    "${cert_name}-intermediate":
-      target => $bundle,
-      source => 'puppet:///modules/ocf_ssl/incommon-intermediate.crt',
-      order  => '1';
   }
 }

--- a/modules/ocf_stats/manifests/init.pp
+++ b/modules/ocf_stats/manifests/init.pp
@@ -1,5 +1,5 @@
 class ocf_stats {
-  include ocf_ssl
+  include ocf_ssl::default_bundle
 
   class { '::apache':
     default_vhost => false,

--- a/modules/ocf_stats/manifests/munin.pp
+++ b/modules/ocf_stats/manifests/munin.pp
@@ -1,6 +1,6 @@
 # munin master config
 class ocf_stats::munin {
-  include ocf_ssl
+  include ocf_ssl::default_bundle
 
   package {
     ['munin', 'nmap']:;

--- a/modules/ocf_www/manifests/init.pp
+++ b/modules/ocf_www/manifests/init.pp
@@ -16,7 +16,7 @@ class ocf_www {
   include ocf::limits
   include ocf::packages::mysql
   include ocf::tmpfs
-  include ocf_ssl
+  include ocf_ssl::default_bundle
 
   class { 'ocf::nfs':
     cron   => false,


### PR DESCRIPTION
Sometimes we have the need to provide provide additional SSL certs/keys besides the main one based on the vhost. (In the past we did this for virtual hosts; another reason now is so that we can use a wildcard cert, since InCommon doesn't seem to have an option to use both a wildcard and other SANs on the same cert.)

This lets us easily define additional bundles, e.g.:

```puppet
ocf_ssl::bundle { 'wildcard.agent.mesos.ocf.berkeley.edu':; }
```

The default bundle is also provided this way now.