### PR TITLE
Shorturls to OCF code on Github

### DIFF
--- a/modules/ocf_www/manifests/site/shorturl.pp
+++ b/modules/ocf_www/manifests/site/shorturl.pp
@@ -42,6 +42,7 @@ class ocf_www::site::shorturl {
       {rewrite_rule => '^/email-update$ http://status.ocf.berkeley.edu/2014/06/email-discontinuation-update-forward.html [R]'},
       {rewrite_rule => '^/facebook$ https://goo.gl/forms/dEzJmyRMwAPWCDAY2 [R]'},
       {rewrite_rule => '^/faq$ https://www.ocf.berkeley.edu/docs/faq/ [R]'},
+      {rewrite_rule => '^/gh/([^/]*)(/(?!blob)(?!tree)(?!issue)(?!pull).+)$ https://ocf.io/gh/$1/blob/master$2 [R]'},
       {rewrite_rule => '^/gh/l(/.*)?$ https://github.com/ocf/ocflib$1 [R]'},
       {rewrite_rule => '^/gh/p(/.*)?$ https://github.com/ocf/puppet$1 [R]'},
       {rewrite_rule => '^/gh/u(/.*)?$ https://github.com/ocf/utils$1 [R]'},

--- a/modules/ocf_www/manifests/site/shorturl.pp
+++ b/modules/ocf_www/manifests/site/shorturl.pp
@@ -42,7 +42,7 @@ class ocf_www::site::shorturl {
       {rewrite_rule => '^/email-update$ http://status.ocf.berkeley.edu/2014/06/email-discontinuation-update-forward.html [R]'},
       {rewrite_rule => '^/facebook$ https://goo.gl/forms/dEzJmyRMwAPWCDAY2 [R]'},
       {rewrite_rule => '^/faq$ https://www.ocf.berkeley.edu/docs/faq/ [R]'},
-      {rewrite_rule => '^/gh/([^/]*)(/(?!blob)(?!tree)(?!issue)(?!pull).+)$ https://ocf.io/gh/$1/blob/master$2 [R]'},
+      {rewrite_rule => '^/gh/([^/]*)(/(?!blob/)(?!tree/)(?!info/)(?!issue)(?!pull).+)$ https://ocf.io/gh/$1/blob/master$2 [R]'},
       {rewrite_rule => '^/gh/l(/.*)?$ https://github.com/ocf/ocflib$1 [R]'},
       {rewrite_rule => '^/gh/p(/.*)?$ https://github.com/ocf/puppet$1 [R]'},
       {rewrite_rule => '^/gh/u(/.*)?$ https://github.com/ocf/utils$1 [R]'},


### PR DESCRIPTION
This will allow links to code on Github in the format ocf.io/gh/p/... to automatically redirect to blob/master if not already pointing there. Links to pulls and issues will not be redirected, but all other "special pages" like /pulse will redirect to project code.

I have not tested this on a staff VM, but I have tested it with .htaccess. Some examples:

ocf.io/nikitnainwal/gh/p/modules/ocf_tv/manifests/pulse.pp : redirects
ocf.io/nikitnainwal/gh/p/blob/master/modules/ocf_tv/manifests/pulse.pp : falls through
ocf.io/nikitnainwal/gh/p/modules/ocf_tv/ : redirects
ocf.io/nikitnainwal/gh/p : falls through
ocf.io/nikitnainwal/gh/l/issues : falls through