### PR TITLE
ocf_mysql: Use new innodb format, large prefixes

### DIFF
--- a/modules/ocf_mysql/files/99-ocf.cnf
+++ b/modules/ocf_mysql/files/99-ocf.cnf
@@ -25,3 +25,9 @@ innodb_buffer_pool_instances = 4
 # http://dev.mysql.com/doc/refman/5.6/en/innodb-parameters.html#sysvar_innodb_log_buffer_size
 innodb_log_buffer_size = 256M
 innodb_log_file_size = 1G
+
+# https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/#innodb_large_prefix
+# Support large prefixes by using MariaDB 10.2 defaults
+innodb_file_format = 'Barracuda'
+innodb_file_format_check = 1
+innodb_large_prefix = 1


### PR DESCRIPTION
Some software requires these features from newer MySQL versions. They're supported in MariaDB but have to be enabled in < 10.2. This won't update existing tables until they are rebuilt.