### PR TITLE
Create ocf::nginx_proxy for common proxy settings

### DIFF
--- a/modules/ocf/manifests/nginx_proxy.pp
+++ b/modules/ocf/manifests/nginx_proxy.pp
@@ -17,18 +17,20 @@ define ocf::nginx_proxy(
   $nginx_options = {},
 ) {
 
+  $base_headers = [
+    'Host $host',
+    'X-Forwarded-For $proxy_add_x_forwarded_for',
+    'X-Forwarded-Protocol $scheme',
+    'X-Real-IP $remote_addr',
+  ]
+
   if $ssl {
     nginx::resource::server {
       $title:
         server_name      => [$server_name],
         proxy            => $proxy,
         proxy_redirect   => $proxy_redirect,
-        proxy_set_header => concat([
-          'Host $host',
-          'X-Forwarded-For $proxy_add_x_forwarded_for',
-          'X-Forwarded-Protocol $scheme',
-          'X-Real-IP $remote_addr',
-        ], $proxy_set_header),
+        proxy_set_header => concat($base_headers, $proxy_set_header),
 
         listen_port => 443,
         ssl         => true,
@@ -62,12 +64,7 @@ define ocf::nginx_proxy(
       server_name      => concat([$server_name], $server_aliases),
       proxy            => $proxy,
       proxy_redirect   => $proxy_redirect,
-      proxy_set_header => concat([
-        'Host $host',
-        'X-Forwarded-For $proxy_add_x_forwarded_for',
-        'X-Forwarded-Protocol $scheme',
-        'X-Real-IP $remote_addr',
-      ], $proxy_set_header),
+      proxy_set_header => concat($base_headers, $proxy_set_header),
       add_header       => $headers,
       *                => $nginx_options,
     }

--- a/modules/ocf/manifests/nginx_proxy.pp
+++ b/modules/ocf/manifests/nginx_proxy.pp
@@ -59,10 +59,17 @@ define ocf::nginx_proxy(
     }
   } else {
     nginx::resource::server { $title:
-      server_name => concat([$server_name], $server_aliases),
-      proxy       => $proxy,
-      add_header  => $headers,
-      *           => $nginx_options,
+      server_name      => concat([$server_name], $server_aliases),
+      proxy            => $proxy,
+      proxy_redirect   => $proxy_redirect,
+      proxy_set_header => concat([
+        'Host $host',
+        'X-Forwarded-For $proxy_add_x_forwarded_for',
+        'X-Forwarded-Protocol $scheme',
+        'X-Real-IP $remote_addr',
+      ], $proxy_set_header),
+      add_header       => $headers,
+      *                => $nginx_options,
     }
   }
 }

--- a/modules/ocf/manifests/nginx_proxy.pp
+++ b/modules/ocf/manifests/nginx_proxy.pp
@@ -1,0 +1,68 @@
+define ocf::nginx_proxy(
+  $proxy,
+  $proxy_redirect   = undef,
+  $proxy_set_header = [],
+
+  $server_name    = $title,
+  $server_aliases = [],
+  $headers        = {},
+
+  $ssl         = false,
+  $ssl_cert    = "/etc/ssl/private/${::fqdn}.bundle",
+  $ssl_key     = "/etc/ssl/private/${::fqdn}.key",
+  $ssl_dhparam = '/etc/ssl/dhparam.pem',
+
+  # Accept any other arbitrary options passed in and pass them on to
+  # nginx::resource::server
+  $nginx_options = {},
+) {
+
+  if $ssl {
+    nginx::resource::server {
+      $title:
+        server_name      => [$server_name],
+        proxy            => $proxy,
+        proxy_redirect   => $proxy_redirect,
+        proxy_set_header => concat([
+          'Host $host',
+          'X-Forwarded-For $proxy_add_x_forwarded_for',
+          'X-Forwarded-Protocol $scheme',
+          'X-Real-IP $remote_addr',
+        ], $proxy_set_header),
+
+        listen_port => 443,
+        ssl         => true,
+        ssl_cert    => $ssl_cert,
+        ssl_key     => $ssl_key,
+        ssl_dhparam => $ssl_dhparam,
+
+        add_header => merge({
+          # HSTS header
+          'Strict-Transport-Security' => 'max-age=31536000',
+        }, $headers),
+
+        * => $nginx_options;
+
+      "${title}-redirect":
+        # We have to specify www_root even though we always redirect/proxy
+        www_root => '/var/www',
+
+        server_name => concat([$server_name], $server_aliases),
+
+        server_cfg_append => {
+          'return' => "301 https://${server_name}\$request_uri"
+        },
+
+        add_header => $headers,
+
+        * => $nginx_options;
+    }
+  } else {
+    nginx::resource::server { $title:
+      server_name => concat([$server_name], $server_aliases),
+      proxy       => $proxy,
+      add_header  => $headers,
+      *           => $nginx_options,
+    }
+  }
+}

--- a/modules/ocf_irc/manifests/webirc.pp
+++ b/modules/ocf_irc/manifests/webirc.pp
@@ -12,43 +12,12 @@ class ocf_irc::webirc {
     server_purge => true,
   }
 
-  $ssl_options = {
-    ssl         => true,
-    ssl_cert    => "/etc/ssl/private/${::fqdn}.bundle",
-    ssl_key     => "/etc/ssl/private/${::fqdn}.key",
-    ssl_dhparam => '/etc/ssl/dhparam.pem',
-
-    add_header => {
-      'Strict-Transport-Security' => 'max-age=31536000',
-    },
-  }
-
-  nginx::resource::server {
-    $webirc_fqdn:
-      server_name      => [$webirc_fqdn],
-      proxy            => 'https://thelounge.ocf.berkeley.edu',
-      proxy_set_header => [
-        'X-Forwarded-For $remote_addr',
-        'Host thelounge.ocf.berkeley.edu',
-      ],
-
-      * => $ssl_options,
-
-      ssl_redirect => true;
-
-    "${webirc_fqdn}-redirect":
-      # Needs a www_root even though we just redirect
-      www_root => '/var/www',
-
-      server_name => [
-        $::hostname,
-        $::fqdn
-      ],
-
-      * => $ssl_options,
-
-      server_cfg_append => {
-        'return' => "301 https://${webirc_fqdn}\$request_uri"
-      };
+  ocf::nginx_proxy { $webirc_fqdn:
+    server_aliases => [
+      $::hostname,
+      $::fqdn,
+    ],
+    proxy => 'http://lb.ocf.berkeley.edu:10008',
+    ssl   => true,
   }
 }

--- a/modules/ocf_jenkins/manifests/proxy.pp
+++ b/modules/ocf_jenkins/manifests/proxy.pp
@@ -14,10 +14,5 @@ class ocf_jenkins::proxy {
     ssl              => true,
     proxy            => 'http://localhost:8080',
     proxy_redirect   => 'http://localhost:8080 https://jenkins.ocf.berkeley.edu',
-    proxy_set_header => [
-      'X-Forwarded-Proto $scheme',
-      'X-Forwarded-For $proxy_add_x_forwarded_for',
-      'Host $http_host'
-    ],
   }
 }

--- a/modules/ocf_jenkins/manifests/proxy.pp
+++ b/modules/ocf_jenkins/manifests/proxy.pp
@@ -2,58 +2,22 @@ class ocf_jenkins::proxy {
   class { 'nginx':
     manage_repo   => false,
     confd_purge   => true,
-    server_purge   => true,
+    server_purge  => true,
     server_tokens => off,
   }
 
-  nginx::resource::upstream { 'jenkins':
-    members => ['localhost:8080'];
-  }
-
-  nginx::resource::server {
-    'jenkins.ocf.berkeley.edu':
-      server_name => ['jenkins.ocf.berkeley.edu'],
-
-      proxy            => 'http://jenkins',
-      proxy_redirect   => 'http://localhost:8080 https://jenkins.ocf.berkeley.edu',
-      proxy_set_header => [
-        'X-Forwarded-Proto $scheme',
-        'X-Forwarded-For $proxy_add_x_forwarded_for',
-        'Host $http_host'
-      ],
-
-      ssl         => true,
-      ssl_cert    => "/etc/ssl/private/${::fqdn}.bundle",
-      ssl_key     => "/etc/ssl/private/${::fqdn}.key",
-      ssl_dhparam => '/etc/ssl/dhparam.pem',
-
-      add_header => {
-        'Strict-Transport-Security' => 'max-age=31536000',
-      },
-
-      listen_port      => 443,
-      ssl_redirect => true;
-
-    'jenkins.ocf.berkeley.edu-redirect':
-      # we have to specify www_root even though we always redirect
-      www_root => '/var/www',
-
-      server_name => [
-        $::hostname,
-        $::fqdn
-      ],
-
-      ssl         => true,
-      ssl_cert    => "/etc/ssl/private/${::fqdn}.bundle",
-      ssl_key     => "/etc/ssl/private/${::fqdn}.key",
-      ssl_dhparam => '/etc/ssl/dhparam.pem',
-
-      add_header  => {
-        'Strict-Transport-Security' => 'max-age=31536000',
-      },
-
-      server_cfg_append => {
-        'return' => '301 https://jenkins.ocf.berkeley.edu$request_uri'
-      };
+  ocf::nginx_proxy { 'jenkins.ocf.berkeley.edu':
+    server_aliases => [
+      $::hostname,
+      $::fqdn
+    ],
+    ssl              => true,
+    proxy            => 'http://localhost:8080',
+    proxy_redirect   => 'http://localhost:8080 https://jenkins.ocf.berkeley.edu',
+    proxy_set_header => [
+      'X-Forwarded-Proto $scheme',
+      'X-Forwarded-For $proxy_add_x_forwarded_for',
+      'Host $http_host'
+    ],
   }
 }

--- a/modules/ocf_mesos/manifests/master/load_balancer.pp
+++ b/modules/ocf_mesos/manifests/master/load_balancer.pp
@@ -53,59 +53,52 @@ class ocf_mesos::master::load_balancer($marathon_http_password) {
     notify  => Service['keepalived'],
   }
 
-  # Service virtual host definitions
+  ####################################
+  # Service virtual host definitions #
+  ####################################
+
+  # Port 10000 is unused, it used to be used for fluffy, and then was used for
+  # a trivial testing service, but is now unused again
+
   ocf_mesos::master::load_balancer::http_vhost { 'rt':
     server_name    => 'rt.ocf.berkeley.edu',
     server_aliases => ['rt'],
     service_port   => 10001,
     ssl            => true,
-    ssl_cert       => '/opt/share/docker/secrets/rt/rt.crt',
-    ssl_key        => '/opt/share/docker/secrets/rt/rt.key',
   }
 
-  # Port 10002 is used by ocfweb-web
+  # Port 10002 is used by ocfweb-web and proxied to by ocf_www
 
   ocf_mesos::master::load_balancer::http_vhost { 'pma':
     server_name    => 'pma.ocf.berkeley.edu',
     server_aliases => ['pma', 'phpmyadmin', 'phpmyadmin.ocf.berkeley.edu'],
     service_port   => 10003,
     ssl            => true,
-    ssl_cert       => '/opt/share/docker/secrets/pma/pma.ocf.berkeley.edu.crt',
-    ssl_key        => '/opt/share/docker/secrets/pma/pma.ocf.berkeley.edu.key',
   }
 
   ocf_mesos::master::load_balancer::http_vhost { 'ocfweb-static':
     server_name    => 'static.ocf.berkeley.edu',
     service_port   => 10004,
     ssl            => true,
-    ssl_cert       => '/opt/share/docker/secrets/ocfweb/static.ocf.berkeley.edu.crt',
-    ssl_key        => '/opt/share/docker/secrets/ocfweb/static.ocf.berkeley.edu.key',
+    ssl_dir        => 'ocfweb',
   }
+
+  # Ports 10005 and 10006 are unused
 
   ocf_mesos::master::load_balancer::http_vhost { 'templates':
     server_name    => 'templates.ocf.berkeley.edu',
     server_aliases => ['templates'],
     service_port   => 10007,
     ssl            => true,
-    ssl_cert       => '/opt/share/docker/secrets/templates/templates.ocf.berkeley.edu.crt',
-    ssl_key        => '/opt/share/docker/secrets/templates/templates.ocf.berkeley.edu.key',
   }
 
-  ocf_mesos::master::load_balancer::http_vhost { 'thelounge':
-    server_name    => 'thelounge.ocf.berkeley.edu',
-    server_aliases => ['thelounge'],
-    service_port   => 10008,
-    ssl            => true,
-    ssl_cert       => '/opt/share/docker/secrets/thelounge/thelounge.ocf.berkeley.edu.crt',
-    ssl_key        => '/opt/share/docker/secrets/thelounge/thelounge.ocf.berkeley.edu.key',
-  }
+  # Port 10008 is used by thelounge, it is proxied to by ocf_irc
+  # Port 10009 is used by puppetboard, it is proxied to by ocf_puppet
 
   ocf_mesos::master::load_balancer::http_vhost { 'metabase':
     server_name    => 'metabase.ocf.berkeley.edu',
     server_aliases => ['mb', 'metabase', 'mb.ocf.berkeley.edu'],
     service_port   => 10010,
     ssl            => true,
-    ssl_cert       => '/opt/share/docker/secrets/metabase/metabase.ocf.berkeley.edu.crt',
-    ssl_key        => '/opt/share/docker/secrets/metabase/metabase.ocf.berkeley.edu.key',
   }
 }

--- a/modules/ocf_puppet/manifests/init.pp
+++ b/modules/ocf_puppet/manifests/init.pp
@@ -1,5 +1,7 @@
 class ocf_puppet {
+  include ocf_ssl::default_bundle
   include ocf_puppet::environments
+  include ocf_puppet::puppetboard
   include ocf_puppet::puppetmaster
 
   file { '/etc/sudoers.d/ocfdeploy-puppet':

--- a/modules/ocf_puppet/manifests/puppetboard.pp
+++ b/modules/ocf_puppet/manifests/puppetboard.pp
@@ -1,0 +1,25 @@
+class ocf_puppet::puppetboard {
+  $puppet_fqdn = $::host_env ? {
+    'dev'  => 'dev-puppet.ocf.berkeley.edu',
+    'prod' => 'puppet.ocf.berkeley.edu',
+  }
+
+  # Nginx is used to proxy to Marathon and to supply a HTTP -> HTTPS redirect
+  class { 'nginx':
+    manage_repo => false,
+    confd_purge => true,
+    server_purge => true,
+  }
+
+  ocf::nginx_proxy { $puppet_fqdn:
+    server_aliases => [
+      'pb.ocf.berkeley.edu',
+      'pb',
+      'puppet',
+      $::hostname,
+      $::fqdn,
+    ],
+    proxy => 'http://lb.ocf.berkeley.edu:10009',
+    ssl   => true,
+  }
+}


### PR DESCRIPTION
I found myself wanting to repeat the same proxy setup many times and thought `ocf_mesos::master::load_balancer::http_vhost` was pretty useful, but it could only really be used for Marathon proxies unless it was made more generic. Anyway, so I made a more general-purpose proxy that makes it easy to create new SSL proxies. It should also make it easier to change any OCF-wide SSL settings as well, for instance.

This is still a bit of a WIP, since some of the `ocf_mesos` stuff could be migrated to use this, and my original intention was to add a puppetboard proxy at https://puppet.ocf.berkeley.edu, but that hasn't been done yet either.