### PR TITLE
Make falsevacuum a puppetdb host for testing.

### DIFF
--- a/hieradata/nodes/falsevacuum.yaml
+++ b/hieradata/nodes/falsevacuum.yaml
@@ -1,1 +1,4 @@
+classes:
+    - ocf_puppetdb
+
 owner: bzh


### PR DESCRIPTION
I'm working on packaging [pypuppetdb](https://github.com/voxpupuli/pypuppetdb) for Debian, and some of the tests require a puppetdb instance to be running on localhost.