### PR TITLE
ocf_admin: Replace stunnel with hitch

### DIFF
--- a/modules/ocf_admin/templates/hitch.conf.erb
+++ b/modules/ocf_admin/templates/hitch.conf.erb
@@ -1,0 +1,10 @@
+frontend = {
+	host = "*"
+	port = "6378"
+}
+backend = "[127.0.0.1]:6379"
+workers = <%= @processors['count'] %>
+# This is the max keepalive supported by hitch
+keepalive = 32767
+
+pem-file = "/etc/ssl/private/<%= @fqdn %>.pem"

--- a/modules/ocf_admin/templates/stunnel/redis.conf.erb
+++ b/modules/ocf_admin/templates/stunnel/redis.conf.erb
@@ -1,5 +1,0 @@
-[redis]
-accept = 6378
-connect = /var/run/redis/redis.sock
-cert = /etc/ssl/private/<%= @fqdn %>.bundle
-key = /etc/ssl/private/<%= @fqdn %>.key


### PR DESCRIPTION
stunnel has horrible problems with leaking memory and spamming up the
logs; hitch is nice and simple and spawns way fewer worker processes