### PR TITLE
Mirror Qt project

### DIFF
--- a/modules/ocf_mirrors/files/project/qt/sync-archive
+++ b/modules/ocf_mirrors/files/project/qt/sync-archive
@@ -1,0 +1,3 @@
+#!/bin/sh -eu
+/usr/local/bin/rsync-no-vanished -az --delete --safe-links \
+	rsync://master.qt.io/qt-all /opt/mirrors/ftp/qt

--- a/modules/ocf_mirrors/files/rsyncd.conf
+++ b/modules/ocf_mirrors/files/rsyncd.conf
@@ -69,6 +69,10 @@ dont compress = *.gz *.tgz *.zip *.z *.rpm *.deb *.iso *.bz2 *.tbz
 	comment = puppetlabs apt mirror
 	path = /opt/mirrors/ftp/puppetlabs
 
+[qt]
+	comment = qt mirror
+	path = /opt/mirrors/ftp/qt
+
 [raspbian]
 	comment = raspbian mirror
 	path = /opt/mirrors/ftp/raspbian

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -16,6 +16,7 @@ class ocf_mirrors {
   include ocf_mirrors::manjaro
   include ocf_mirrors::parrot
   include ocf_mirrors::puppetlabs
+  include ocf_mirrors::qt
   include ocf_mirrors::raspbian
   include ocf_mirrors::tails
   include ocf_mirrors::tanglu

--- a/modules/ocf_mirrors/manifests/qt.pp
+++ b/modules/ocf_mirrors/manifests/qt.pp
@@ -1,0 +1,19 @@
+class ocf_mirrors::qt {
+  file {
+    '/opt/mirrors/project/qt':
+      ensure  => directory,
+      source  => 'puppet:///modules/ocf_mirrors/project/qt/',
+      owner   => mirrors,
+      group   => mirrors,
+      mode    => '0755',
+      recurse => true;
+  }
+
+  cron {
+    'qt':
+      command => '/opt/mirrors/project/qt/sync-archive > /dev/null',
+      user    => 'mirrors',
+      hour    => '*/4',
+      minute  => '5';
+  }
+}


### PR DESCRIPTION
After the first sync, this project comes out to a whopping 1.1TB in size when we mirror *everything*. [Their wiki gives multiple, contradicting, and completely wrong values for this size](https://wiki.qt.io/Mirror_howto), which makes me think the project is ballooning rapidly in size---not a good sign.

Still, we did agree that it will be helpful to mirror this project, and we will be the first bay area mirror. Since we already downloaded it all, I think we may as well mirror it for now; if it really does get to be even more huge, we can mirror only official and development releases at a third the size.