### PR TITLE
Generalize systemd override

### DIFF
--- a/modules/ocf/manifests/systemd/override.pp
+++ b/modules/ocf/manifests/systemd/override.pp
@@ -21,4 +21,11 @@ define ocf::systemd::override(
     notify  => Exec['systemd-reload'],
     require => Package['systemd-sysv'],
   }
+
+  if $unit =~ /(.*)\.service$/ {
+    ensure_resource('service', $1)
+
+    File["/etc/systemd/system/${unit}.d/${title}.conf"] ~> Service[$1]
+    Exec['systemd-reload'] -> Service[$1]
+  }
 }

--- a/modules/ocf/manifests/systemd/override.pp
+++ b/modules/ocf/manifests/systemd/override.pp
@@ -7,21 +7,18 @@
 #     ExecStart=
 #     ExecStart=/path/to/my/thing
 define ocf::systemd::override(
-    $service,
+    $unit,
     $source = undef,
     $content = undef,
 ) {
-  ensure_resource('file', "/etc/systemd/system/${service}.service.d", {
+  ensure_resource('file', "/etc/systemd/system/${unit}.d", {
     ensure => directory,
   })
 
-  file { "/etc/systemd/system/${service}.service.d/${title}.conf":
-    source   => $source,
-    content  => $content,
-    notify   => [
-      Exec['systemd-reload'],
-      Service[$service],
-    ],
-    require  => Package['systemd-sysv'],
+  file { "/etc/systemd/system/${unit}.d/${title}.conf":
+    source  => $source,
+    content => $content,
+    notify  => Exec['systemd-reload'],
+    require => Package['systemd-sysv'],
   }
 }

--- a/modules/ocf_irc/manifests/ircd.pp
+++ b/modules/ocf_irc/manifests/ircd.pp
@@ -11,7 +11,6 @@ class ocf_irc::ircd {
     unit    => 'inspircd.service',
     content => "[Unit]\nBefore=anope.service\n",
     require => Package['inspircd', 'anope'],
-    notify  => Service['inspircd'],
   }
 
   $passwords = parsejson(file("/opt/puppet/shares/private/${::hostname}/ircd-passwords"))

--- a/modules/ocf_irc/manifests/ircd.pp
+++ b/modules/ocf_irc/manifests/ircd.pp
@@ -8,10 +8,10 @@ class ocf_irc::ircd {
   }
 
   ocf::systemd::override { 'start-inspircd-before-anope':
-    service => 'inspircd',
-    content => "[Unit]\nBefore=anope.service",
+    unit    => 'inspircd.service',
+    content => "[Unit]\nBefore=anope.service\n",
     require => Package['inspircd', 'anope'],
-    before  => Service['inspircd'],
+    notify  => Service['inspircd'],
   }
 
   $passwords = parsejson(file("/opt/puppet/shares/private/${::hostname}/ircd-passwords"))

--- a/modules/ocf_mesos/manifests/slave.pp
+++ b/modules/ocf_mesos/manifests/slave.pp
@@ -113,7 +113,6 @@ class ocf_mesos::slave($attributes = {}) {
     unit    => 'mesos-slave.service',
     content => "[Service]\nExecStart=\nExecStart=/usr/local/bin/ocf-mesos-slave\n",
     require => File['/usr/local/bin/ocf-mesos-slave'],
-    notify  => Service['mesos-slave'],
   }
 
   # Some operations change the agent's "info" and require the entire agent to

--- a/modules/ocf_mesos/manifests/slave.pp
+++ b/modules/ocf_mesos/manifests/slave.pp
@@ -110,10 +110,10 @@ class ocf_mesos::slave($attributes = {}) {
   }
 
   ocf::systemd::override { 'mesos-slave-change-start':
-    service => 'mesos-slave',
+    unit    => 'mesos-slave.service',
     content => "[Service]\nExecStart=\nExecStart=/usr/local/bin/ocf-mesos-slave\n",
     require => File['/usr/local/bin/ocf-mesos-slave'],
-    before  => Service['mesos-slave'],
+    notify  => Service['mesos-slave'],
   }
 
   # Some operations change the agent's "info" and require the entire agent to


### PR DESCRIPTION
Generalize `ocf::systemd::override` to handle any type of unit, and make use of that to set the docker socket group with systemd drop-ins.

Please review.