### PR TITLE
Convert rancid from cvs to git, remove dnssec logs

### DIFF
--- a/modules/ocf_ns/files/named.conf.options
+++ b/modules/ocf_ns/files/named.conf.options
@@ -49,20 +49,6 @@ options {
   listen-on-v6 { any; };
 };
 
-logging {
-  channel dnssec_log {
-    file "/var/log/dnssec" size 20m;
-    print-time yes;
-    print-category yes;
-    print-severity yes;
-    severity debug 3;
-  };
-
-  category dnssec {
-    dnssec_log;
-  };
-};
-
 // Query URIBL directly because campus nameservers are often blocked
 zone "multi.uribl.com" {
   type forward;


### PR DESCRIPTION
These are the changes I've made to pestilence on stretch, it also backs up rancid config diffs to GitHub, which is pretty nice to have, especially since it strips the password (I didn't know it did that). `rancid-run` already attempts to push to a remote when it is run, so that part doesn't have to be added like it does in the `ocf_ldap` module for GitHub backups.

I removed the `/var/log/dnssec` log because `bind9` wouldn't start without it and it didn't even seem to be logging anything, so I figured keeping it didn't make sense.