### PR TITLE
Enable PulseAudio SSH tunneling to TV

### DIFF
--- a/modules/ocf/manifests/packages/pulse.pp
+++ b/modules/ocf/manifests/packages/pulse.pp
@@ -1,5 +1,4 @@
-class ocf_desktop::pulse {
-
+class ocf::packages::pulse {
   ocf::repackage {
     # PulseAudio without recommends
     'pulseaudio':
@@ -10,7 +9,7 @@ class ocf_desktop::pulse {
       require    => Ocf::Repackage['pulseaudio'];
   }
 
-  # ALSA ultilities and PulseAudio plugin
+  # ALSA utilities and PulseAudio plugin
   package { [ 'alsa-utils', 'libasound2-plugins' ]: }
 
   # route ALSA sound through PulseAudio
@@ -18,5 +17,4 @@ class ocf_desktop::pulse {
     source  => 'puppet:///modules/ocf_desktop/asound.conf',
     require => Package['libasound2-plugins'],
   }
-
 }

--- a/modules/ocf_desktop/manifests/init.pp
+++ b/modules/ocf_desktop/manifests/init.pp
@@ -3,6 +3,7 @@ class ocf_desktop {
   include ocf::packages::chrome
   include ocf::packages::cups
   include ocf::packages::firefox
+  include ocf::packages::pulse
 
   include ocf_mesos::slave
 
@@ -12,7 +13,6 @@ class ocf_desktop {
   include ocf_desktop::grub
   include ocf_desktop::modprobe
   include ocf_desktop::packages
-  include ocf_desktop::pulse
   include ocf_desktop::sshfs
   include ocf_desktop::stats
   include ocf_desktop::steam

--- a/modules/ocf_tv/manifests/init.pp
+++ b/modules/ocf_tv/manifests/init.pp
@@ -1,4 +1,6 @@
 class ocf_tv {
+  include ocf_tv::pulse
+
   include ocf::packages::chrome
   include ocf::packages::firefox
   include ocf_desktop::drivers
@@ -11,8 +13,6 @@ class ocf_tv {
       'feh',
       'i3',
       'nodm',
-      'pavucontrol',
-      'pulseaudio',
       'vlc',
       'x11vnc',
       'xinit',

--- a/modules/ocf_tv/manifests/pulse.pp
+++ b/modules/ocf_tv/manifests/pulse.pp
@@ -1,0 +1,11 @@
+class ocf_tv::pulse {
+  include ocf::packages::pulse;
+
+  # Make pulse listen on localhost so desktops can SSH tunnel to it
+  $tcp_module = 'load-module module-native-protocol-tcp listen=127.0.0.1 port=4713 auth-anonymous=1'
+  exec { 'enable-pulse-tcp-listen':
+    command => "echo '${tcp_module}' >> /etc/pulse/default.pa",
+    unless  => "grep -q '^${tcp_module}$' /etc/pulse/default.pa",
+    require => Package['pulseaudio'],
+  }
+}


### PR DESCRIPTION
This enables connecting to Pulse via TCP on the desktops and tells Pulse
to listen for TCP connections on localhost