### PR TITLE
Allow debian-security-support local login

### DIFF
--- a/modules/ocf/templates/access.conf.erb
+++ b/modules/ocf/templates/access.conf.erb
@@ -6,6 +6,7 @@
 + : ALL : cron crond
 + : root : ALL
 + : apt-dater : lightning.ocf.berkeley.edu
++ : debian-security-support : LOCAL
 + : ocfbackups : hal.ocf.berkeley.edu
 + : ocfdeploy : reaper.ocf.berkeley.edu LOCAL
 <% @ulogin.each do |user,from| -%>


### PR DESCRIPTION
This is needed for the dpkg hook installed by the package
of the same name which runs check-support-status as that user:
/usr/share/debian-security-support/check-support-status.hook

Technically the origin is "???" which works in access.conf
but I think allowing all LOCAL logins is more readable.
The user's shell is already /bin/false (overriden with su command).

This should fix these messages during apt/dpkg operations:

    su: Permission denied
    (Ignored)