### PR TITLE
Add staff to docker on staffvms

### DIFF
--- a/hieradata/type/staffvm.yaml
+++ b/hieradata/type/staffvm.yaml
@@ -9,5 +9,5 @@ ocf::auth::nopasswd: true
 # let any staff use docker on staff VMs without sudo
 classes:
     - ocf_staffvm::docker_group
-# temporary
+# TODO: temporary
 ocf::packages::docker::admin_group: docker

--- a/hieradata/type/staffvm.yaml
+++ b/hieradata/type/staffvm.yaml
@@ -7,4 +7,7 @@ ocf::auth::nopasswd: true
 
 
 # let any staff use docker on staff VMs without sudo
-ocf::packages::docker::admin_group: ocfstaff
+classes:
+    - ocf_staffvm::docker_group
+# temporary
+ocf::packages::docker::admin_group: docker

--- a/modules/ocf_staffvm/manifests/docker_group.pp
+++ b/modules/ocf_staffvm/manifests/docker_group.pp
@@ -1,0 +1,12 @@
+class ocf_staffvm::docker_group {
+  if tagged('ocf::packages::docker') {
+    require ocf::packages::docker
+
+    $owner = lookup('owner')
+
+    ensure_resource('user', $owner)
+    User[$owner] {
+      groups +> 'docker'
+    }
+  }
+}


### PR DESCRIPTION
I never felt too comfortable with giving every staffer root on every other staffer's VM. This change aims to preserve the intent of 29b8882 while narrowing the grant of root privileges.