### PR TITLE
Only allow certain names for remote syslog files

### DIFF
--- a/modules/ocf_syslog/files/ocf.conf
+++ b/modules/ocf_syslog/files/ocf.conf
@@ -12,6 +12,19 @@ template(name="ocf-remote" type="list") {
     constant(value="\n")
 }
 
+# template for errored remote log lines
+template(name="ocf-errors" type="list") {
+    constant(value="ERRORED_TAG[")
+    property(name="syslogtag")
+    constant(value="]  MESSAGE[")
+    property(name="timegenerated" dateFormat="rfc3339")
+    constant(value=" ")
+    property(name="hostname")
+    constant(value=":  ")
+    property(name="msg")
+    constant(value="]\n")
+}
+
 # template for remote log filenames
 template(name="ocf-remote-file" type="list") {
     constant(value="/var/log/remote/")
@@ -23,5 +36,17 @@ template(name="ocf-remote-file" type="list") {
 
 # rules for storing the logs
 ruleset(name="ocf-remote") {
-    action(type="omfile" dynaFile="ocf-remote-file" template="ocf-remote" fileGroup="ocfstaff" fileCreateMode="0640")
+    # This regex was fiendish, since the hyphen must be next to the end bracket
+    # for it to work.
+    #
+    # It uses POSIX ERE (http://www.regular-expressions.info/posixbrackets.html)
+    # and has a tester at http://www.rsyslog.com/regex/
+    #
+    # Make sure this at least matches all the items let through in the regex in
+    # the stdin2syslog script so that real logs aren't put in errors.log
+    if re_match($syslogtag, '^[a-zA-Z0-9:_-]+$') then {
+        action(type="omfile" dynaFile="ocf-remote-file" template="ocf-remote" fileGroup="ocfstaff" fileCreateMode="0640")
+    } else {
+        action(type="omfile" file="/var/log/remote/errors.log" template="ocf-errors" fileGroup="ocfstaff" fileCreateMode="0640")
+    }
 }


### PR DESCRIPTION
The security scanner was probing our rsyslog server and made files like `#000#000#000@#000#003#000#000user#000pgbouncer#000UTF8#000.log` (except longer) that we don't really want, so now any files not matching a similar regex to the one in stdin2syslog will be put in a generic `errors.log` file.

This seems a reasonable amount more secure too, since there aren't as many arbitrary files that someone could create.