### PR TITLE
Add base class to fix excess classes in motds

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,5 +1,5 @@
 classes:
-    - ocf::base
+    - ocf
 
 staff_only: true
 puppet_agent: false

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,22 +1,5 @@
 classes:
-    - ocf::apt
-    - ocf::auth
-    - ocf::autologout
-    - ocf::firewall
-    - ocf::groups
-    - ocf::kerberos
-    - ocf::ldap
-    - ocf::locale
-    - ocf::motd
-    - ocf::munin::node
-    - ocf::networking
-    - ocf::packages
-    - ocf::puppet
-    - ocf::rootpw
-    - ocf::serial_getty
-    - ocf::staff_users
-    - ocf::systemd
-    - ocf::utils
+    - ocf::base
 
 staff_only: true
 puppet_agent: false

--- a/modules/ocf/manifests/base.pp
+++ b/modules/ocf/manifests/base.pp
@@ -1,0 +1,19 @@
+class ocf::base {
+  include ocf::apt
+  include ocf::auth
+  include ocf::autologout
+  include ocf::groups
+  include ocf::kerberos
+  include ocf::ldap
+  include ocf::locale
+  include ocf::motd
+  include ocf::munin::node
+  include ocf::networking
+  include ocf::packages
+  include ocf::puppet
+  include ocf::rootpw
+  include ocf::serial_getty
+  include ocf::staff_users
+  include ocf::systemd
+  include ocf::utils
+}

--- a/modules/ocf/manifests/init.pp
+++ b/modules/ocf/manifests/init.pp
@@ -1,7 +1,8 @@
-class ocf::base {
+class ocf {
   include ocf::apt
   include ocf::auth
   include ocf::autologout
+  include ocf::firewall
   include ocf::groups
   include ocf::kerberos
   include ocf::ldap


### PR DESCRIPTION
This isn't an issue as much any more since staff VMs have a single class now that is shown instead pertaining to docker groups, and they were mostly the hosts that had this problem before, but I think this would make things a bit cleaner organization-wise. This is [rt#5848](https://rt.ocf.berkeley.edu/Ticket/Display.html?id=5848).