### PR TITLE
Set NFS grace period using the environment file.

### DIFF
--- a/modules/ocf/manifests/systemd/override.pp
+++ b/modules/ocf/manifests/systemd/override.pp
@@ -8,6 +8,7 @@
 #     ExecStart=/path/to/my/thing
 define ocf::systemd::override(
     $unit,
+    $ensure = present,
     $source = undef,
     $content = undef,
 ) {
@@ -16,6 +17,7 @@ define ocf::systemd::override(
   })
 
   file { "/etc/systemd/system/${unit}.d/${title}.conf":
+    ensure  => $ensure,
     source  => $source,
     content => $content,
     notify  => Exec['systemd-reload'],


### PR DESCRIPTION
It was a little tricky to find how to do this, but I ran `systemctl list-dependencies nfs-server`, found an `nfs-config` service which ran a script that read the files in `/etc/default` and built the environment file for `nfs-server.service`, and reading that script, found the correct option to add to `/etc/default/nfs-kernel-server`.