### PR TITLE
Ocfweb printers firewall

### DIFF
--- a/modules/ocf_ocfweb/manifests/dev_config.pp
+++ b/modules/ocf_ocfweb/manifests/dev_config.pp
@@ -2,6 +2,7 @@
 # This contains suitable settings for local dev and can be used on supernova,
 # staff VMs, etc.
 class ocf_ocfweb::dev_config($group = 'ocfstaff') {
+  include ocf::firewall::output_printers
   # TODO: stop copy-pasting this everywhere
   $redis_password = hiera('create::redis::password')
   validate_re($redis_password, '^[a-zA-Z0-9]*$', 'Bad Redis password')


### PR DESCRIPTION
A fix for the new firewall rules that block staffvms from accessing printing stats.