### PR TITLE
ocf_mysql: Listen on all interfaces and on IPv6 (rt#5935)

### DIFF
--- a/modules/ocf_mysql/files/99-ocf.cnf
+++ b/modules/ocf_mysql/files/99-ocf.cnf
@@ -1,5 +1,5 @@
 [mysqld]
-bind-address = 0.0.0.0
+bind-address = ::
 
 # https://mariadb.com/kb/en/mariadb/optimizing-key_buffer_size/
 key_buffer_size = 128M

--- a/modules/ocf_mysql/manifests/init.pp
+++ b/modules/ocf_mysql/manifests/init.pp
@@ -17,19 +17,8 @@ class ocf_mysql {
     require        => File['/opt/share/puppet/mariadb-server-10.0.preseed'],
   }
 
-  # Listen on all interfaces and on both IPv4/IPv6
-  augeas { '/etc/mysql/mariadb.conf.d/50-server.cnf':
-    lens    => 'MySQL.lns',
-    incl    => '/etc/mysql/mariadb.conf.d/50-server.cnf',
-    changes => [
-      "set target[.='mysqld']/bind-address ::",
-    ],
-    require => Class['ocf::packages::mysql_server'],
-    notify  => Service['mysql'],
-  }
-
-  file { '/etc/mysql/conf.d/99ocf.cnf':
-    source  => 'puppet:///modules/ocf_mysql/99ocf.cnf',
+  file { '/etc/mysql/mariadb.conf.d/99-ocf.cnf':
+    source  => 'puppet:///modules/ocf_mysql/99-ocf.cnf',
     require => Class['ocf::packages::mysql_server'],
     notify  => Service['mysql'],
   }

--- a/modules/ocf_mysql/manifests/init.pp
+++ b/modules/ocf_mysql/manifests/init.pp
@@ -9,13 +9,30 @@ class ocf_mysql {
     '/root/.my.cnf':
       mode   => '0600',
       source => 'puppet:///private/root-my.cnf';
-  } ->
+  }
+
   class { 'ocf::packages::mysql_server':
     responsefile   => '/opt/share/puppet/mariadb-server-10.0.preseed',
     manage_service => false,
-  } ->
+    require        => File['/opt/share/puppet/mariadb-server-10.0.preseed'],
+  }
+
+  # Listen on all interfaces and on both IPv4/IPv6
+  augeas { '/etc/mysql/mariadb.conf.d/50-server.cnf':
+    lens    => 'MySQL.lns',
+    incl    => '/etc/mysql/mariadb.conf.d/50-server.cnf',
+    changes => [
+      "set target[.='mysqld']/bind-address ::",
+    ],
+    require => Class['ocf::packages::mysql_server'],
+    notify  => Service['mysql'],
+  }
+
   file { '/etc/mysql/conf.d/99ocf.cnf':
     source  => 'puppet:///modules/ocf_mysql/99ocf.cnf',
-  } ~>
+    require => Class['ocf::packages::mysql_server'],
+    notify  => Service['mysql'],
+  }
+
   service { 'mysql': }
 }


### PR DESCRIPTION
I also removed all the chaining arrows from `ocf_mysql/init.pp`, because they are confusing and we use them very rarely. There's a few others scattered around that should probably be removed, although obviously not if there are objections :P