### PR TITLE
Use upstream pre-commit

### DIFF
--- a/.activate.sh
+++ b/.activate.sh
@@ -1,0 +1,1 @@
+venv/bin/activate

--- a/.deactivate.sh
+++ b/.deactivate.sh
@@ -1,0 +1,1 @@
+deactivate

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: vendor
 venv: bin/venv-update Makefile
 	bin/venv-update \
 		venv= $@ -ppython3 \
-		install= ckuehl-pre-commit-types==0.7.6.dev1
+		install= 'pre-commit>=0.15.0'
 
 .PHONY: test
 test: venv install-hooks


### PR DESCRIPTION
@asottile did a bunch of work to get the "types" fork I started a couple years ago merged into pre-commit itself! pre-commit 0.15 supports "types" in a much better way than my original fork and also has a bunch of fixes included in newer pre-commit versions (my fork was based on 0.7.6).

For historical context, the reason we were using my fork in this repo (and only this repo) is because we have a bunch of extension-less files (mostly python) that pre-commit couldn't previously do anything with. The new version is able to parse shebangs and correctly identify them.

![](https://i.fluffy.cc/2VN5sRNLH0hds4wglBHfnstJlJXC4mgJ.gif)

We're still using my fork of the pre-commit-hooks repo (in `.pre-commit-config.yaml`) since it hasn't been switched to use types yet.