### PR TITLE
ocf: add icedtea-netx

### DIFF
--- a/modules/ocf/manifests/extrapackages.pp
+++ b/modules/ocf/manifests/extrapackages.pp
@@ -48,6 +48,7 @@ class ocf::extrapackages {
     'ghc',
     'git-buildpackage',
     'golang',
+    'icedtea-netx',
     'ikiwiki',
     'inotify-tools',
     'intltool',


### PR DESCRIPTION
Added to extrapackages (instead of ocf_desktop) so you can
at some future point use it to access the firewall from
supernova.