### PR TITLE
Serve unavailable vhost for sorried vhosts (rt#5955)

### DIFF
--- a/modules/ocf_www/files/build-vhosts
+++ b/modules/ocf_www/files/build-vhosts
@@ -13,6 +13,7 @@ from collections import namedtuple
 from pathlib import Path
 
 import jinja2
+from ocflib.account.search import user_is_sorried
 from ocflib.account.utils import web_dir
 from ocflib.misc.mail import email_for_user
 from ocflib.vhost.web import get_vhosts
@@ -37,6 +38,7 @@ class VirtualHost(namedtuple('VirtualHost', (
         'ssl_key',
         'ssl_chain',
         'use_hsts',
+        'disabled',
 ))):
     """A single <VirtualHost>.
 
@@ -103,15 +105,17 @@ def build_config_file():
             ssl_options = {}
 
         # primary vhost
+        user = vhost['username']
         primary = VirtualHost(
             fqdn=domain,
-            user=vhost['username'],
+            user=user,
             relative_docroot=vhost['docroot'],
             redirect_dest=None,
             ssl_cert=ssl_options.get('ssl_cert'),
             ssl_key=ssl_options.get('ssl_key'),
             ssl_chain=ssl_options.get('ssl_chain'),
             use_hsts='hsts' in vhost['flags'],
+            disabled=user_is_sorried(user),
         )
         vhosts.add(primary)
 
@@ -129,6 +133,7 @@ def build_config_file():
                 ssl_key=None,
                 ssl_chain=None,
                 use_hsts=None,
+                disabled=False,
             ))
 
     return '\n\n'.join(

--- a/modules/ocf_www/files/vhost.jinja
+++ b/modules/ocf_www/files/vhost.jinja
@@ -12,7 +12,12 @@
         SSLCertificateChainFile {{vhost.ssl_chain}}
     {% endif %}
 
-    {% if not vhost.is_redirect %}
+    {% if vhost.disabled %}
+        # Proxy to the local "unavailable" vhost, which serves up a friendly
+        # "your website is rekt" page.
+        RequestHeader set Host unavailable
+        ProxyPass / http://localhost/
+    {% elif not vhost.is_redirect %}
         <Directory {{vhost.docroot}}>
             Options ExecCGI IncludesNoExec Indexes MultiViews SymLinksIfOwnerMatch
             AllowOverride All


### PR DESCRIPTION
It looks just like you expect:
![](https://i.fluffy.cc/rKf30lNzF7rVSkNrw17ScVnjCkl28PHk.png)

Is the proxy approach okay? Seems better to me than duplicating the vhost config. Alternatively we could factor that out into some config file and include it in both, but it's a bit harder to do with the puppetlabs apache module. I don't really see any problems with this approach?