### PR TITLE
Add Let's Encrypt interface and use for www/apps

### DIFF
--- a/hieradata/nodes/meltdown.yaml
+++ b/hieradata/nodes/meltdown.yaml
@@ -1,5 +1,4 @@
 classes:
-    - ocf_ssl::default_bundle
     - ocf::lets_encrypt
     - ocf::packages::docker
 

--- a/hieradata/nodes/meltdown.yaml
+++ b/hieradata/nodes/meltdown.yaml
@@ -1,5 +1,6 @@
 classes:
     - ocf_ssl::default_bundle
+    - ocf::lets_encrypt
     - ocf::packages::docker
 
 owner: mattmcal

--- a/modules/ocf/files/ssl/ocf-lets-encrypt
+++ b/modules/ocf/files/ssl/ocf-lets-encrypt
@@ -1,23 +1,22 @@
 #!/usr/bin/env python3
 """Update or acquire Let's Encrypt certificates for a host.
 
-This script is triggered every time Puppet runs with the certs needed by
-the host in the arguments. It is also triggered by other scripts, e.g.
+This script is triggered every time Puppet runs with the host's domain
+name(s) in the arguments. It is also triggered by other scripts, e.g.
 the Let's Encrypt scripts for vhosts on www and apphost.
 
 The script takes the following basic steps to acquire a certificate:
 
-    1. Checks whether we have already acquired a certificate in the past
-       for this domain.
+    1. Checks if we have already acquired this certificate in the past.
 
     2. If we already have a cert, further checks the expiration date to
        see if it is expired or going to expire within a few weeks.
 
     3. If the answer to (1) or (2) is "no", we invoke acme-tiny to
-       acquire/renew a cert for the domain.
+       acquire/renew the cert.
 
 Sounds simple enough? Well, there's more to it. acme-tiny proves that we
-actually own the domain by writing a challenge file and expecting it to
+actually own the domains by writing a challenge file and expecting it to
 be served under http://<fqdn>/.well-known/acme-challenge/. This presents
 two problems: 1) on hosts that don't run a web server (e.g. mail), we
 need something to serve that file, and 2) on hosts that do run a web
@@ -51,19 +50,17 @@ The return code indicates whether the script did anything, so the caller
 can reload services as necessary:
 
     0       nothing changed
-    255     certs added/changed
+    255     cert renewed/acquired
     else    error
 """
 import argparse
 import functools
 import os
 import re
-import shutil
 import socket
 import subprocess
 import sys
 import tempfile
-from collections import namedtuple
 from contextlib import contextmanager
 from datetime import datetime
 from datetime import timedelta
@@ -71,16 +68,13 @@ from datetime import timezone
 from pathlib import Path
 
 import dateutil.parser
+from OpenSSL import crypto
 
 
 RENEW_WHEN_TIME_REMAINING = timedelta(days=45)
 
-DEFAULT_CERT_STORAGE_DIR = '/etc/ssl/private/'
 LE_ACCOUNT_KEY = Path('/etc/ssl/lets-encrypt/le-account.key')
 ACME_BASE_DIR = Path('/var/lib/lets-encrypt/')
-
-
-Request = namedtuple('Request', ('domain', 'cert_path', 'has_cert'))
 
 
 def debug(*args, **kwargs):
@@ -88,32 +82,48 @@ def debug(*args, **kwargs):
 
 
 def expiration_date(cert_path):
-    output = subprocess.check_output((
-        'openssl', 'x509', '-enddate', '-noout',
-        '-in', str(cert_path),
-    ))
-    m = re.match(b'notAfter=(.+)$', output)
-    assert m, output
-    return dateutil.parser.parse(m.group(1).decode('ascii'))
+    with cert_path.open('rb') as f:
+        cert = crypto.load_certificate(crypto.FILETYPE_PEM, f.read())
+    return dateutil.parser.parse(cert.get_notAfter())
+
+
+def cert_status(cert_path):
+    if cert_path.exists():
+        expires = expiration_date(cert_path)
+        time_remaining = expires - datetime.now(timezone.utc)
+        if time_remaining > RENEW_WHEN_TIME_REMAINING:
+            return False, time_remaining
+        else:
+            return True, time_remaining
+    else:
+        return True, None
 
 
 @contextmanager
-def make_csr(domain, key):
-    _, csr_path = tempfile.mkstemp()
-    try:
-        subprocess.check_call((
-            'openssl', 'req', '-new', '-sha256',
-            '-key', key,
-            '-subj', '/CN={}'.format(domain),
-            '-out', csr_path,
-        ))
-        yield csr_path
-    finally:
-        os.remove(csr_path)
+def make_csr(domains, key_path):
+    req = crypto.X509Req()
+    req.get_subject().CN = domains[0]
+
+    with open(key_path, 'rt') as f:
+        key = crypto.load_privatekey(crypto.FILETYPE_PEM, f.read())
+        req.set_pubkey(key)
+
+    req.add_extensions((crypto.X509Extension(
+        b'subjectAltName',
+        False,
+        bytes(', '.join('DNS:' + domain for domain in domains), encoding='ascii'),
+    ),))
+
+    req.sign(key, 'sha256')
+
+    with tempfile.NamedTemporaryFile() as csr:
+        csr.write(crypto.dump_certificate_request(crypto.FILETYPE_PEM, req))
+        csr.flush()
+        yield csr.name
 
 
-def acme_tiny(domain, key):
-    with make_csr(domain, key) as csr_path:
+def acme_tiny(domains, key_path):
+    with make_csr(domains, key_path) as csr_path:
         # TODO: use subprocess.run when we get python3.5
         proc = subprocess.Popen(
             (
@@ -131,41 +141,39 @@ def acme_tiny(domain, key):
 
 
 def write_cert(cert, cert_path):
-    """Write certificate file for a domain."""
-    _, temp_cert_path = tempfile.mkstemp(dir=str(cert_path.parent), prefix='.tmp')
-    try:
-        with open(temp_cert_path, 'wb') as f:
-            f.write(cert)
-        # atomic overwrite in case of errors
-        os.chmod(temp_cert_path, 0o644)
-        shutil.move(temp_cert_path, str(cert_path))
-    finally:
+    """Write certificate file."""
+    with tempfile.NamedTemporaryFile(
+        dir=str(cert_path.parent),
+        prefix='.tmp',
+        delete=False,
+    ) as temp_cert:
         try:
-            os.remove(temp_cert_path)
-        except FileNotFoundError:
-            pass
+            temp_cert.write(cert)
+            # atomic overwrite in case of errors
+            os.chmod(temp_cert.name, 0o644)
+            os.rename(temp_cert.name, str(cert_path))
+        finally:
+            try:
+                os.remove(temp_cert.name)
+            except FileNotFoundError:
+                pass
 
 
-def acquire(request, key, dry_run=False):
+def make_request(domains, cert_path, key, dry_run=False):
     """Makes a Let's Encrypt certificate request."""
+    for domain in domains:
+        assert re.match(r'^[a-z\-_\.0-9]+$', domain)
     if not dry_run:
         try:
-            cert, stderr, returncode = acme_tiny(request.domain, key)
+            cert, stderr, returncode = acme_tiny(domains, key)
             assert returncode == 0, returncode
-            write_cert(cert, request.cert_path)
-            if request.has_cert:
-                print('cert renewed for: ' + request.domain)
-            else:
-                print('cert acquired for: ' + request.domain)
-            return True
+            write_cert(cert, cert_path)
         except:
             print('An error occured!', file=sys.stderr)
             print('stderr from acme-tiny:', file=sys.stderr)
             for line in stderr.decode().split('\n'):
                 print('>', line, file=sys.stderr)
             raise
-    else:
-        return False
 
 
 @contextmanager
@@ -183,7 +191,14 @@ def maybe_start_webserver(dry_run):
         yield proc
 
         proc.terminate()
-        print('Stopped ephemeral web server on port 80')
+        try:
+            proc.communicate(timeout=10)
+            print('Stopped ephemeral web server on port 80')
+        except:
+            # Might not be possible, but kill and quit noisily just in case
+            proc.kill()
+            print('Force-stopped ephemeral web server on port 80')
+            raise
     else:
         yield None
 
@@ -191,25 +206,32 @@ def maybe_start_webserver(dry_run):
 def main():
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument('-n', '--dry-run', action='store_true')
     parser.add_argument('-v', '--verbose', action='store_true')
     parser.add_argument(
-        '--private-key',
-        required=True,
-        help='Path to the private SSL key to use in certificate requests',
+        '--extended-return-codes',
+        action='store_true',
+        help='Use extended return codes:\n'
+             '    254     cert renewed\n'
+             '    255     cert acquired',
     )
     parser.add_argument(
-        '--cert-dir',
-        default=DEFAULT_CERT_STORAGE_DIR,
-        help='Where to find and store acquired cert files. '
-             'Defaults to ' + DEFAULT_CERT_STORAGE_DIR,
+        '--private-key',
+        required=True,
+        help='Path to the private SSL key for the cert.',
+    )
+    parser.add_argument(
+        '--cert',
+        required=True,
+        help='Path to find and store the acquired cert.',
     )
     parser.add_argument(
         'domains',
         nargs='+',
-        help='List of domains to acquire/renew certs for',
+        help='List of domains the cert should have on it. '
+             'The first name will become the subject common name.',
     )
     args = parser.parse_args()
 
@@ -217,36 +239,22 @@ def main():
         global debug
         debug = functools.partial(print, flush=True)
 
-    requests = set()
-    for domain in args.domains:
-        assert re.match('^[a-z\-_\.0-9]+$', domain)
-        cert_path = Path(args.cert_dir) / '{}.crt'.format(domain)
-
-        if cert_path.exists():
-            expires = expiration_date(cert_path)
-            time_remaining = expires - datetime.now(timezone.utc)
-            if time_remaining > RENEW_WHEN_TIME_REMAINING:
-                debug('not renewing {} (remaining: {})'.format(domain, time_remaining))
-            else:
-                debug('renewing {} (remaining: {})'.format(domain, time_remaining))
-                requests.add(Request(domain, cert_path, has_cert=True))
-        else:
-            requests.add(Request(domain, cert_path, has_cert=False))
-
-    if requests:
+    cert_path = Path(args.cert)
+    needs_replaced, time_remaining = cert_status(cert_path)
+    if needs_replaced:
         with maybe_start_webserver(dry_run=args.dry_run):
-            for request in requests:
-                acquire(
-                    request,
-                    key=args.private_key,
-                    dry_run=args.dry_run,
-                )
+            if time_remaining:
+                print('Renewing {} (remaining: {})'.format(cert_path.name, time_remaining))
+                ret = 254
+            else:
+                print('Acquiring {}'.format(cert_path.name))
+                ret = 255
 
-    need_cert = {request for request in requests if not request.has_cert}
-    debug('Want cert: {}'.format(len(need_cert)))
-    debug('Already have cert: {}'.format(len(args.domains) - len(need_cert)))
-
-    return 255 if requests else 0
+            make_request(args.domains, cert_path, args.private_key, args.dry_run)
+            return ret if args.extended_return_codes else 255
+    else:
+        debug('Not renewing {} (remaining: {})'.format(cert_path.name, time_remaining))
+        return 0
 
 
 if __name__ == '__main__':

--- a/modules/ocf/files/ssl/ocf-lets-encrypt
+++ b/modules/ocf/files/ssl/ocf-lets-encrypt
@@ -63,6 +63,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+from collections import namedtuple
 from contextlib import contextmanager
 from datetime import datetime
 from datetime import timedelta
@@ -77,6 +78,9 @@ RENEW_WHEN_TIME_REMAINING = timedelta(days=45)
 DEFAULT_CERT_STORAGE_DIR = '/etc/ssl/private/'
 LE_ACCOUNT_KEY = Path('/etc/ssl/lets-encrypt/le-account.key')
 ACME_BASE_DIR = Path('/var/lib/lets-encrypt/')
+
+
+Request = namedtuple('Request', ('domain', 'cert_path', 'has_cert'))
 
 
 def debug(*args, **kwargs):
@@ -142,30 +146,17 @@ def write_cert(cert, cert_path):
             pass
 
 
-def maybe_acquire(domain, cert_path, key, dry_run=False):
-    """Acquires/renews a cert for the given domain if necessary and
-    returns True if it did."""
-    renewing = False
-    if cert_path.exists():
-        renewing = True
-
-        expires = expiration_date(cert_path)
-        time_remaining = expires - datetime.now(timezone.utc)
-        if time_remaining > RENEW_WHEN_TIME_REMAINING:
-            debug('not renewing {} (remaining: {})'.format(domain, time_remaining))
-            return False
-        else:
-            debug('renewing {} (remaining: {})'.format(domain, time_remaining))
-
+def acquire(request, key, dry_run=False):
+    """Makes a Let's Encrypt certificate request."""
     if not dry_run:
         try:
-            cert, stderr, returncode = acme_tiny(domain, key)
+            cert, stderr, returncode = acme_tiny(request.domain, key)
             assert returncode == 0, returncode
-            write_cert(cert, cert_path)
-            if renewing:
-                print('cert renewed for: ' + domain)
+            write_cert(cert, request.cert_path)
+            if request.has_cert:
+                print('cert renewed for: ' + request.domain)
             else:
-                print('cert acquired for: ' + domain)
+                print('cert acquired for: ' + request.domain)
             return True
         except:
             print('An error occured!', file=sys.stderr)
@@ -226,27 +217,36 @@ def main(argv=None):
         global debug
         debug = functools.partial(print, flush=True)
 
-    changed = False
-    need_cert = set()
-    with maybe_start_webserver(dry_run=args.dry_run):
-        for domain in args.domains:
-            assert re.match('^[a-z\-_\.0-9]+$', domain)
-            cert_path = Path(args.cert_dir) / '{}.crt'.format(domain)
+    requests = set()
+    for domain in args.domains:
+        assert re.match('^[a-z\-_\.0-9]+$', domain)
+        cert_path = Path(args.cert_dir) / '{}.crt'.format(domain)
 
-            if not cert_path.exists():
-                need_cert.add(domain)
+        if cert_path.exists():
+            expires = expiration_date(cert_path)
+            time_remaining = expires - datetime.now(timezone.utc)
+            if time_remaining > RENEW_WHEN_TIME_REMAINING:
+                debug('not renewing {} (remaining: {})'.format(domain, time_remaining))
+            else:
+                debug('renewing {} (remaining: {})'.format(domain, time_remaining))
+                requests.add(Request(domain, cert_path, has_cert=True))
+        else:
+            requests.add(Request(domain, cert_path, has_cert=False))
 
-            changed |= maybe_acquire(
-                domain,
-                cert_path,
-                key=args.private_key,
-                dry_run=args.dry_run
-            )
+    if requests:
+        with maybe_start_webserver(dry_run=args.dry_run):
+            for request in requests:
+                acquire(
+                    request,
+                    key=args.private_key,
+                    dry_run=args.dry_run,
+                )
 
+    need_cert = {request for request in requests if not request.has_cert}
     debug('Want cert: {}'.format(len(need_cert)))
     debug('Already have cert: {}'.format(len(args.domains) - len(need_cert)))
 
-    return 255 if changed else 0
+    return 255 if requests else 0
 
 
 if __name__ == '__main__':

--- a/modules/ocf/files/ssl/ocf-lets-encrypt
+++ b/modules/ocf/files/ssl/ocf-lets-encrypt
@@ -178,17 +178,17 @@ def maybe_start_webserver(dry_run):
 
         # Wait for server to start up before proceeding
         while socket.socket().connect_ex(('127.0.0.1', 80)) != 0:
-            pass
+            assert proc.poll() is None, proc.returncode
 
         yield proc
 
-        proc.kill()
+        proc.terminate()
         print('Stopped ephemeral web server on port 80')
     else:
         yield None
 
 
-def main(argv=None):
+def main():
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/modules/ocf/files/ssl/ocf-lets-encrypt
+++ b/modules/ocf/files/ssl/ocf-lets-encrypt
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Update or acquire Let's Encrypt certificates for a host.
+
+This script is triggered every time Puppet runs with the certs needed by
+the host in the arguments. It is also triggered by other scripts, e.g.
+the Let's Encrypt scripts for vhosts on www and apphost.
+
+The script takes the following basic steps to acquire a certificate:
+
+    1. Checks whether we have already acquired a certificate in the past
+       for this domain.
+
+    2. If we already have a cert, further checks the expiration date to
+       see if it is expired or going to expire within a few weeks.
+
+    3. If the answer to (1) or (2) is "no", we invoke acme-tiny to
+       acquire/renew a cert for the domain.
+
+Sounds simple enough? Well, there's more to it. acme-tiny proves that we
+actually own the domain by writing a challenge file and expecting it to
+be served under http://<fqdn>/.well-known/acme-challenge/. This presents
+two problems: 1) on hosts that don't run a web server (e.g. mail), we
+need something to serve that file, and 2) on hosts that do run a web
+server, we may need to acquire the cert before the web server can even
+start.
+
+Our solution is to enforce the following assumption: if there is a
+running web server, it MUST serve up the challenge directory at
+http://<fqdn>/.well-known/acme-challenge. This simplifies our logic to
+the following:
+
+    1. If there's something already listening on port 80, just make any
+       needed certificate requests and expect them to succeed; the
+       running web server will handle it.
+
+    2. If not, then we're either bootstrapping or the host doesn't run a
+       web server. In this case, we start a temporary server (Python's
+       http.server) to serve the challenge files while making requests
+       and shut it down when we're finished.
+
+It is also possible for us to hit our rate limit for Let's Encrypt
+requests, but our limit as of writing is 1000 new certs per week with
+unlimited renewals, so this is only possible in case of catastrophic
+failure (i.e. we lose all of our web vhost certs).
+
+Once the needed certs are acquired, the corresponding .pem and .bundle
+files still have to be generated. This is left to the caller, i.e.
+puppet or a host-specific script.
+
+The return code indicates whether the script did anything, so the caller
+can reload services as necessary:
+
+    0       nothing changed
+    255     certs added/changed
+    else    error
+"""
+import argparse
+import functools
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from pathlib import Path
+
+import dateutil.parser
+
+
+RENEW_WHEN_TIME_REMAINING = timedelta(days=45)
+
+DEFAULT_CERT_STORAGE_DIR = '/etc/ssl/private/'
+LE_ACCOUNT_KEY = Path('/etc/ssl/lets-encrypt/le-account.key')
+ACME_BASE_DIR = Path('/var/lib/lets-encrypt/')
+
+
+def debug(*args, **kwargs):
+    pass
+
+
+def expiration_date(cert_path):
+    output = subprocess.check_output((
+        'openssl', 'x509', '-enddate', '-noout',
+        '-in', str(cert_path),
+    ))
+    m = re.match(b'notAfter=(.+)$', output)
+    assert m, output
+    return dateutil.parser.parse(m.group(1).decode('ascii'))
+
+
+@contextmanager
+def make_csr(domain, key):
+    _, csr_path = tempfile.mkstemp()
+    try:
+        subprocess.check_call((
+            'openssl', 'req', '-new', '-sha256',
+            '-key', key,
+            '-subj', '/CN={}'.format(domain),
+            '-out', csr_path,
+        ))
+        yield csr_path
+    finally:
+        os.remove(csr_path)
+
+
+def acme_tiny(domain, key):
+    with make_csr(domain, key) as csr_path:
+        # TODO: use subprocess.run when we get python3.5
+        proc = subprocess.Popen(
+            (
+                'acme-tiny',
+                '--account-key', str(LE_ACCOUNT_KEY),
+                '--csr', csr_path,
+                '--acme-dir', str(ACME_BASE_DIR / '.well-known' / 'acme-challenge'),
+                # '--ca', 'https://acme-staging.api.letsencrypt.org',
+            ),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = proc.communicate()
+    return stdout, stderr, proc.returncode
+
+
+def write_cert(cert, cert_path):
+    """Write certificate file for a domain."""
+    _, temp_cert_path = tempfile.mkstemp(dir=str(cert_path.parent), prefix='.tmp')
+    try:
+        with open(temp_cert_path, 'wb') as f:
+            f.write(cert)
+        # atomic overwrite in case of errors
+        os.chmod(temp_cert_path, 0o644)
+        shutil.move(temp_cert_path, str(cert_path))
+    finally:
+        try:
+            os.remove(temp_cert_path)
+        except FileNotFoundError:
+            pass
+
+
+def maybe_acquire(domain, cert_path, key, dry_run=False):
+    """Acquires/renews a cert for the given domain if necessary and
+    returns True if it did."""
+    renewing = False
+    if cert_path.exists():
+        renewing = True
+
+        expires = expiration_date(cert_path)
+        time_remaining = expires - datetime.now(timezone.utc)
+        if time_remaining > RENEW_WHEN_TIME_REMAINING:
+            debug('not renewing {} (remaining: {})'.format(domain, time_remaining))
+            return False
+        else:
+            debug('renewing {} (remaining: {})'.format(domain, time_remaining))
+
+    if not dry_run:
+        try:
+            cert, stderr, returncode = acme_tiny(domain, key)
+            assert returncode == 0, returncode
+            write_cert(cert, cert_path)
+            if renewing:
+                print('cert renewed for: ' + domain)
+            else:
+                print('cert acquired for: ' + domain)
+            return True
+        except:
+            print('An error occured!', file=sys.stderr)
+            print('stderr from acme-tiny:', file=sys.stderr)
+            for line in stderr.decode().split('\n'):
+                print('>', line, file=sys.stderr)
+            raise
+    else:
+        return False
+
+
+@contextmanager
+def maybe_start_webserver(dry_run):
+    if not dry_run and socket.socket().connect_ex(('127.0.0.1', 80)) != 0:
+        proc = subprocess.Popen(
+            ('python3', '-m', 'http.server', '80'),
+            cwd=str(ACME_BASE_DIR),
+        )
+
+        # Wait for server to start up before proceeding
+        while socket.socket().connect_ex(('127.0.0.1', 80)) != 0:
+            pass
+
+        yield proc
+
+        proc.kill()
+        print('Stopped ephemeral web server on port 80')
+    else:
+        yield None
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument('-n', '--dry-run', action='store_true')
+    parser.add_argument('-v', '--verbose', action='store_true')
+    parser.add_argument(
+        '--private-key',
+        required=True,
+        help='Path to the private SSL key to use in certificate requests',
+    )
+    parser.add_argument(
+        '--cert-dir',
+        default=DEFAULT_CERT_STORAGE_DIR,
+        help='Where to find and store acquired cert files. '
+             'Defaults to ' + DEFAULT_CERT_STORAGE_DIR,
+    )
+    parser.add_argument(
+        'domains',
+        nargs='+',
+        help='List of domains to acquire/renew certs for',
+    )
+    args = parser.parse_args()
+
+    if args.verbose:
+        global debug
+        debug = functools.partial(print, flush=True)
+
+    changed = False
+    need_cert = set()
+    with maybe_start_webserver(dry_run=args.dry_run):
+        for domain in args.domains:
+            assert re.match('^[a-z\-_\.0-9]+$', domain)
+            cert_path = Path(args.cert_dir) / '{}.crt'.format(domain)
+
+            if not cert_path.exists():
+                need_cert.add(domain)
+
+            changed |= maybe_acquire(
+                domain,
+                cert_path,
+                key=args.private_key,
+                dry_run=args.dry_run
+            )
+
+    debug('Want cert: {}'.format(len(need_cert)))
+    debug('Already have cert: {}'.format(len(args.domains) - len(need_cert)))
+
+    return 255 if changed else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/modules/ocf/manifests/lets_encrypt.pp
+++ b/modules/ocf/manifests/lets_encrypt.pp
@@ -1,5 +1,5 @@
 class ocf::lets_encrypt {
-  package { 'acme-tiny':; }
+  package { ['acme-tiny', 'python3-openssl']:; }
 
   file {
     '/etc/ssl/lets-encrypt':
@@ -21,7 +21,8 @@ class ocf::lets_encrypt {
       group  => sys;
 
     '/usr/local/bin/ocf-lets-encrypt':
-      source => 'puppet:///modules/ocf/ssl/ocf-lets-encrypt',
-      mode   => '0755';
+      source  => 'puppet:///modules/ocf/ssl/ocf-lets-encrypt',
+      mode    => '0755',
+      require => Package['acme-tiny', 'python3-openssl'];
   }
 }

--- a/modules/ocf/manifests/lets_encrypt.pp
+++ b/modules/ocf/manifests/lets_encrypt.pp
@@ -11,12 +11,17 @@ class ocf::lets_encrypt {
       show_diff => false,
       mode      => '0400';
 
-    '/srv/well-known':
-      ensure => directory;
-
-    '/srv/well-known/acme-challenge':
+    [
+      '/var/lib/lets-encrypt',
+      '/var/lib/lets-encrypt/.well-known',
+      '/var/lib/lets-encrypt/.well-known/acme-challenge',
+    ]:
       ensure => directory,
       owner  => ocfletsencrypt,
       group  => sys;
+
+    '/usr/local/bin/ocf-lets-encrypt':
+      source => 'puppet:///modules/ocf/ssl/ocf-lets-encrypt',
+      mode   => '0755';
   }
 }

--- a/modules/ocf_apphost/files/vhost-app.jinja
+++ b/modules/ocf_apphost/files/vhost-app.jinja
@@ -5,7 +5,7 @@ server {
     server_name "{{vhost.fqdn}}";
 
     location /.well-known/ {
-        alias /srv/well-known/;
+        alias /var/lib/lets-encrypt/.well-known/;
     }
 
     location / {

--- a/modules/ocf_apphost/manifests/lets_encrypt.pp
+++ b/modules/ocf_apphost/manifests/lets_encrypt.pp
@@ -4,7 +4,8 @@ class ocf_apphost::lets_encrypt {
   file {
     '/usr/local/bin/lets-encrypt-update':
       source    => 'puppet:///modules/ocf_www/lets-encrypt-update',
-      mode      => '0755';
+      mode      => '0755',
+      require   => File['/usr/local/bin/ocf-lets-encrypt'];
 
     '/etc/ssl/lets-encrypt/le-vhost.key':
       source    => 'puppet:///private/lets-encrypt-vhost.key',
@@ -17,7 +18,7 @@ class ocf_apphost::lets_encrypt {
     cron { 'lets-encrypt-update':
       command     => 'chronic /usr/local/bin/lets-encrypt-update -v app',
       user        => ocfletsencrypt,
-      environment => 'MAILTO=root',
+      environment => ['MAILTO=root', 'PATH=/bin:/usr/bin:/usr/local/bin'],
       special     => hourly,
       require     => File['/usr/local/bin/lets-encrypt-update',
                           '/etc/ssl/lets-encrypt/le-vhost.key'],

--- a/modules/ocf_apphost/manifests/proxy.pp
+++ b/modules/ocf_apphost/manifests/proxy.pp
@@ -16,7 +16,7 @@ class ocf_apphost::proxy($dev_config = false) {
       require => Package['nginx'],
       notify  => Service['nginx'];
 
-    '/usr/local/sbin/build-vhosts':
+    '/usr/local/bin/build-vhosts':
       source  => 'puppet:///modules/ocf_www/build-vhosts',
       mode    => '0755';
 
@@ -30,14 +30,14 @@ class ocf_apphost::proxy($dev_config = false) {
   }
 
   if $dev_config {
-    $build_vhosts_cmd = 'chronic /usr/local/sbin/build-vhosts --dev app'
+    $build_args = '--dev'
   } else {
-    $build_vhosts_cmd = 'chronic /usr/local/sbin/build-vhosts app'
+    $build_args = ''
   }
 
   cron {
     'build-vhosts':
-      command => $build_vhosts_cmd,
+      command => "chronic /usr/local/bin/build-vhosts ${build_args} app",
       minute  => '*/10',
       require => Package['nginx'];
   }

--- a/modules/ocf_www/files/build-vhosts
+++ b/modules/ocf_www/files/build-vhosts
@@ -200,7 +200,7 @@ def build_config(src_vhosts, template, dev_config=False):
     )
 
 
-def test_and_overwrite_config(config_path, new_config, target):
+def test_and_overwrite_config(config_path, new_config, config_test_cmd):
     """Diffs and tests the new config and overwrites the old config if
     the test passes.
 
@@ -229,7 +229,6 @@ def test_and_overwrite_config(config_path, new_config, target):
             report('[end diff]')
 
             if ret == 0:
-                report('Nothing changed, not doing anything.')
                 return False
 
             # Save existing config
@@ -240,10 +239,7 @@ def test_and_overwrite_config(config_path, new_config, target):
         os.rename(new_path, config_path)
 
         report('Performing config test.')
-        if target == 'web':
-            ret = subprocess.call(('apachectl', 'configtest'))
-        else:
-            ret = subprocess.call(('nginx', '-t'))
+        ret = subprocess.call(config_test_cmd)
 
         if ret != 0:
             report('Test failed!')
@@ -353,8 +349,12 @@ def main():
         report(config)
         return 0
 
-    changed = test_and_overwrite_config(site_cfg, config, args.target)
+    if args.target == 'web':
+        config_test_cmd = ('apachect', 'configtest')
+    else:
+        config_test_cmd = ('nginx', '-t')
 
+    changed = test_and_overwrite_config(site_cfg, config, config_test_cmd)
     if changed:
         if not args.no_reload:
             report('Things changed, reloading.')
@@ -364,6 +364,8 @@ def main():
                 subprocess.check_call(('systemctl', 'reload', 'nginx'))
         else:
             report('Not reloading, as you requested.')
+    else:
+        report('Nothing changed, not doing anything.')
 
 
 if __name__ == '__main__':

--- a/modules/ocf_www/files/build-vhosts
+++ b/modules/ocf_www/files/build-vhosts
@@ -200,7 +200,7 @@ def build_config(src_vhosts, template, dev_config=False):
     )
 
 
-def test_and_overwrite_config(config_path, new_config, config_test_cmd):
+def test_and_overwrite_config(config_path, new_config, target):
     """Diffs and tests the new config and overwrites the old config if
     the test passes.
 
@@ -239,7 +239,10 @@ def test_and_overwrite_config(config_path, new_config, config_test_cmd):
         os.rename(new_path, config_path)
 
         report('Performing config test.')
-        ret = subprocess.call(config_test_cmd)
+        if target == 'web':
+            ret = subprocess.call(('apachectl', 'configtest'))
+        else:
+            ret = subprocess.call(('nginx', '-t'))
 
         if ret != 0:
             report('Test failed!')
@@ -259,11 +262,12 @@ def test_and_overwrite_config(config_path, new_config, config_test_cmd):
 def process_app_vhosts():
     """Perform extra tasks specific to app vhosts.
 
-    This includes checking for membership in the ocfdev group, fixing
-    socket permissions, and generating SSL bundles."""
+    This includes checking for membership in the ocfdev group and fixing
+    socket permissions. Returns true if nginx should reload."""
     def groups_for_user(user):
         return (g.gr_name for g in grp.getgrall() if user in g.gr_mem)
 
+    changed = False
     for domain, vhost in get_app_vhosts().items():
         user = vhost['username']
 
@@ -287,11 +291,14 @@ def process_app_vhosts():
                 os.path.getmtime(ssl.bundle) < os.path.getmtime(ssl.cert)
             ):
                 report('Generating SSL bundle for ' + ssl.fqdn)
+                changed = True
                 with open(ssl.bundle, 'w') as f, \
                         open(ssl.cert) as f1, \
                         open(ssl.chain) as f2:
                     shutil.copyfileobj(f1, f)
                     shutil.copyfileobj(f2, f)
+
+    return changed
 
 
 def main():
@@ -327,8 +334,10 @@ def main():
     )
     args = parser.parse_args(sys.argv[1:])
 
+    changed = False
+
     if args.target == 'app' and not args.dry_run:
-        process_app_vhosts()
+        changed |= process_app_vhosts()
 
     if args.target == 'web':
         site_cfg = APACHE_SITE_CONFIG
@@ -349,12 +358,7 @@ def main():
         report(config)
         return 0
 
-    if args.target == 'web':
-        config_test_cmd = ('apachect', 'configtest')
-    else:
-        config_test_cmd = ('nginx', '-t')
-
-    changed = test_and_overwrite_config(site_cfg, config, config_test_cmd)
+    changed |= test_and_overwrite_config(site_cfg, config, args.target)
     if changed:
         if not args.no_reload:
             report('Things changed, reloading.')

--- a/modules/ocf_www/files/lets-encrypt-update
+++ b/modules/ocf_www/files/lets-encrypt-update
@@ -1,69 +1,49 @@
 #!/usr/bin/env python3
-"""Update or acquire Let's Encrypt certificates for OCF's traditional vhosts.
+"""Update or acquire Let's Encrypt certificates for OCF's traditional
+vhosts.
 
-This script is intended to be run by a cronjob. It works as follows:
+This script is intended to be run by a cronjob. All it actually does is:
 
-    1. Lists all domains that need certificates.
+    1. Fetches the list of vhost domains via ocflib.
 
-    2. For each domain, checks whether we have already acquired a ceritficate
-       in the past for this domain.
+    2. Checks the DNS to see which ones point to the right server.
 
-    3. If we already have a certificate, we check the expiration date and renew
-       it (using acme-tiny) if will expire in the next 30 days.
+    3. Passes the valid domains to ocf-lets-encrypt.
 
-    4. If we do not have a certificate, we attempt to acquire one using
-       acme-tiny.
-
-It tries to be somewhat intelligent (e.g. stops trying to acquire new certs
-when we hit the rate limit for new domains).
-
-Note that with the current rate limits, if you add lots of domains, or other
-people in *.berkeley.edu are requesting lots of certificates, it may take some
-weeks before we can acquire enough new certs.
-
-Fortunately, renewals have no rate limit, which is the only reason we can
-actually use Let's Encrypt.
+It works equally well for web and app vhosts and takes an argument to
+specify which to update.
 """
 import argparse
 import functools
-import os
-import re
-import shutil
 import subprocess
 import sys
-import tempfile
-from contextlib import contextmanager
-from datetime import datetime
-from datetime import timedelta
-from datetime import timezone
 from itertools import chain
-from pathlib import Path
 
-import dateutil.parser
 import dns.resolver
 from ocflib.vhost.application import get_app_vhosts
 from ocflib.vhost.web import get_vhosts
-
-
-RENEW_WHEN_TIME_REMAINING = timedelta(days=45)
-
-CERT_STORAGE_DIR = Path('/services/http/ssl/')
-LE_ACCOUNT_KEY = Path('/etc/ssl/lets-encrypt/le-account.key')
-LE_VHOST_KEY = Path('/etc/ssl/lets-encrypt/le-vhost.key')
-
-rate_limit_hit = set()
 
 
 def debug(*args, **kwargs):
     pass
 
 
-def eligible_domains(target):
-    """Return domains that should have certificates.
+def all_domains(vhosts):
+    """Get all domains being hosted from the list of vhosts.
 
     This includes:
       * base virtual host domains
       * aliases which redirect to the base domain
+    """
+    return (
+        set(vhosts.keys()) |
+        set(chain.from_iterable(vhost.get('aliases', [])
+                                for vhost in vhosts.values()))
+    )
+
+
+def eligible_domains(domains, target_domain):
+    """Picks out the domains which we can get certs for.
 
     We check that the domains appear to be served by us (in particular,
     we check public DNS to see whether they seem to point to the right
@@ -81,24 +61,15 @@ def eligible_domains(target):
             if answers:
                 return str(answers[0])
 
-    ip = resolve(
-        'death.ocf.berkeley.edu' if target == 'web' else
-        'werewolves.ocf.berkeley.edu'
-    )
+    ip = resolve(target_domain)
 
-    vhosts = get_vhosts() if target == 'web' else get_app_vhosts()
-    all_domains = (
-        set(vhosts.keys()) |
-        set(chain.from_iterable(vhost.get('aliases', [])
-                                for vhost in vhosts.values()))
-    )
     eligible_domains = {
         domain
-        for domain in all_domains
+        for domain in domains
         if resolve(domain) == ip
     }
 
-    bad_domains = all_domains - eligible_domains
+    bad_domains = domains - eligible_domains
     if bad_domains:
         debug('Excluded {} domains for bad DNS:\n    {}'.format(
             len(bad_domains),
@@ -108,136 +79,6 @@ def eligible_domains(target):
         debug('Did not exclude any domains for bad DNS.')
 
     return eligible_domains
-
-
-def expiration_date(cert_path):
-    output = subprocess.check_output((
-        'openssl', 'x509', '-enddate', '-noout',
-        '-in', str(cert_path),
-    ))
-    m = re.match(b'notAfter=(.+)$', output)
-    assert m, output
-    return dateutil.parser.parse(m.group(1).decode('ascii'))
-
-
-@contextmanager
-def make_csr(domain):
-    _, csr_path = tempfile.mkstemp()
-    try:
-        subprocess.check_call((
-            'openssl', 'req', '-new', '-sha256',
-            '-key', str(LE_VHOST_KEY),
-            '-subj', '/CN={}'.format(domain),
-            '-out', csr_path,
-        ))
-        yield csr_path
-    finally:
-        os.remove(csr_path)
-
-
-def acme_tiny(domain):
-    with make_csr(domain) as csr_path:
-        # TODO: use subprocess.run when we get python3.5
-        proc = subprocess.Popen(
-            (
-                'acme-tiny',
-                '--account-key', str(LE_ACCOUNT_KEY),
-                '--csr', csr_path,
-                '--acme-dir', '/srv/well-known/acme-challenge',
-                # '--ca', 'https://acme-staging.api.letsencrypt.org',
-            ),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        stdout, stderr = proc.communicate()
-    return stdout, stderr, proc.returncode
-
-
-def write_cert(cert, cert_path):
-    """Write certificate file for a domain."""
-    _, temp_cert_path = tempfile.mkstemp(dir=str(cert_path.parent), prefix='.tmp')
-    try:
-        with open(temp_cert_path, 'wb') as f:
-            f.write(cert)
-        # atomic overwrite in case of errors
-        os.chmod(temp_cert_path, 0o644)
-        shutil.move(temp_cert_path, str(cert_path))
-    finally:
-        try:
-            os.remove(temp_cert_path)
-        except FileNotFoundError:
-            pass
-
-
-def maybe_renew(domain, cert_path, dry_run=False):
-    expires = expiration_date(cert_path)
-    time_remaining = expires - datetime.now(timezone.utc)
-
-    if time_remaining > RENEW_WHEN_TIME_REMAINING:
-        debug('not renewing {} (remaining: {})'.format(domain, time_remaining))
-        return
-
-    debug('renewing {} (remaining: {})'.format(domain, time_remaining))
-    if not dry_run:
-        try:
-            cert, stderr, returncode = acme_tiny(domain)
-            assert returncode == 0, returncode
-            write_cert(cert, cert_path)
-            print('cert renewed for: {}'.format(domain))
-        except:
-            print('An error occured!', file=sys.stderr)
-            print('stderr from acme-tiny:', file=sys.stderr)
-            for line in stderr.decode().split('\n'):
-                print('>', line, file=sys.stderr)
-            raise
-
-
-def base_domain(fqdn):
-    """Return base domain (TLD+1).
-
-    >>> base_domain('ocf.berkeley.edu')
-    'berkeley.edu'
-
-    >>> base_domain('www.handbook.perspectives.modern.archive.asuc.org')
-    'asuc.org'
-    """
-    return '.'.join(fqdn.split('.')[::-1][:2][::-1])
-
-
-def maybe_acquire(domain, cert_path, dry_run=True):
-    base = base_domain(domain)
-    if base in rate_limit_hit:
-        debug('skipping {} due to rate limit on {}'.format(domain, base))
-        return
-
-    debug('acquiring {}'.format(domain))
-    if not dry_run:
-        stderr = None
-        try:
-            cert, stderr, returncode = acme_tiny(domain)
-            if returncode != 0:
-                # assume it must be a rate limit, otherwise we'll raise below
-                assert returncode == 1, returncode
-                match = re.search(
-                    b'"Error creating new cert :: Too many certificates already issued for: ([^"]+)"',
-                    stderr,
-                )
-                assert match
-                hit_for_domain = match.group(1).decode('ascii')
-                assert hit_for_domain == base, (hit_for_domain, base)
-                debug('hit rate limit for {} on {}'.format(base, domain))
-                rate_limit_hit.add(base)
-                return
-            else:
-                write_cert(cert, cert_path)
-                print('cert acquired for {}'.format(domain))
-                return
-        except:
-            print('An error occured!', file=sys.stderr)
-            print('stderr from acme-tiny:', file=sys.stderr)
-            for line in stderr.decode().split('\n'):
-                print('>', line, file=sys.stderr)
-            raise
 
 
 def main(argv=None):
@@ -254,24 +95,27 @@ def main(argv=None):
         global debug
         debug = functools.partial(print, flush=True)
 
-    eligible = eligible_domains(args.target)
-    have_cert = set()
-    need_cert = set()
-    for domain in eligible:
-        assert re.match('^[a-z\-_\.0-9]+$', domain)
-        cert_path = CERT_STORAGE_DIR / '{}.crt'.format(domain)
+    if args.target == 'web':
+        vhosts, target_domain = get_vhosts(), 'death.ocf.berkeley.edu'
+    else:
+        vhosts, target_domain = get_app_vhosts(), 'werewolves.ocf.berkeley.edu'
 
-        if cert_path.exists():
-            have_cert.add(domain)
-            maybe_renew(domain, cert_path, dry_run=args.dry_run)
-        else:
-            need_cert.add(domain)
-            maybe_acquire(domain, cert_path, dry_run=args.dry_run)
+    domains = all_domains(vhosts)
+    eligible = eligible_domains(domains, target_domain)
 
-    debug('Total domains: {}'.format(len(get_vhosts())))
+    ret = subprocess.call(chain(
+        ('ocf-lets-encrypt',),
+        ('--verbose',) if args.verbose else (),
+        ('--dry-run',) if args.dry_run else (),
+        ('--private-key', '/etc/ssl/lets-encrypt/le-vhost.key'),
+        ('--cert-dir', '/services/http/ssl/'),
+        eligible,
+    ))
+
     debug('Total eligible domains: {}'.format(len(eligible)))
-    debug('  Already have cert: {}'.format(len(have_cert)))
-    debug('  Want cert: {}'.format(len(need_cert)))
+    debug('Total domains: {}'.format(len(domains)))
+
+    return ret
 
 
 if __name__ == '__main__':

--- a/modules/ocf_www/files/lets-encrypt-update
+++ b/modules/ocf_www/files/lets-encrypt-update
@@ -81,7 +81,7 @@ def eligible_domains(domains, target_domain):
     return eligible_domains
 
 
-def main(argv=None):
+def main():
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/modules/ocf_www/files/lets-encrypt-update
+++ b/modules/ocf_www/files/lets-encrypt-update
@@ -102,20 +102,28 @@ def main():
 
     domains = all_domains(vhosts)
     eligible = eligible_domains(domains, target_domain)
+    acquired = set()
+    renewed = set()
+    for domain in eligible:
+        ret = subprocess.call(chain(
+            ('ocf-lets-encrypt', domain),
+            ('--verbose',) if args.verbose else (),
+            ('--dry-run',) if args.dry_run else (),
+            ('--extended-return-codes',),
+            ('--private-key', '/etc/ssl/lets-encrypt/le-vhost.key'),
+            ('--cert', '/services/http/ssl/{}.crt'.format(domain)),
+        ))
+        if ret == 255:
+            acquired.add(domain)
+        elif ret == 254:
+            renewed.add(domain)
+        else:
+            assert ret == 0, 'ocf-lets-encrypt returned {}'.format(ret)
 
-    ret = subprocess.call(chain(
-        ('ocf-lets-encrypt',),
-        ('--verbose',) if args.verbose else (),
-        ('--dry-run',) if args.dry_run else (),
-        ('--private-key', '/etc/ssl/lets-encrypt/le-vhost.key'),
-        ('--cert-dir', '/services/http/ssl/'),
-        eligible,
-    ))
-
-    debug('Total eligible domains: {}'.format(len(eligible)))
     debug('Total domains: {}'.format(len(domains)))
-
-    return ret
+    debug('Total eligible domains: {}'.format(len(eligible)))
+    debug('Certs acquired: {}'.format(len(acquired)))
+    debug('Certs renewed: {}'.format(len(renewed)))
 
 
 if __name__ == '__main__':

--- a/modules/ocf_www/files/vhost-web.jinja
+++ b/modules/ocf_www/files/vhost-web.jinja
@@ -49,7 +49,7 @@
         SuexecUserGroup {{vhost.user}} ocf
     {% endif %}
 
-    Alias /.well-known /srv/well-known
+    Alias /.well-known /var/lib/lets-encrypt/.well-known
 
     ServerSignature Off
 

--- a/modules/ocf_www/manifests/lets_encrypt.pp
+++ b/modules/ocf_www/manifests/lets_encrypt.pp
@@ -4,7 +4,8 @@ class ocf_www::lets_encrypt {
   file {
     '/usr/local/bin/lets-encrypt-update':
       source    => 'puppet:///modules/ocf_www/lets-encrypt-update',
-      mode      => '0755';
+      mode      => '0755',
+      require   => File['/usr/local/bin/ocf-lets-encrypt'];
 
     '/etc/ssl/lets-encrypt/le-vhost.key':
       source    => 'puppet:///private/lets-encrypt-vhost.key',
@@ -17,7 +18,7 @@ class ocf_www::lets_encrypt {
     cron { 'lets-encrypt-update':
       command     => 'chronic /usr/local/bin/lets-encrypt-update -v web',
       user        => ocfletsencrypt,
-      environment => 'MAILTO=root',
+      environment => ['MAILTO=root', 'PATH=/bin:/usr/bin:/usr/local/bin'],
       special     => hourly,
       require     => File['/usr/local/bin/lets-encrypt-update',
                           '/etc/ssl/lets-encrypt/le-vhost.key'],


### PR DESCRIPTION
Among minor bug fixes and superficial changes, this branch adds a script `ocf-lets-encrypt` which implements the interface proposed in [this doc](https://docs.google.com/document/d/1teNCynslk71N0UU-O_GiSbCMBLZkAvL8SEot4RN1U5E). It also configures `www`/`apphost` to defer acquiring certs to the script, so it will be put to use right away.

I'll provide the puppet interface for invoking the script in a subsequent PR. However, I've already used it to obtain a cert for meltdown.ocf.io with a new private key, and it was incredibly easy.

The script should be run as a cron job or by another script. In the case of `www`/`apphost`, we run it as the `ocfletsencrypt` user, but on other hosts we presumably want to run as `root:ssl-cert` and put the certs in `/etc/ssl/private`, which is the existing convention.