### PR TITLE
Add syslog server

### DIFF
--- a/hieradata/nodes/democracy.yaml
+++ b/hieradata/nodes/democracy.yaml
@@ -1,0 +1,2 @@
+classes:
+    - ocf_syslog

--- a/modules/ocf_syslog/files/logrotate
+++ b/modules/ocf_syslog/files/logrotate
@@ -1,0 +1,6 @@
+/var/log/remote/* {
+	daily
+	missingok
+	rotate 14
+	compress
+}

--- a/modules/ocf_syslog/files/ocf.conf
+++ b/modules/ocf_syslog/files/ocf.conf
@@ -1,0 +1,24 @@
+# enable receiving remote logs over TCP
+module(load="imtcp")
+input(type="imtcp" port="514" ruleset="ocf-remote")
+
+# template for remote log lines
+template(name="ocf-remote" type="list") {
+    property(name="timegenerated" dateFormat="rfc3339")
+    constant(value=" ")
+    property(name="hostname")
+    constant(value=":  ")
+    property(name="msg")
+    constant(value="\n")
+}
+
+# template for remote log filenames
+template(name="ocf-remote-file" type="list") {
+    constant(value="/var/log/remote/")
+    property(name="programname" SecurePath="replace")
+}
+
+# rules for storing the logs
+ruleset(name="ocf-remote") {
+    action(type="omfile" dynaFile="ocf-remote-file" template="ocf-remote")
+}

--- a/modules/ocf_syslog/manifests/init.pp
+++ b/modules/ocf_syslog/manifests/init.pp
@@ -19,5 +19,8 @@ class ocf_syslog {
       source  => 'puppet:///modules/ocf_syslog/ocf.conf',
       notify  => Service['rsyslog'],
       require => Ocf::Repackage['rsyslog'];
+
+    '/etc/logrotate.d/ocf-syslog':
+      source  => 'puppet:///modules/ocf_syslog/logrotate';
   }
 }

--- a/modules/ocf_syslog/manifests/init.pp
+++ b/modules/ocf_syslog/manifests/init.pp
@@ -1,0 +1,23 @@
+class ocf_syslog {
+  ocf::repackage { 'rsyslog':
+    # TCP logging is broken in jessie :\
+    backport_on => jessie,
+  }
+
+  service { 'rsyslog':
+    require => [
+      Ocf::Repackage['rsyslog'],
+      File['/etc/rsyslog.d/ocf.conf'],
+    ],
+  }
+
+  file {
+    '/var/log/remote':
+      ensure => directory;
+
+    '/etc/rsyslog.d/ocf.conf':
+      source  => 'puppet:///modules/ocf_syslog/ocf.conf',
+      notify  => Service['rsyslog'],
+      require => Ocf::Repackage['rsyslog'];
+  }
+}


### PR DESCRIPTION
The config file should be pretty easy to read. Basically, each log line coming in specifies a tag ("programname" is a variable for it which strips off some stuff we don't want, same thing).

We use that tag as the "stream" name.

The messages then get saved to `/var/log/remote/<stream>` on `democracy`, the new syslog server.

For now we're not using this to aggregate syslog from servers, just to get centralized logging for applications (especially ones running in Marathon).

Here's my script for writing to it: https://i.fluffy.cc/hm6XhQnJtCc4DbdR95kjdVnQBfsNb9WH.html

Need to figure out where to put that, but you can download and try it out if you'd like.