### PR TITLE
Update Puppet pre-commit hooks to 2.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@
         -   --no-documentation-check
         -   --no-puppet_url_without_modules-check
         -   --no-arrow_alignment-check
+        -   --no-arrow_on_right_operand_line-check
 -   repo: https://github.com/pre-commit/pre-commit-hooks.git
     sha: v0.9.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 -   repo: https://github.com/chriskuehl/puppet-pre-commit-hooks.git
-    sha: v2.0
+    sha: v2.0.1
     hooks:
     -   id: puppet-validate
     -   id: erb-validate


### PR DESCRIPTION
No real changes, just a rename from hooks.yaml => .pre-commit-hooks.yaml to get rid of the deprecation warning.