### PR TITLE
enforcer: correctly deduct pages when printing multiple copies on double

### DIFF
--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -112,8 +112,10 @@ def read_config():
     return mysql_user, mysql_passwd
 
 
-def page_count(path):
-    return int(subprocess.check_output(('/usr/local/bin/enforcer-pc', path), timeout=30))
+def page_count(env):
+    path = env['TEADATAFILE']
+    num_copy = 1 if env['CLASS'] == 'single' else int(env['TEACOPIES'])
+    return num_copy * int(subprocess.check_output(('/usr/local/bin/enforcer-pc', path), timeout=30))
 
 
 def create_job(env):
@@ -122,7 +124,7 @@ def create_job(env):
     return quota.Job(
         user=env['TEAUSERNAME'],
         time=datetime.now(),
-        pages=page_count(env['TEADATAFILE']),
+        pages=page_count(env),
         queue=queue,
         printer=printer,
         doc_name=env['TEATITLE'],
@@ -178,7 +180,7 @@ def main(argv):
                 posthook(c, job, success)
     except SystemExit as e:
         sys.exit(e.code)
-    except:
+    except Exception:
         msg = dedent("""\
             enforcer encountered the following error while processing a job:
 
@@ -204,7 +206,7 @@ def main(argv):
                     quo or quota.UserQuota(user=job.user, daily='Unknown',
                                            semesterly='Unknown')
                 )
-            except:
+            except Exception:
                 pass
         # Don't retry; it's not going to print the second time.
         sys.exit(255)

--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -114,6 +114,7 @@ def read_config():
 
 def page_count(env):
     path = env['TEADATAFILE']
+    # When printing with single, page number is already multiplied by copy count
     num_copy = 1 if env['CLASS'] == 'single' else int(env['TEACOPIES'])
     return num_copy * int(subprocess.check_output(('/usr/local/bin/enforcer-pc', path), timeout=30))
 


### PR DESCRIPTION
Fixing an enforcer bug where printing multiple copies of a document double sided will only deduct 1 copy worth of pages.

**Repro steps:**
1. Make a 2 page document
1. Print 10 copies on single: 20 pages deducted
1. Print 10 copies on double: 2 pages deducted

When you look at the generated PostScript files, page_count() called on the single version returns 20 vs. PS output from double results in 2 (probably because they use different PostScript writers aka pdftops vs ps2write, which write different values on "Pages:" header).
In both cases, the TEACOPIES constant is set to the user-defined number of copies (10).

As a workaround, we can multiply TEACOPIES with the number returned by page_count() only when printing on double.