### PR TITLE
Upgrade puppet pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,12 @@
 -   repo: https://github.com/chriskuehl/puppet-pre-commit-hooks.git
-    sha: 862bf8eab7d34739ff1055e1824398b0c69b578f
+    sha: v2.0
     hooks:
     -   id: puppet-validate
-        args: [--parser=future]
     -   id: erb-validate
     -   id: puppet-lint
         args:
         -   --fail-on-warnings
-        -   --no-80chars-check
+        -   --no-140chars-check
         -   --no-documentation-check
         -   --no-puppet_url_without_modules-check
         -   --no-arrow_alignment-check

--- a/modules/ocf/manifests/networking.pp
+++ b/modules/ocf/manifests/networking.pp
@@ -1,11 +1,11 @@
 class ocf::networking(
     $bridge     = false,
 
-    $ipaddress  = $::ipHostNumber,
+    $ipaddress  = $::ipHostNumber,  # lint:ignore:variable_is_lowercase
     $netmask    = '255.255.255.0',
     $gateway    = '169.229.226.1',
 
-    $ipaddress6 = regsubst($::ipHostNumber, '^(\d+)\.(\d+)\.(\d+)\.(\d+)$', '2607:f140:8801::1:\4'),
+    $ipaddress6 = regsubst($::ipHostNumber, '^(\d+)\.(\d+)\.(\d+)\.(\d+)$', '2607:f140:8801::1:\4'),  # lint:ignore:variable_is_lowercase
     $netmask6   = '64',
     $gateway6   = '2607:f140:8801::1',
 


### PR DESCRIPTION
We're using puppet 4 for validation now, but that's probably fine since soon we'll be on Puppet 4.