### PR TITLE
Add check-executables-have-shebangs pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@
     -   id: check-added-large-files
     -   id: check-docstring-first
         language_version: python3
+    -   id: check-executables-have-shebangs
     -   id: check-json
     -   id: check-merge-conflict
     -   id: check-xml

--- a/modules/ocf_mirrors/files/project/apache/sync-archive
+++ b/modules/ocf_mirrors/files/project/apache/sync-archive
@@ -1,3 +1,3 @@
-#/bin/sh -eu
+#!/bin/sh -eu
 /usr/local/bin/rsync-no-vanished -az --delete --safe-links \
 	rsync://rsync.us.apache.org/apache-dist/ /opt/mirrors/ftp/apache

--- a/modules/ocf_mirrors/files/project/archlinux/sync-archive
+++ b/modules/ocf_mirrors/files/project/archlinux/sync-archive
@@ -1,3 +1,3 @@
-#/bin/sh -eu
+#!/bin/sh -eu
 /usr/local/bin/rsync-no-vanished -rtlH --delete-after --delay-updates --safe-links \
 	rsync://mirrors.kernel.org/archlinux/ /opt/mirrors/ftp/archlinux

--- a/modules/ocf_mirrors/files/project/centos/sync-archive
+++ b/modules/ocf_mirrors/files/project/centos/sync-archive
@@ -1,2 +1,2 @@
-#/bin/sh -eu
+#!/bin/sh -eu
 /usr/local/bin/rsync-no-vanished -aqzH --delete rsync://us-msync.centos.org/CentOS /opt/mirrors/ftp/centos

--- a/modules/ocf_mirrors/files/project/finnix/sync-releases
+++ b/modules/ocf_mirrors/files/project/finnix/sync-releases
@@ -1,4 +1,4 @@
-#/bin/sh -eu
+#!/bin/sh -eu
 /usr/local/bin/rsync-no-vanished -a \
     --password-file /opt/mirrors/project/finnix/password \
     rsync://ucb-ocf@rsync-master.finnix.org/finnix-releases-master/ /opt/mirrors/ftp/finnix-releases

--- a/modules/ocf_mirrors/files/project/gnu/sync-archive
+++ b/modules/ocf_mirrors/files/project/gnu/sync-archive
@@ -1,3 +1,3 @@
-#/bin/sh -eu
+#!/bin/sh -eu
 /usr/local/bin/rsync-no-vanished -rltpHS --delete-excluded \
 	rsync://mirrors.kernel.org/gnu/ /opt/mirrors/ftp/gnu

--- a/modules/ocf_mirrors/files/project/manjaro/sync-archive
+++ b/modules/ocf_mirrors/files/project/manjaro/sync-archive
@@ -1,3 +1,3 @@
-#/bin/sh -eu
+#!/bin/sh -eu
 /usr/local/bin/rsync-no-vanished -rtlH --delete-after --delay-updates --safe-links \
 	rsync://mirror.jmu.edu/manjaro/ /opt/mirrors/ftp/manjaro

--- a/modules/ocf_mirrors/files/project/parrot/sync
+++ b/modules/ocf_mirrors/files/project/parrot/sync
@@ -1,3 +1,3 @@
-#/bin/sh -eu
+#!/bin/sh -eu
 /usr/local/bin/rsync-no-vanished -rltpHS --delete-excluded \
 	rsync://archive.parrotsec.org/parrot/ /opt/mirrors/ftp/parrot

--- a/modules/ocf_mirrors/files/project/tails/sync
+++ b/modules/ocf_mirrors/files/project/tails/sync
@@ -1,3 +1,3 @@
-#/bin/sh -eu
+#!/bin/sh -eu
 /usr/local/bin/rsync-no-vanished -rt --delete \
 	rsync://rsync.torproject.org/amnesia-archive/tails/ /opt/mirrors/ftp/tails

--- a/modules/ocf_mirrors/files/project/tanglu/sync-releases
+++ b/modules/ocf_mirrors/files/project/tanglu/sync-releases
@@ -1,4 +1,4 @@
-#/bin/dash
+#!/bin/dash
 # source: https://wiki.ubuntu.com/Mirrors/Scripts (2014-08-11)
 # modified by OCF to use rsync-no-vanished
 

--- a/modules/ocf_mirrors/files/project/ubuntu/sync-releases
+++ b/modules/ocf_mirrors/files/project/ubuntu/sync-releases
@@ -1,4 +1,4 @@
-#/bin/dash
+#!/bin/dash
 # source: https://wiki.ubuntu.com/Mirrors/Scripts (2014-08-11)
 # modified by OCF to use rsync-no-vanished
 


### PR DESCRIPTION
Pretty hilarious that we copy-pasted '#/bin/sh` everywhere and never noticed. I'm pretty sure it originated from copying from the Ubuntu wiki: https://wiki.ubuntu.com/Mirrors/Scripts#The_script

Somehow it works... but we should probably use a proper shebang anyway :)