### PR TITLE
Add private hiera lookup (rt#5884)

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -8,6 +8,9 @@ defaults:
   data_hash: yaml_data
 
 hierarchy:
+  - name: "Private config (passwords, etc.)"
+    path: "private.yaml"
+
   - name: "Nodes"
     path: "nodes/%{::hostname}.yaml"
 

--- a/hieradata/private.yaml
+++ b/hieradata/private.yaml
@@ -1,0 +1,1 @@
+/opt/puppet/shares/private/private.yaml

--- a/modules/ocf_mail/manifests/site_vhost.pp
+++ b/modules/ocf_mail/manifests/site_vhost.pp
@@ -9,7 +9,7 @@ class ocf_mail::site_vhost {
     backport_on => jessie,
   }
 
-  $mysql_ro_password = file('/opt/puppet/shares/private/ocfmail/mysql-ro-password')
+  $mysql_ro_password = hiera('ocfmail::mysql::ro_password')
 
   file {
     '/etc/pam-mysql.conf':


### PR DESCRIPTION
This adds a private hiera config file in the private share, which we can use to list secrets like passwords.

Often we want to get these passwords as variables so we can use them in templates, augeas, etc. Generally speaking, this is preferred to putting an entire config file in the private share, when only a small part of it is secret.

This changes one instance of the `file(...)` hack into using hiera. I'll change the rest if people like this.

Here's more context from the ticket:

> Currently we do stuff like
>
> ```puppet
> $redis_password = file('/opt/puppet/shares/private/create/redis-password')
> $mysql_password = file('/opt/puppet/shares/private/create/mysql-password')
> ```
>
> ...and then use those as variables in templates or other places.
>
> This works okay but is a little hard to manage. For example, you have to be careful when creating those files that they don't have a newline at the end, and you're pretty much limited to single strings. It'd be better if we could write a hiera config like:
>
> ```yaml
> create::dev_config:
>     redis:
>         url: admin.ocf.berkeley.edu:6378
>         password: hunter2
>     mysql:
>         url: mysql
>         user: ocfcreate
>         password: hunter2
> ```

P.S. here's a useful way to debug hiera lookup issues: `sudo puppet lookup --debug --explain --node anthrax.ocf.berkeley.edu ocfmail::mysql::ro_password` on the puppetmaster