### PR TITLE
add libcrack2-dev to ocfweb::dev_config

### DIFF
--- a/modules/ocf_ocfweb/manifests/dev_config.pp
+++ b/modules/ocf_ocfweb/manifests/dev_config.pp
@@ -11,6 +11,11 @@ class ocf_ocfweb::dev_config($group = 'ocfstaff') {
   $broker = "redis://:${redis_password}@admin.ocf.berkeley.edu:6378"
   $backend = $broker
 
+
+  # installed in extrapackages but this is an dependency
+  # of the crypto libraries used in ocfweb as well
+  package { 'libcrack2-dev':; }
+
   file {
     '/etc/ocfweb':
       ensure    => directory;

--- a/modules/ocf_ocfweb/manifests/dev_config.pp
+++ b/modules/ocf_ocfweb/manifests/dev_config.pp
@@ -12,9 +12,11 @@ class ocf_ocfweb::dev_config($group = 'ocfstaff') {
   $backend = $broker
 
 
-  # installed in extrapackages but this is an dependency
-  # of the crypto libraries used in ocfweb as well
-  package { 'libcrack2-dev':; }
+  # libcrack2-dev is a dependency of the crypto libraries that
+  # ocfweb depends on, but we can't just declare the package
+  # because it conflicts with extrapackages, which is declared in
+  # ocf_admin along with this manifest (for supernova)
+  ensure_packages(['libcrack2-dev'])
 
   file {
     '/etc/ocfweb':


### PR DESCRIPTION
we ran into this problem recently with @tanx16's staffvm, where running `make venv` would fail when compiling the python crypto libraries because of a missing header file. Making it an explicit dependency for the dev config should fix that issue.