### PR TITLE
ocf_www: Disable Apache OPTIONS requests

### DIFF
--- a/modules/ocf_www/manifests/mod/security.pp
+++ b/modules/ocf_www/manifests/mod/security.pp
@@ -1,0 +1,6 @@
+class ocf_www::mod::security {
+  class { '::apache::mod::security':
+    # Disable OPTIONS requests, originally due to CVE-2017-9798
+    allowed_methods => 'GET HEAD POST',
+  }
+}

--- a/modules/ocf_www/manifests/mod/security.pp
+++ b/modules/ocf_www/manifests/mod/security.pp
@@ -1,6 +1,6 @@
 class ocf_www::mod::security {
   class { '::apache::mod::security':
     # Disable OPTIONS requests, originally due to CVE-2017-9798
-    allowed_methods => 'GET HEAD POST',
+    allowed_methods => 'GET HEAD POST PUT DELETE PATCH',
   }
 }

--- a/modules/ocf_www/manifests/site/www.pp
+++ b/modules/ocf_www/manifests/site/www.pp
@@ -21,6 +21,7 @@ class ocf_www::site::www {
   include ocf_www::mod::fastcgi
   include ocf_www::mod::ocfdir
   include ocf_www::mod::php
+  include ocf_www::mod::security
   include ocf_www::mod::suexec
 
   # TODO: dev-death should add a robots.txt disallowing everything


### PR DESCRIPTION
We could potentially re-enable these requests once [CVE-2017-9798](https://security-tracker.debian.org/tracker/CVE-2017-9798) is patched, but I don't see a good reason to.