### PR TITLE
Add aliases for SSH known hosts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
         -   --no-puppet_url_without_modules-check
         -   --no-arrow_alignment-check
         -   --no-arrow_on_right_operand_line-check
+        -   --no-variable_is_lowercase-check
 -   repo: https://github.com/pre-commit/pre-commit-hooks.git
     sha: v0.9.5
     hooks:

--- a/modules/ocf/manifests/auth.pp
+++ b/modules/ocf/manifests/auth.pp
@@ -132,11 +132,23 @@ class ocf::auth($glogin = [], $ulogin = [[]], $gsudo = [], $usudo = [], $nopassw
     require => Augeas['sshd_config'],
   }
 
+  # Get all DNS names, FQDNs, and IPs for a host to include in SSH keys
+  $ssh_aliases = delete(concat(
+    suffix(delete(any2array($::dnsA), ''), ".${::domain}"),
+    $::dnsA,
+    suffix(delete(any2array($::dnsCname), ''), ".${::domain}"),
+    $::dnsCname,
+    $::fqdn,
+    $::ipHostNumber,
+    $::ipaddress6,
+  ), '')
+
   # Export SSH keys from every host, and use them to populate the global list
   # in /etc/ssh/ssh_known_hosts
   @@sshkey { $::hostname:
-    type => ecdsa-sha2-nistp256,
-    key  => $::sshecdsakey,
+    host_aliases => $ssh_aliases,
+    key          => $::sshecdsakey,
+    type         => ecdsa-sha2-nistp256,
   }
   Sshkey <<| |>>
 


### PR DESCRIPTION
This should make it so that connecting to hosts that have been recently re-puppeted does not cause SSH host key errors.