### PR TITLE
Add report-sizes script to mirrors

### DIFF
--- a/modules/ocf_mirrors/files/report-sizes
+++ b/modules/ocf_mirrors/files/report-sizes
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Generate a "sizes" file in /opt/mirrors/ftp for convenience of us and any
+# curious internet people.
+set -euo pipefail
+
+{
+    cd /opt/mirrors/ftp
+    find -mindepth 1 -maxdepth 1 -type d |
+        sort |
+	cut -d/ -f2 |
+	grep -vE '^\.' |
+	xargs nice ionice du -hs
+
+    echo -n 'Last updated: '
+    date
+} | sponge /opt/mirrors/ftp/sizes

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -34,7 +34,7 @@ class ocf_mirrors {
   }
 
   file {
-    ['/opt/mirrors', '/opt/mirrors/ftp', '/opt/mirrors/project']:
+    ['/opt/mirrors', '/opt/mirrors/ftp', '/opt/mirrors/project', '/opt/mirrors/bin']:
       ensure  => directory,
       mode    => '0755',
       owner   => mirrors,
@@ -155,5 +155,14 @@ class ocf_mirrors {
     ssl_key   => "/etc/ssl/private/${::fqdn}.key",
     ssl_cert  => "/etc/ssl/private/${::fqdn}.crt",
     ssl_chain => '/etc/ssl/certs/incommon-intermediate.crt',
+  }
+
+  file { '/opt/mirrors/bin/report-sizes':
+    source => 'puppet:///modules/ocf_mirrors/report-sizes',
+    mode   => '0755',
+  } ->
+  cron { 'report-sizes':
+    command => '/opt/mirrors/bin/report-sizes',
+    special => 'daily',
   }
 }


### PR DESCRIPTION
Creates this file: https://mirrors.ocf.berkeley.edu/sizes

It only takes ~30 seconds to generate, but I nice'd and ionice'd it just to be nice.