### PR TITLE
Remove economode textbox from cups dialog

### DIFF
--- a/modules/ocf_printhost/templates/cups/ppd/m806.ppd.epp
+++ b/modules/ocf_printhost/templates/cups/ppd/m806.ppd.epp
@@ -62,16 +62,6 @@
 <%- } -%>
 *CloseUI: *Duplex
 
-*% Print quality
-
-*OpenUI *HPEconoMode/EconoMode: Boolean
-*OrderDependency: 18 AnySetup *HPEconoMode
-*DefaultHPEconoMode: True
-*HPEconoMode True/On: "<</EconoMode true>> setpagedevice"
-*HPEconoMode False/Off: "<</EconoMode false>> setpagedevice"
-*CloseUI: *HPEconoMode
-
-
 *%%% The rest is straight from the stock driver
 
 *ColorDevice: False


### PR DESCRIPTION
Tested on dev-whiteout-- doesn't crash cups. Based on Dara's suggestion in [rt/6568](https://rt.ocf.berkeley.edu/Ticket/Display.html?id=6568).