### PR TITLE
pdf-open default

### DIFF
--- a/modules/ocf_desktop/files/xsession/mimeapps.list
+++ b/modules/ocf_desktop/files/xsession/mimeapps.list
@@ -1,6 +1,6 @@
 [Added Associations]
-application/pdf=evince.desktop
-image/pdf=evince.desktop
+application/pdf=pdfopen.desktop
+image/pdf=pdfopen.desktop
 
 image/gif=eog.desktop
 image/png=eog.desktop

--- a/modules/ocf_desktop/files/xsession/pdf-open
+++ b/modules/ocf_desktop/files/xsession/pdf-open
@@ -1,22 +1,35 @@
-#!/bin/bash -e
-[ "$#" -ne 1 ] && { echo 'Bad arguments, trying evince...'; exec evince "$1"; }
+#!/bin/bash
+set -euo pipefail
+
+[ "$#" -ne 1 ] && { echo 'Bad arguments, trying evince...'; exec evince "$@"; }
 [ -f "$1" ] || { echo 'File does not exist, trying evince...'; exec evince "$1"; }
 
 size=$(du "$1") || { echo 'Cannot get size, trying evince...'; exec evince "$1"; }
 size=$(cut -f1 <<< "$size")
 [ "$size" -lt 5120 ] || { echo 'Too large, trying evince...'; exec evince "$1"; }
 
-echo 'Rasterizing PDF...'
-filename=$(basename $1)
-tmp="/tmp/ocf_$filename"
+len=$(pdftk "$1" dump_data | awk '/NumberOfPages/{print $2}')
+[ -z "$len" ] || [ "$len" -gt 75 ] && { echo 'Too long, trying evince...'; exec evince "$1"; }
 
-if ! convert -density 250 "$1" "$tmp" | zenity --progress --pulsate --auto-close; then
-    rm "$tmp"
+filename=$(basename "$1")
+tmpdir=$(mktemp -d)
+tmp="$tmpdir/$filename"
+
+convert -density 250 "$1" "$tmp" |
+zenity --progress \
+	--pulsate \
+	--auto-close \
+	--auto-kill \
+	--text="Rasterizing File..."
+
+if [ $? -ne 0 ]; then
+    rm -rf "$tmpdir"
     echo 'Convert failed, trying evince...'
     exec evince "$1"
 fi
 
 echo 'Done rasterizing, now opening with evince...'
-exiftool -tagsfromfile "$1" -title "$tmp"
+exiftool -tagsfromfile "$1" -title "$tmp" || true
 echo "(output file: $tmp)"
-exec evince "$tmp"
+evince "$tmp"
+rm -rf "$tmpdir"

--- a/modules/ocf_desktop/files/xsession/pdf-open
+++ b/modules/ocf_desktop/files/xsession/pdf-open
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+[ "$#" -ne 1 ] && { echo 'Bad arguments, trying evince...'; exec evince "$@"; }
+[ -f "$1" ] || { echo 'File does not exist, trying evince...'; exec evince "$@"; }
+
+size=$(du "$1") || { echo 'Cannot get size, trying evince...'; exec evince "$@"; }
+size=$(cut -f1 <<< "$size")
+[ "$size" -lt 5120 ] || { echo 'Too large, trying evince...'; exec evince "$@"; }
+
+echo 'Rasterizing PDF...'
+tmp=$(mktemp --suffix='.pdf')
+
+if ! convert -density 250 "$1" "$tmp"; then
+    rm "$tmp"
+    echo 'Convert failed, trying evince...'
+    exec evince "$@"
+fi
+
+echo 'Done rasterizing, now overwriting unrasterized version...'
+exiftool -tagsfromfile "$@" -title "$tmp"
+mv "$tmp" "$@"
+
+echo 'Opening with evince...'
+exec evince "$@"

--- a/modules/ocf_desktop/files/xsession/pdf-open
+++ b/modules/ocf_desktop/files/xsession/pdf-open
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -uo pipefail
 
 [ "$#" -ne 1 ] && { echo 'Bad arguments, trying evince...'; exec evince "$@"; }
 [ -f "$1" ] || { echo 'File does not exist, trying evince...'; exec evince "$1"; }
@@ -8,28 +8,47 @@ size=$(du "$1") || { echo 'Cannot get size, trying evince...'; exec evince "$1";
 size=$(cut -f1 <<< "$size")
 [ "$size" -lt 5120 ] || { echo 'Too large, trying evince...'; exec evince "$1"; }
 
-len=$(pdftk "$1" dump_data | awk '/NumberOfPages/{print $2}')
-[ -z "$len" ] || [ "$len" -gt 75 ] && { echo 'Too long, trying evince...'; exec evince "$1"; }
+ft=$(file -b "$1")
+ft=$(cut -d ' ' -f1 <<< "$ft")
+ft="${ft,,}"
+
+if [ "$ft" == "pdf" ]; then
+    len=$(pdftk "$1" dump_data | awk '/NumberOfPages/{print $2}')
+    [ -z "$len" -o "$len" -gt 75 ] && { echo 'Too long, trying evince...'; exec evince "$1"; }
+fi
 
 filename=$(basename "$1")
 tmpdir=$(mktemp -d)
 tmp="$tmpdir/$filename"
 
-convert -density 250 "$1" "$tmp" |
-zenity --progress \
-	--pulsate \
-	--auto-close \
-	--auto-kill \
-	--text="Rasterizing File..."
+trap 'rm -rf "$tmpdir"' EXIT
 
-if [ $? -ne 0 ]; then
-    rm -rf "$tmpdir"
+(
+    # Because Zenity ...
+    function clean_up {
+        [ -n "$(jobs -pr)" ] && kill $(jobs -pr)
+    }
+
+    trap clean_up EXIT
+
+    convert -density 250 "$1" "$tmp" |
+    zenity --progress \
+    	--pulsate \
+    	--auto-close \
+    	--auto-kill \
+    	--text="Rasterizing File..."
+)
+
+if [ $? -eq 129 ]; then
+    echo 'Rasterization cancelled... Quitting.'
+    exit
+elif [ $? -ne 0 ]; then
     echo 'Convert failed, trying evince...'
-    exec evince "$1"
+    evince "$1"
+    exit
 fi
 
 echo 'Done rasterizing, now opening with evince...'
-exiftool -tagsfromfile "$1" -title "$tmp" || true
+exiftool -tagsfromfile "$1" -title "$tmp"
 echo "(output file: $tmp)"
 evince "$tmp"
-rm -rf "$tmpdir"

--- a/modules/ocf_desktop/files/xsession/pdf-open
+++ b/modules/ocf_desktop/files/xsession/pdf-open
@@ -1,23 +1,22 @@
 #!/bin/bash -e
-[ "$#" -ne 1 ] && { echo 'Bad arguments, trying evince...'; exec evince "$@"; }
-[ -f "$1" ] || { echo 'File does not exist, trying evince...'; exec evince "$@"; }
+[ "$#" -ne 1 ] && { echo 'Bad arguments, trying evince...'; exec evince "$1"; }
+[ -f "$1" ] || { echo 'File does not exist, trying evince...'; exec evince "$1"; }
 
-size=$(du "$1") || { echo 'Cannot get size, trying evince...'; exec evince "$@"; }
+size=$(du "$1") || { echo 'Cannot get size, trying evince...'; exec evince "$1"; }
 size=$(cut -f1 <<< "$size")
-[ "$size" -lt 5120 ] || { echo 'Too large, trying evince...'; exec evince "$@"; }
+[ "$size" -lt 5120 ] || { echo 'Too large, trying evince...'; exec evince "$1"; }
 
 echo 'Rasterizing PDF...'
-tmp=$(mktemp --suffix='.pdf')
+filename=$(basename $1)
+tmp="/tmp/ocf_$filename"
 
-if ! convert -density 250 "$1" "$tmp"; then
+if ! convert -density 250 "$1" "$tmp" | zenity --progress --pulsate --auto-close; then
     rm "$tmp"
     echo 'Convert failed, trying evince...'
-    exec evince "$@"
+    exec evince "$1"
 fi
 
-echo 'Done rasterizing, now overwriting unrasterized version...'
-exiftool -tagsfromfile "$@" -title "$tmp"
-mv "$tmp" "$@"
-
-echo 'Opening with evince...'
-exec evince "$@"
+echo 'Done rasterizing, now opening with evince...'
+exiftool -tagsfromfile "$1" -title "$tmp"
+echo "(output file: $tmp)"
+exec evince "$tmp"

--- a/modules/ocf_desktop/files/xsession/pdfopen.desktop
+++ b/modules/ocf_desktop/files/xsession/pdfopen.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Document Viewer
+Comment=Evince wrapper so that pdfs are properly rendered for printing
+Keywords=pdf;ps;postscript;dvi;xps;djvu;tiff;document;presentation;
+Exec=/opt/share/puppet/pdf-open %U
+Terminal=false
+Type=Application
+Icon=evince
+Categories=Viewer
+MimeType=application/pdf;application/x-bzpdf;application/x-gzpdf;application/x-xzpdf;application/x-ext-pdf;application/postscript;application/x-bzpostscript;application/x-gzpostscript;image/x-eps;image/x-bzeps;image/x-gzeps;application/x-ext-ps;application/x-ext-eps;application/x-dvi;application/x-bzdvi;application/x-gzdvi;application/x-ext-dvi;image/vnd.djvu;image/vnd.djvu+multipage;application/x-ext-djv;application/x-ext-djvu;image/tiff;application/x-cbr;application/x-cbz;application/x-cb7;application/x-ext-cbr;application/x-ext-cbz;application/vnd.comicbook+zip;application/x-ext-cb7;;application/oxps;application/vnd.ms-xpsdocument;

--- a/modules/ocf_desktop/files/xsession/pdfopen.desktop
+++ b/modules/ocf_desktop/files/xsession/pdfopen.desktop
@@ -2,7 +2,7 @@
 Name=Document Viewer
 Comment=Evince wrapper so that pdfs are properly rendered for printing
 Keywords=pdf;ps;postscript;dvi;xps;djvu;tiff;document;presentation;
-Exec=/opt/share/puppet/pdf-open %U
+Exec=/usr/local/bin/pdf-open %u
 Terminal=false
 Type=Application
 Icon=evince

--- a/modules/ocf_desktop/manifests/defaults.pp
+++ b/modules/ocf_desktop/manifests/defaults.pp
@@ -4,7 +4,7 @@ class ocf_desktop::defaults {
     source  => 'puppet:///modules/ocf_desktop/xsession/mimeapps.list';
   }
 
-  file { '/opt/share/puppet/pdf-open':
+  file { '/usr/local/bin/pdf-open':
       mode    => '0755',
       source  => 'puppet:///modules/ocf_desktop/xsession/pdf-open',
       require => Package['libimage-exiftool-perl'];
@@ -12,7 +12,7 @@ class ocf_desktop::defaults {
 
   file { '/usr/share/applications/pdfopen.desktop':
     source => 'puppet:///modules/ocf_desktop/xsession/pdfopen.desktop',
-    require => File['/opt/share/puppet/pdf-open'];
+    require => File['/usr/local/bin/pdf-open'];
   }
 
   # /etc/alternatives/
@@ -22,5 +22,4 @@ class ocf_desktop::defaults {
     }
   }
 
-  package { 'libimage-exiftool-perl':; }
 }

--- a/modules/ocf_desktop/manifests/defaults.pp
+++ b/modules/ocf_desktop/manifests/defaults.pp
@@ -4,10 +4,23 @@ class ocf_desktop::defaults {
     source  => 'puppet:///modules/ocf_desktop/xsession/mimeapps.list';
   }
 
+  file { '/opt/share/puppet/pdf-open':
+      mode    => '0755',
+      source  => 'puppet:///modules/ocf_desktop/xsession/pdf-open',
+      require => Package['libimage-exiftool-perl'];
+  }
+
+  file { '/usr/share/applications/pdfopen.desktop':
+    source => 'puppet:///modules/ocf_desktop/xsession/pdfopen.desktop',
+    require => File['/opt/share/puppet/pdf-open'];
+  }
+
   # /etc/alternatives/
   if $::lsbdistcodename == 'jessie' {
     exec { 'update-alternatives --set x-terminal-emulator /usr/bin/xfce4-terminal.wrapper':
       unless => '/usr/bin/test $(readlink /etc/alternatives/x-terminal-emulator) == "/usr/bin/xfce4-terminal.wrapper"';
     }
   }
+
+  package { 'libimage-exiftool-perl':; }
 }

--- a/modules/ocf_desktop/manifests/defaults.pp
+++ b/modules/ocf_desktop/manifests/defaults.pp
@@ -21,5 +21,4 @@ class ocf_desktop::defaults {
       unless => '/usr/bin/test $(readlink /etc/alternatives/x-terminal-emulator) == "/usr/bin/xfce4-terminal.wrapper"';
     }
   }
-
 }

--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -19,6 +19,8 @@ class ocf_desktop::packages {
     # desktop
     ['desktop-base', 'anacron', 'accountsservice', 'desktop-file-utils',
       'redshift', 'xfce4-whiskermenu-plugin']:;
+    # desktop helpers
+    ['libimage-exiftool-perl']:;
     # display manager
     ['lightdm', 'lightdm-gtk-greeter', 'libpam-trimspaces']:;
     # fonts


### PR DESCRIPTION
As requested by @sahilhasan, uses a modified version of @chriskuehl's pdf-open script (https://github.com/ocf/utils/blob/master/desktop/pdf-open) to be the default for pdf, ps, and related file types. This is to reduce printing issues detailed in ticket 4839 on RT. I moved the script from utils to puppet because, as the default, there is no point in executing it in a terminal. The modifications to the original script address the issue where the filename and title take that of the temp file, which may confuse some people. 