### PR TITLE
Set PulseAudio default sinks on snowflake nodes

### DIFF
--- a/hieradata/nodes/cyclone.yaml
+++ b/hieradata/nodes/cyclone.yaml
@@ -1,1 +1,2 @@
+# get this value by running `pactl list sinks`
 pulse_sink: alsa_output.usb-C-Media_Electronics_Inc._USB_Audio_Device-00.analog-stereo

--- a/hieradata/nodes/cyclone.yaml
+++ b/hieradata/nodes/cyclone.yaml
@@ -1,0 +1,1 @@
+pulse_sink: alsa_output.usb-C-Media_Electronics_Inc._USB_Audio_Device-00.analog-stereo

--- a/hieradata/nodes/invasion.yaml
+++ b/hieradata/nodes/invasion.yaml
@@ -1,1 +1,2 @@
+# get this value by running `pactl list sinks`
 pulse_sink: alsa_output.pci-0000_00_1f.3.iec958-stereo

--- a/hieradata/nodes/invasion.yaml
+++ b/hieradata/nodes/invasion.yaml
@@ -1,0 +1,1 @@
+pulse_sink: alsa_output.pci-0000_00_1f.3.iec958-stereo

--- a/hieradata/nodes/tornado.yaml
+++ b/hieradata/nodes/tornado.yaml
@@ -1,2 +1,4 @@
 classes:
     - ocf_tv
+
+pulse_sink: alsa_output.pci-0000_00_03.0.hdmi-stereo

--- a/hieradata/nodes/tornado.yaml
+++ b/hieradata/nodes/tornado.yaml
@@ -1,4 +1,5 @@
 classes:
     - ocf_tv
 
+# get this value by running `PULSE_SERVER=localhost pactl list sinks`
 pulse_sink: alsa_output.pci-0000_00_03.0.hdmi-stereo

--- a/modules/ocf_desktop/manifests/pulse.pp
+++ b/modules/ocf_desktop/manifests/pulse.pp
@@ -19,4 +19,10 @@ class ocf_desktop::pulse {
     require => Package['libasound2-plugins'],
   }
 
+  $pulse_sink = lookup({name => 'pulse_sink', default => nil})
+
+  if $pulse_sink {
+    exec { "pactl set-default-sink ${pulse_sink}": }y
+  }
+
 }

--- a/modules/ocf_desktop/manifests/pulse.pp
+++ b/modules/ocf_desktop/manifests/pulse.pp
@@ -19,11 +19,12 @@ class ocf_desktop::pulse {
     require => Package['libasound2-plugins'],
   }
 
-  $pulse_sink = lookup({'name' => 'pulse_sink', 'default_value' => nil})
+  $pulse_sink = lookup('pulse_sink')
   if $pulse_sink {
-    exec { 'set-pulse-default-sink':
-      command => "sed -i 's/#set-default-sink output/set-default-sink ${pulse_sink}/' /etc/pulse/default.pa",
-      unless => 'grep ^set-default-sink /etc/pulse/default.pa > /dev/null',
+    augeas { 'set-pulse-default-sink':
+      incl => '/etc/pulse/default.pa',
+      lens => 'Spacevars.simple_lns',
+      changes => "set set-default-sink ${pulse_sink}",
     }
   }
 }

--- a/modules/ocf_desktop/manifests/pulse.pp
+++ b/modules/ocf_desktop/manifests/pulse.pp
@@ -19,10 +19,11 @@ class ocf_desktop::pulse {
     require => Package['libasound2-plugins'],
   }
 
-  $pulse_sink = lookup({name => 'pulse_sink', default => nil})
-
+  $pulse_sink = lookup({'name' => 'pulse_sink', 'default_value' => nil})
   if $pulse_sink {
-    exec { "pactl set-default-sink ${pulse_sink}": }y
+    exec { 'set-pulse-default-sink':
+      command => "sed -i 's/#set-default-sink output/set-default-sink ${pulse_sink}/' /etc/pulse/default.pa",
+      unless => 'grep ^set-default-sink /etc/pulse/default.pa > /dev/null',
+    }
   }
-
 }

--- a/modules/ocf_tv/manifests/init.pp
+++ b/modules/ocf_tv/manifests/init.pp
@@ -63,4 +63,11 @@ class ocf_tv {
       User['ocftv'],
     ],
   }
+
+  $pulse_sink = lookup('pulse_sink')
+
+  exec { "pactl set-default-sink ${pulse_sink}":
+    environment => ['PULSE_SERVER=localhost'],
+  }
+
 }


### PR DESCRIPTION
On cyclone, invasion, and tornado, there are multiple PulseAudio sinks. cyclone because we want to use the USB headphone jack, invasion because it has a different? motherboard, and tornado because it's the TV. 

This sets the correct default sinks on those special nodes. 