### PR TITLE
Fix issue with rotating log files

### DIFF
--- a/modules/ocf_syslog/files/logrotate
+++ b/modules/ocf_syslog/files/logrotate
@@ -4,7 +4,6 @@
     rotate 14
     compress
     delaycompress
-    create 0640 root ocfstaff
 
     sharedscripts
     postrotate

--- a/modules/ocf_syslog/files/logrotate
+++ b/modules/ocf_syslog/files/logrotate
@@ -1,9 +1,10 @@
-/var/log/remote/* {
-	daily
-	missingok
-	rotate 14
-	compress
+/var/log/remote/*.log {
+    daily
+    missingok
+    rotate 14
+    compress
     delaycompress
+    create 0640 root ocfstaff
 
     sharedscripts
     postrotate

--- a/modules/ocf_syslog/files/ocf.conf
+++ b/modules/ocf_syslog/files/ocf.conf
@@ -23,5 +23,5 @@ template(name="ocf-remote-file" type="list") {
 
 # rules for storing the logs
 ruleset(name="ocf-remote") {
-    action(type="omfile" dynaFile="ocf-remote-file" template="ocf-remote")
+    action(type="omfile" dynaFile="ocf-remote-file" template="ocf-remote" fileGroup="ocfstaff" fileCreateMode="0640")
 }

--- a/modules/ocf_syslog/files/ocf.conf
+++ b/modules/ocf_syslog/files/ocf.conf
@@ -18,6 +18,7 @@ template(name="ocf-remote-file" type="list") {
     # in jessie, syslogtag has a weird ":" appended, so we have to regex that out;
     # the regex bits can be removed when we're totally on stretch.
     property(name="syslogtag" regex.Expression="^[^:]+" regex.Type="ERE" regex.Match="0" SecurePath="replace")
+    constant(value=".log")
 }
 
 # rules for storing the logs


### PR DESCRIPTION
This fixes the [issue](https://munin.ocf.berkeley.edu/static/dynazoom.html?plugin_name=ocf.berkeley.edu%2Fdemocracy.ocf.berkeley.edu%2Fdf_inode&start_iso8601=2016-12-23T19%3A35%3A52-0700&stop_iso8601=2017-01-01T13%3A30%3A02-0700&start_epoch=1482546952.08&stop_epoch=1483302602.16&lower_limit=&upper_limit=&size_x=800&size_y=400&cgiurl_graph=%2Fmunin-cgi%2Fmunin-cgi-graph) with log rotation on democracy.

I also renamed the log files to end in `.log` and make the log files not world-readable but still readable to `ocfstaff` (slightly more secure, since before they were world-readable and could contain sensitive data).