### PR TITLE
Remove the stupid Debian vim config

### DIFF
--- a/modules/ocf/files/packages/vim/vimrc.local
+++ b/modules/ocf/files/packages/vim/vimrc.local
@@ -1,0 +1,96 @@
+" Debian ships with absolutely insane defaults when the user has no vimrc.
+let g:skip_defaults_vim = 1
+
+" A small amount of OCF config
+colorscheme ron
+set number
+
+" The rest is taken from vim-sensible:
+" https://github.com/tpope/vim-sensible
+if exists('g:loaded_sensible') || &compatible
+  finish
+else
+  let g:loaded_sensible = 1
+endif
+
+if has('autocmd')
+  filetype plugin indent on
+endif
+if has('syntax') && !exists('g:syntax_on')
+  syntax enable
+endif
+
+" Use :help 'option' to see the documentation for the given option.
+
+set autoindent
+set backspace=indent,eol,start
+set complete-=i
+set smarttab
+
+set nrformats-=octal
+
+set ttimeout
+set ttimeoutlen=100
+
+set incsearch
+" Use <C-L> to clear the highlighting of :set hlsearch.
+if maparg('<C-L>', 'n') ==# ''
+  nnoremap <silent> <C-L> :nohlsearch<C-R>=has('diff')?'<Bar>diffupdate':''<CR><CR><C-L>
+endif
+
+set laststatus=2
+set ruler
+set wildmenu
+
+if !&scrolloff
+  set scrolloff=1
+endif
+if !&sidescrolloff
+  set sidescrolloff=5
+endif
+set display+=lastline
+
+if &encoding ==# 'latin1' && has('gui_running')
+  set encoding=utf-8
+endif
+
+if &listchars ==# 'eol:$'
+  set listchars=tab:>\ ,trail:-,extends:>,precedes:<,nbsp:+
+endif
+
+if v:version > 703 || v:version == 703 && has("patch541")
+  set formatoptions+=j " Delete comment character when joining commented lines
+endif
+
+if has('path_extra')
+  setglobal tags-=./tags tags-=./tags; tags^=./tags;
+endif
+
+if &shell =~# 'fish$' && (v:version < 704 || v:version == 704 && !has('patch276'))
+  set shell=/bin/bash
+endif
+
+set autoread
+
+if &history < 1000
+  set history=1000
+endif
+if &tabpagemax < 50
+  set tabpagemax=50
+endif
+if !empty(&viminfo)
+  set viminfo^=!
+endif
+set sessionoptions-=options
+
+" Allow color schemes to do bright colors without forcing bold.
+if &t_Co == 8 && $TERM !~# '^linux\|^Eterm'
+  set t_Co=16
+endif
+
+" Load matchit.vim, but only if the user hasn't installed a newer version.
+if !exists('g:loaded_matchit') && findfile('plugin/matchit.vim', &rtp) ==# ''
+  runtime! macros/matchit.vim
+endif
+
+inoremap <C-U> <C-G>u<C-U>

--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -15,6 +15,7 @@ class ocf::packages {
   include ocf::packages::rsync
   include ocf::packages::shell
   include ocf::packages::ssh
+  include ocf::packages::vim
 
   # Packages to automatically update to be the latest version. This should be
   # kept short, since apt-dater should be used to update almost all packages.
@@ -113,8 +114,6 @@ class ocf::packages {
     'tofrodos',
     'tree',
     'unzip',
-    'vim',
-    'vim-nox',
     'whois',
     ]:;
   }

--- a/modules/ocf/manifests/packages/vim.pp
+++ b/modules/ocf/manifests/packages/vim.pp
@@ -1,0 +1,10 @@
+# In stretch, Debian starting shipping absolutely awful default vim settings
+# (mouse mode, etc.). We turn those off.
+class ocf::packages::vim {
+  package { ['vim', 'vim-nox']:; }
+
+  file { '/etc/vim/vimrc.local':
+    source  => 'puppet:///modules/ocf/packages/vim/vimrc.local',
+    require => Package['vim', 'vim-nox'],
+  }
+}


### PR DESCRIPTION
Normally I do not like overriding these things, but the new Debian config is completely unusable. I can't even copy-paste text to my system clipboard because the idiotic mouse mode takes over.

I also added [vim-sensible](https://github.com/tpope/vim-sensible) to our default config, which seems reasonable since lots of our users might occasionally use vim, but most won't take the time to install their vimrc (or even have one to install).

I don't really care about that change though, so if people object, I'll delete all the vim-sensible stuff and we can just keep the first 2 lines.