### PR TITLE
Replace Rack puppet master with puppetserver

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ if (env.BRANCH_NAME == 'master') {
         stage('update-prod') {
             sh '''
                 kinit -t /opt/jenkins/deploy/ocfdeploy.keytab ocfdeploy
-                    ssh ocfdeploy@puppet 'sudo /opt/puppet/scripts/update-prod'
+                    ssh ocfdeploy@puppet 'sudo /opt/puppetlabs/scripts/update-prod'
             '''
         }
     }

--- a/Puppetfile
+++ b/Puppetfile
@@ -8,7 +8,12 @@ mod 'puppet-nginx',        '0.5.0'
 mod 'puppet-staging',      '2.0.1'
 mod 'puppetlabs-apache',   '1.11.0'
 mod 'puppetlabs-apt',      '2.3.0'
-mod 'puppetlabs-concat',   '2.2.0'
+
+# Upgrade to 2.2.0 when
+# https://tickets.puppetlabs.com/browse/MODULES-3310 is fixed or
+# all agents are on Puppet 4
+mod 'puppetlabs-concat',   '1.2.5'
 mod 'puppetlabs-rabbitmq', '5.6.0'
 mod 'puppetlabs-stdlib',   '4.14.0'
+mod 'puppetlabs-tagmail',  '2.1.1'
 mod 'puppetlabs-vcsrepo',  '1.5.0'

--- a/environment.conf
+++ b/environment.conf
@@ -1,2 +1,1 @@
 modulepath = modules:vendor:$basemodulepath
-parser = future

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -10,7 +10,7 @@
     - common
 
 :yaml:
-    :datadir: /opt/puppet/env/%{environment}/hieradata
+    :datadir: /etc/puppetlabs/code/environments/%{environment}/hieradata
 
 :puppet:
     :datasource: data

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -17,7 +17,7 @@ classes:
     - ocf::utils
 
 staff_only: true
-
+puppet_agent: false
 
 # Mesos/Marathon configuration
 #

--- a/hieradata/nodes/dev-lightning.yaml
+++ b/hieradata/nodes/dev-lightning.yaml
@@ -1,2 +1,4 @@
 classes:
     - ocf_puppet
+
+puppet_agent: true

--- a/hieradata/nodes/lightning.yaml
+++ b/hieradata/nodes/lightning.yaml
@@ -1,2 +1,4 @@
 classes:
     - ocf_puppet
+
+puppet_agent: true

--- a/modules/ocf/manifests/puppet.pp
+++ b/modules/ocf/manifests/puppet.pp
@@ -1,59 +1,91 @@
 class ocf::puppet($stage = 'first') {
-  package { ['facter', 'puppet']: }
+  if hiera('puppet_agent') {
+    package { 'puppet-agent':; }
 
-  # configure puppet agent
-  # set environment to match server and disable cached catalog on failure
-  augeas { '/etc/puppet/puppet.conf':
-    context => '/files/etc/puppet/puppet.conf',
-    changes => [
-      # These changes can change the puppetmaster config, which is
-      # defined separately in the ocf_puppet module, causing the
-      # puppet agent on the puppetmaster to restart twice. Make sure
-      # the changes made here are also made in that module.
-      "set agent/environment ${::environment}",
-      'set agent/usecacheonfailure false',
-      'set main/pluginsync true',
-      'set main/stringify_facts false',
-      'set main/rundir /run/puppet',
+    augeas { '/etc/puppetlabs/puppet/puppet.conf':
+      context => '/files/etc/puppetlabs/puppet/puppet.conf',
+      changes => [
+        # These changes can change the puppetmaster config, which is
+        # defined separately in the ocf_puppet module, causing the
+        # puppet agent on the puppetmaster to restart twice. Make sure
+        # the changes made here are also made in that module.
+        "set agent/environment ${::environment}",
+        'set agent/usecacheonfailure false',
 
-      # future parser breaks too many 3rd-party modules
-      'rm main/parser',
+        # TODO: Remove this after the puppetmaster upgrade is complete
+        'set main/server dev-puppet',
 
-      # templatedir is deprecated in 3.8+ and we don't use it
-      'rm main/templatedir',
-    ],
-    require => Package['augeas-tools', 'libaugeas-ruby', 'puppet'],
-    notify  => Service['puppet'],
-  }
+        # Remove a bunch of old settings that are no longer needed
+        'rm main/logdir',
+        'rm main/vardir',
+        'rm main/ssldir',
+        'rm main/rundir',
+        'rm main/templatedir',
+        'rm main/factpath',
+        'rm main/pluginsync',
+        'rm main/stringify_facts',
+        'rm main/prerun_command',
+        'rm main/postrun_command',
+        'rm agent/certname',
+        'rm master/ssl_client_header',
+        'rm master/ssl_client_verify_header',
+      ],
+      require => Package['puppet-agent'],
+    }
+  } else {
+    package { ['facter', 'puppet']: }
 
-  service { 'puppet':
-    require   => Package['puppet'],
+    # configure puppet agent
+    # set environment to match server and disable cached catalog on failure
+    augeas { '/etc/puppet/puppet.conf':
+      context => '/files/etc/puppet/puppet.conf',
+      changes => [
+        # These changes can change the puppetmaster config, which is
+        # defined separately in the ocf_puppet module, causing the
+        # puppet agent on the puppetmaster to restart twice. Make sure
+        # the changes made here are also made in that module.
+        "set agent/environment ${::environment}",
+        'set agent/usecacheonfailure false',
+        'set main/pluginsync true',
+        'set main/stringify_facts false',
+        'set main/rundir /run/puppet',
+
+        # future parser breaks too many 3rd-party modules
+        'rm main/parser',
+
+        # templatedir is deprecated in 3.8+ and we don't use it
+        'rm main/templatedir',
+      ],
+      require => Package['augeas-tools', 'libaugeas-ruby', 'puppet'],
+      notify  => Service['puppet'],
+    }
+
+    service { 'puppet':
+      require   => Package['puppet'],
+    }
   }
 
   # create share directories
   file {
     '/opt/share':
-      ensure => directory,
-    ;
+      ensure => directory;
+
     '/opt/share/puppet':
       ensure  => directory,
       recurse => true,
       purge   => true,
       force   => true,
-      backup  => false,
-    ;
+      backup  => false;
   }
 
   # install augeas
-  package { [ 'augeas-tools', 'libaugeas-ruby', ]: }
+  package { [ 'augeas-tools', 'libaugeas-ruby']:; }
 
   # install custom scripts
   file {
     # trigger a puppet run by the agent
     '/usr/local/sbin/puppet-trigger':
       mode    => '0755',
-      source  => 'puppet:///modules/ocf/puppet-trigger',
-      require => Package['puppet'],
-    ;
+      source  => 'puppet:///modules/ocf/puppet-trigger';
   }
 }

--- a/modules/ocf/manifests/puppet.pp
+++ b/modules/ocf/manifests/puppet.pp
@@ -29,6 +29,14 @@ class ocf::puppet($stage = 'first') {
       ],
       require => Package['puppet-agent'],
     }
+
+    # Run puppet as a cron job
+    cron { 'puppet-agent':
+      ensure  => present,
+      command => '/opt/puppetlabs/bin/puppet agent --verbose --onetime --no-daemonize --logdest syslog > /dev/null 2>&1',
+      user    => 'root',
+      minute  => [fqdn_rand(30), fqdn_rand(30) + 30],
+    }
   } else {
     package { ['facter', 'puppet']: }
 

--- a/modules/ocf/manifests/puppet.pp
+++ b/modules/ocf/manifests/puppet.pp
@@ -12,9 +12,6 @@ class ocf::puppet($stage = 'first') {
         "set agent/environment ${::environment}",
         'set agent/usecacheonfailure false',
 
-        # TODO: Remove this after the puppetmaster upgrade is complete
-        'set main/server dev-puppet',
-
         # Remove a bunch of old settings that are no longer needed
         'rm main/logdir',
         'rm main/vardir',

--- a/modules/ocf/manifests/staff_users.pp
+++ b/modules/ocf/manifests/staff_users.pp
@@ -4,7 +4,7 @@ class ocf::staff_users($noop = false) {
   # Only create home directories if:
   #   - we don't mount NFS
   #   - it hasn't been turned off in Hiera
-  if !str2bool($::ocf_nfs) and !$noop {
+  if !str2bool($::ocf_nfs) and !$noop and $::ocf_staff {
     $staff = split($::ocf_staff, ',')
     ocf::staff_users::user { $staff:; }
   }

--- a/modules/ocf_backups/files/rsnapshot.conf
+++ b/modules/ocf_backups/files/rsnapshot.conf
@@ -58,7 +58,8 @@ backup	ocfbackups@ldap:/etc/ldap/	servers/ldap/
 backup	ocfbackups@ldap:/var/lib/ldap/	servers/ldap/
 backup	ocfbackups@ldap:/var/backups/ldap/	servers/ldap/
 
-backup	ocfbackups@puppet:/var/lib/puppet/	servers/puppet/
+backup	ocfbackups@puppet:/etc/puppetlabs/puppet/	servers/puppet/
+backup	ocfbackups@puppet:/opt/puppetlabs/	servers/puppet/
 backup	ocfbackups@puppet:/opt/puppet/	servers/puppet/
 
 backup	ocfbackups@stats:/opt/stats/var/	servers/stats/

--- a/modules/ocf_desktop/files/xsession/auto-lock
+++ b/modules/ocf_desktop/files/xsession/auto-lock
@@ -140,5 +140,6 @@ def main():
     else:
         timebomb_explode()
 
+
 if __name__ == '__main__':
     main()

--- a/modules/ocf_desktop/files/xsession/lab-close-notify
+++ b/modules/ocf_desktop/files/xsession/lab-close-notify
@@ -50,5 +50,6 @@ def main():
     Notify.init('OCF')
     s.run()
 
+
 if __name__ == '__main__':
     main()

--- a/modules/ocf_puppet/files/ldap-enc
+++ b/modules/ocf_puppet/files/ldap-enc
@@ -35,21 +35,16 @@ def main():
         # Could not find a unique node to classify, exit
         sys.exit(1)
 
-    output = {'parameters': {}}
+    output = {'parameters': {}, 'environment': host['environment'][0]}
 
     for key, values in host.items():
-        # The environment is a special parameter that needs some conversion to
-        # work correctly.
-        if key == 'environment':
-            output['environment'] = values[0]
-
         # Remove the value from its list only if it is a singular value
         if len(values) == 1:
             output['parameters'][key] = values[0]
         else:
             output['parameters'][key] = values
 
-    print(yaml.dump(output, default_flow_style=False))
+    print(yaml.safe_dump(output, default_flow_style=False))
 
 
 if __name__ == '__main__':

--- a/modules/ocf_puppet/files/ldap-enc
+++ b/modules/ocf_puppet/files/ldap-enc
@@ -10,13 +10,13 @@ nodes like the built-in LDAP classifier.
 This is that classifier! It takes in node FQDNs, and looks them up in LDAP
 to get variables and classes to give to Puppet.
 """
-
 import argparse
 import sys
-import yaml
 
-from ocflib.infra.hosts import hosts_by_filter
+import yaml
 from ocflib.infra.hosts import hostname_from_domain
+from ocflib.infra.hosts import hosts_by_filter
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -50,6 +50,7 @@ def main():
             output['parameters'][key] = values
 
     print(yaml.dump(output, default_flow_style=False))
+
 
 if __name__ == '__main__':
     main()

--- a/modules/ocf_puppet/files/ldap-enc
+++ b/modules/ocf_puppet/files/ldap-enc
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""LDAP External Node Classifier for Puppet
+
+Since Puppet Server uses JRuby, we can't use the same ruby-ldap package that
+we have used with Puppet's LDAP node classifier in the past and instead must
+either patch jruby-ldap to work with Puppet (fragile for the future and tough
+if anything moves locations), or create an ENC for Puppet that will classify
+nodes like the built-in LDAP classifier.
+
+This is that classifier! It takes in node FQDNs, and looks them up in LDAP
+to get variables and classes to give to Puppet.
+"""
+
+import argparse
+import sys
+import yaml
+
+from ocflib.infra.hosts import hosts_by_filter
+from ocflib.infra.hosts import hostname_from_domain
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument('hostname', help='Hostname of LDAP node to classify.')
+    args = parser.parse_args()
+
+    hostname = hostname_from_domain(args.hostname)
+    search = hosts_by_filter('(&(objectclass=puppetClient)(cn={}))'.format(hostname))
+
+    if len(search) == 1:
+        host = search[0]
+    else:
+        # Could not find a unique node to classify, exit
+        sys.exit(1)
+
+    output = {'parameters': {}}
+
+    for key, values in host.items():
+        # The environment is a special parameter that needs some conversion to
+        # work correctly.
+        if key == 'environment':
+            output['environment'] = values[0]
+
+        # Remove the value from its list only if it is a singular value
+        if len(values) == 1:
+            output['parameters'][key] = values[0]
+        else:
+            output['parameters'][key] = values
+
+    print(yaml.dump(output, default_flow_style=False))
+
+if __name__ == '__main__':
+    main()

--- a/modules/ocf_puppet/files/tagmail.conf
+++ b/modules/ocf_puppet/files/tagmail.conf
@@ -1,0 +1,7 @@
+[transport]
+reportfrom = puppet
+sendmail = /usr/sbin/sendmail
+
+[tagmap]
+warning, err, alert, emerg, crit: puppet
+

--- a/modules/ocf_puppet/files/tagmail.conf
+++ b/modules/ocf_puppet/files/tagmail.conf
@@ -4,4 +4,3 @@ sendmail = /usr/sbin/sendmail
 
 [tagmap]
 warning, err, alert, emerg, crit: puppet
-

--- a/modules/ocf_puppet/files/webserver.conf
+++ b/modules/ocf_puppet/files/webserver.conf
@@ -1,0 +1,12 @@
+webserver: {
+  access-log-config : /etc/puppetlabs/puppetserver/request-logging.xml
+  client-auth       : want
+  ssl-host          : 0.0.0.0
+  ssl-port          : 8140
+
+  ssl-cert       : /etc/puppetlabs/puppet/ssl/certs/puppet.pem
+  ssl-key        : /etc/puppetlabs/puppet/ssl/private_keys/puppet.pem
+  ssl-ca-cert    : /etc/puppetlabs/puppet/ssl/certs/ca.pem
+  ssl-cert-chain : /etc/puppetlabs/puppet/ssl/certs/ca.pem
+  ssl-crl-path   : /etc/puppetlabs/puppet/ssl/ca/ca_crl.pem
+}

--- a/modules/ocf_puppet/manifests/environments.pp
+++ b/modules/ocf_puppet/manifests/environments.pp
@@ -10,11 +10,11 @@ class ocf_puppet::environments {
   # Instead, we just call `git clone`.
   $staff = split($::ocf_staff, ',')
   $staff.each |$user| {
-    $repo_path = "/opt/puppet/env/${user}"
+    $repo_path = "${puppet_environmentpath}/${user}"
 
     # We do the git checkout as the user, so we must ensure the directory exists
     # (and is owned by the user) first, since users can't make directories under
-    # the /opt/puppet/env directory.
+    # the root environments directory.
     file { $repo_path:
       ensure => directory,
       owner  => $user,

--- a/modules/ocf_puppet/manifests/environments.pp
+++ b/modules/ocf_puppet/manifests/environments.pp
@@ -8,23 +8,25 @@ class ocf_puppet::environments {
   # don't use any more, but used to use.
   #
   # Instead, we just call `git clone`.
+  if $::ocf_staff {
   $staff = split($::ocf_staff, ',')
-  $staff.each |$user| {
-    $repo_path = "${::puppet_environmentpath}/${user}"
+    $staff.each |$user| {
+      $repo_path = "${::puppet_environmentpath}/${user}"
 
-    # We do the git checkout as the user, so we must ensure the directory exists
-    # (and is owned by the user) first, since users can't make directories under
-    # the root environments directory.
-    file { $repo_path:
-      ensure => directory,
-      owner  => $user,
-      group  => ocf,
-    }
+      # We do the git checkout as the user, so we must ensure the directory exists
+      # (and is owned by the user) first, since users can't make directories under
+      # the root environments directory.
+      file { $repo_path:
+        ensure => directory,
+        owner  => $user,
+        group  => ocf,
+      }
 
-    exec { "git clone https://github.com/ocf/puppet ${repo_path} && cd ${repo_path} && make vendor":
-      user    => $user,
-      unless  => "test -d ${repo_path}/.git",
-      require => [File[$repo_path], Package['git'], Package['r10k']];
+      exec { "git clone https://github.com/ocf/puppet ${repo_path} && cd ${repo_path} && make vendor":
+        user    => $user,
+        unless  => "test -d ${repo_path}/.git",
+        require => [File[$repo_path], Package['git'], Package['r10k']];
+      }
     }
   }
 }

--- a/modules/ocf_puppet/manifests/environments.pp
+++ b/modules/ocf_puppet/manifests/environments.pp
@@ -10,7 +10,7 @@ class ocf_puppet::environments {
   # Instead, we just call `git clone`.
   $staff = split($::ocf_staff, ',')
   $staff.each |$user| {
-    $repo_path = "${puppet_environmentpath}/${user}"
+    $repo_path = "${::puppet_environmentpath}/${user}"
 
     # We do the git checkout as the user, so we must ensure the directory exists
     # (and is owned by the user) first, since users can't make directories under

--- a/modules/ocf_puppet/manifests/init.pp
+++ b/modules/ocf_puppet/manifests/init.pp
@@ -5,6 +5,6 @@ class ocf_puppet {
   include ocf_puppet::puppetmaster
 
   file { '/etc/sudoers.d/ocfdeploy-puppet':
-    content => "ocfdeploy ALL=NOPASSWD: /opt/puppet/scripts/update-prod\n";
+    content => "ocfdeploy ALL=NOPASSWD: /opt/puppetlabs/scripts/update-prod\n";
   }
 }

--- a/modules/ocf_puppet/manifests/puppetmaster.pp
+++ b/modules/ocf_puppet/manifests/puppetmaster.pp
@@ -40,7 +40,7 @@ class ocf_puppet::puppetmaster {
       content => template('ocf_puppet/puppet.conf.erb'),
       require => Package['puppet-agent'];
 
-    ['/opt/puppetlabs/scripts', '/opt/puppetlabs/shares', '/opt/puppetlabs/shares/contrib']:
+    ['/opt/puppet', '/opt/puppetlabs/scripts', '/opt/puppetlabs/shares', '/opt/puppetlabs/shares/contrib']:
       ensure  => directory,
       require => Package['puppetserver'];
 

--- a/modules/ocf_puppet/manifests/puppetmaster.pp
+++ b/modules/ocf_puppet/manifests/puppetmaster.pp
@@ -12,7 +12,7 @@ class ocf_puppet::puppetmaster {
   augeas { '/etc/default/puppetserver':
     context => '/files/etc/default/puppetserver',
     changes => [
-      "set JAVA_ARGS '\"-Xms512m -Xmx512m -XX:MaxPermSize=256m\"'",
+      "set JAVA_ARGS '\"-Xms1g -Xmx1g -XX:MaxPermSize=512m\"'",
     ],
     require => Package['puppetserver'],
     notify  => Service['puppetserver'],

--- a/modules/ocf_puppet/manifests/puppetmaster.pp
+++ b/modules/ocf_puppet/manifests/puppetmaster.pp
@@ -31,6 +31,11 @@ class ocf_puppet::puppetmaster {
       require => Package['puppetserver'],
       notify  => Service['puppetserver'];
 
+    '/etc/puppetlabs/puppetserver/conf.d/webserver.conf':
+      source  => 'puppet:///modules/ocf_puppet/webserver.conf',
+      require => Package['puppetserver'],
+      notify  => Service['puppetserver'];
+
     '/opt/share/puppet/ldap-enc':
       mode    => '0755',
       source  => 'puppet:///modules/ocf_puppet/ldap-enc',

--- a/modules/ocf_puppet/manifests/puppetmaster.pp
+++ b/modules/ocf_puppet/manifests/puppetmaster.pp
@@ -4,6 +4,7 @@ class ocf_puppet::puppetmaster {
   }
 
   service { 'puppetserver':
+    enable  => true,
     require => Package['puppetserver'],
   }
 
@@ -22,11 +23,13 @@ class ocf_puppet::puppetmaster {
   file {
     '/etc/puppetlabs/puppet/fileserver.conf':
       content => template('ocf_puppet/fileserver.conf.erb'),
-      require => Package['puppetserver'];
+      require => Package['puppetserver'],
+      notify  => Service['puppetserver'];
 
     '/etc/puppetlabs/puppet/tagmail.conf':
       source  => 'puppet:///modules/ocf_puppet/tagmail.conf',
-      require => Package['puppetserver'];
+      require => Package['puppetserver'],
+      notify  => Service['puppetserver'];
 
     '/opt/share/puppet/ldap-enc':
       mode    => '0755',

--- a/modules/ocf_puppet/manifests/puppetmaster.pp
+++ b/modules/ocf_puppet/manifests/puppetmaster.pp
@@ -1,52 +1,67 @@
 class ocf_puppet::puppetmaster {
   package {
-    ['puppetmaster-passenger', 'puppet-lint']:;
+    ['puppetserver', 'puppet-lint']:;
   }
 
-  class { '::apache':
-    default_vhost => false;
+  service { 'puppetserver':
+    require => Package['puppetserver'],
   }
 
-  apache::vhost { 'puppetmaster':
-    docroot    => '/usr/share/puppet/rack/puppetmasterd/public/',
-    port       => 8140,
-
-    ssl               => true,
-    ssl_key           => '/var/lib/puppet/ssl/private_keys/puppet.pem',
-    ssl_cert          => '/var/lib/puppet/ssl/certs/puppet.pem',
-    ssl_chain         => '/var/lib/puppet/ssl/certs/ca.pem',
-    ssl_ca            => '/var/lib/puppet/ssl/certs/ca.pem',
-    ssl_crl           => '/var/lib/puppet/ssl/ca/ca_crl.pem',
-    ssl_verify_client => 'optional',
-    ssl_verify_depth  => 1,
-    ssl_options       => ['+StdEnvVars', '+ExportCertData'],
-
-    rack_base_uris => ['/'];
+  # Set correct memory limits on puppetserver so that it doesn't run out
+  augeas { '/etc/default/puppetserver':
+    context => '/files/etc/default/puppetserver',
+    changes => [
+      "set JAVA_ARGS '\"-Xms512m -Xmx512m -XX:MaxPermSize=256m\"'",
+    ],
+    require => Package['puppetserver'],
+    notify  => Service['puppetserver'],
   }
 
   $docker_private_hosts = union(keys(hiera('mesos_masters')), hiera('mesos_slaves'))
 
   file {
-    '/etc/puppet/fileserver.conf':
-      content => template('ocf_puppet/fileserver.conf.erb');
+    '/etc/puppetlabs/puppet/fileserver.conf':
+      content => template('ocf_puppet/fileserver.conf.erb'),
+      require => Package['puppetserver'];
 
-    '/etc/puppet/puppet.conf':
-      content => template('ocf_puppet/puppet.conf.erb');
+    '/etc/puppetlabs/puppet/tagmail.conf':
+      source  => 'puppet:///modules/ocf_puppet/tagmail.conf',
+      require => Package['puppetserver'];
 
-    '/etc/puppet/tagmail.conf':
-      content => "warning, err, alert, emerg, crit: puppet\n";
+    '/opt/share/puppet/ldap-enc':
+      mode    => '0755',
+      source  => 'puppet:///modules/ocf_puppet/ldap-enc',
+      require => File['/opt/share/puppet'];
 
-    ['/opt/puppet', '/opt/puppet/env', '/opt/puppet/scripts', '/opt/puppet/shares', '/opt/puppet/shares/contrib']:
-      ensure  => directory;
+    '/etc/puppetlabs/puppet/puppet.conf':
+      content => template('ocf_puppet/puppet.conf.erb'),
+      require => Package['puppet-agent'];
 
-    '/opt/puppet/shares/private':
+    ['/opt/puppetlabs/scripts', '/opt/puppetlabs/shares', '/opt/puppetlabs/shares/contrib']:
+      ensure  => directory,
+      require => Package['puppetserver'];
+
+    '/opt/puppetlabs/shares/private':
       mode    => '0400',
       owner   => puppet,
       group   => puppet,
-      recurse => true;
+      recurse => true,
+      require => File['/opt/puppetlabs/shares'];
 
-    '/opt/puppet/scripts/update-prod':
+    '/opt/puppetlabs/scripts/update-prod':
       source  => 'puppet:///modules/ocf_puppet/update-prod',
       mode    => '0755';
+
+    # TODO: Remove old puppet directories after the upgrade is fully done
+    # (for now they are just links to the new locations)
+    '/opt/puppet/env':
+      ensure  => symlink,
+      target  => '/etc/puppetlabs/code/environments',
+      require => Package['puppetserver'];
+
+    '/opt/puppet/shares':
+      ensure  => symlink,
+      target  => '/opt/puppetlabs/shares',
+      require => Package['puppetserver'];
   }
 }

--- a/modules/ocf_puppet/templates/puppet.conf.erb
+++ b/modules/ocf_puppet/templates/puppet.conf.erb
@@ -7,43 +7,27 @@
 
 [main]
 
-environmentpath = /opt/puppet/env
-hiera_config = /opt/puppet/env/<%= @environment %>/hiera.yaml
+hiera_config = <%= @puppet_environmentpath %>/<%= @environment %>/hiera.yaml
 
-# debian paths
-logdir = /var/log/puppet
-vardir = /var/lib/puppet
-ssldir = /var/lib/puppet/ssl
-rundir = /run/puppet
-factpath = $vardir/lib/facter
-
-# plugin sync (used by concat)
-pluginsync = true
-
-stringify_facts = false
+# TODO: Remove this after ths upgrade
+server = dev-puppet
 
 [agent]
 
-certname = <%= @clientcert %>
 environment = <%= @environment %>
 usecacheonfailure = false
 
 [master]
 
-# puppetmaster ssl certificate name
-certname = puppet
+vardir  = /opt/puppetlabs/server/data/puppetserver
+logdir  = /var/log/puppetlabs/puppetserver
+rundir  = /var/run/puppetlabs/puppetserver
+pidfile = /var/run/puppetlabs/puppetserver/puppetserver.pid
+codedir = /etc/puppetlabs/code
 
-# ssl support for apache passenger
-ssl_client_header = SSL_CLIENT_S_DN
-ssl_client_verify_header = SSL_CLIENT_VERIFY
+# Use custom LDAP external node classifer (ENC)
+node_terminus = exec
+external_nodes = /opt/share/puppet/ldap-enc
 
-# use external node classifer
-node_terminus = ldap
-ldapserver = ldap.ocf.berkeley.edu
-ldapport = 636
-ldapssl = true
-ldapbase = ou=Hosts,dc=OCF,dc=Berkeley,dc=EDU
-
-# log and mail reports from clients
+# log and mail reports from failed clients
 reports = log, tagmail
-reportfrom = puppet

--- a/modules/ocf_puppet/templates/puppet.conf.erb
+++ b/modules/ocf_puppet/templates/puppet.conf.erb
@@ -9,9 +9,6 @@
 
 hiera_config = <%= @puppet_environmentpath %>/<%= @environment %>/hiera.yaml
 
-# TODO: Remove this after ths upgrade
-server = dev-puppet
-
 [agent]
 
 environment = <%= @environment %>


### PR DESCRIPTION
Puppetserver is not my favorite, mostly because it's a scary all-in-one JVM application, but it does have some especially nice features, like being able to support both Puppet 3 and Puppet 4 clients in the same server, and being able to use PuppetDB. The puppet documentation does say that the Rack puppet master will be removed in the future, so it seems like a good idea to migrate to puppetserver now, since it also allows for using Puppet 4 with no barriers.

Also all the current errors being emailed are coming from [this issue](https://tickets.puppetlabs.com/browse/MODULES-3310), which appears to be some kind of issue when using Puppet 3 agents with puppetserver and the concat module, which we do almost everywhere now, so anything using the concat module (pretty much just used for joining SSL certs right now into bundles) will error until the concat module is downgraded.