### PR TITLE
Staff ZNC server

### DIFF
--- a/modules/ocf_backups/files/rsnapshot.conf
+++ b/modules/ocf_backups/files/rsnapshot.conf
@@ -73,4 +73,6 @@ backup	ocfbackups@rancid:/var/lib/rancid/	servers/rancid/
 
 backup	ocfbackups@ns:/etc/bind/keys/	servers/ns/
 
+backup	ocfbackups@irc:/var/lib/znc/	servers/irc/
+
 # vim: ts=16 sts=16 sw=16 noet

--- a/modules/ocf_irc/files/znc.service
+++ b/modules/ocf_irc/files/znc.service
@@ -1,0 +1,9 @@
+[Service]
+ExecStart=/usr/bin/znc --foreground --datadir /var/lib/znc
+User=ocfznc
+Group=ocfznc
+Restart=always
+SyslogIdentifier=znc
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/ocf_irc/manifests/init.pp
+++ b/modules/ocf_irc/manifests/init.pp
@@ -3,6 +3,7 @@ class ocf_irc {
   include ocf_irc::ircd
   include ocf_irc::services
   include ocf_irc::nodejs::webirc
+  include ocf_irc::znc
 
   class { 'ocf_irc::nodejs::apt':
     stage => first,

--- a/modules/ocf_irc/manifests/znc.pp
+++ b/modules/ocf_irc/manifests/znc.pp
@@ -1,0 +1,28 @@
+# A minimal ZNC installation
+# All extra configuration is managed by web interface and kept in backups
+class ocf_irc::znc {
+  package { 'znc': }
+
+  user { 'ocfznc':
+    comment => 'IRC Bouncer Server',
+    groups  => [ssl-cert],
+    home    => '/var/lib/znc',
+    shell   => '/bin/false',
+    system  => true,
+    require => Package['ssl-cert'],
+  }
+
+  file {
+    '/var/lib/znc':
+      ensure  => directory,
+      owner   => ocfznc,
+      group   => ocfznc,
+      mode    => '0700',
+      require => User['ocfznc'],
+  }
+
+  ocf::systemd::service { 'znc':
+    source  => 'puppet:///modules/ocf_irc/znc.service',
+    require => [Package['znc'], File['/var/lib/znc']],
+  }
+}


### PR DESCRIPTION
The installation is very simple; all the config is living unmanaged in `/opt/znc` on flood and has to be manually managed by the web interface. Keeping it backed up should be sufficient in case we have to do a restore.