### PR TITLE
mirrors systemd timers

### DIFF
--- a/modules/ocf/manifests/systemd/service.pp
+++ b/modules/ocf/manifests/systemd/service.pp
@@ -18,10 +18,10 @@ define ocf::systemd::service(
     require => Package['systemd-sysv'],
   } ~>
   service { $title:
-    ensure    => $ensure,
-    enable    => $enable,
-    provider  => systemd,
-    require   => [
+    ensure   => $ensure,
+    enable   => $enable,
+    provider => systemd,
+    require  => [
       Package['systemd-sysv'],
       File["/etc/systemd/system/${title}.service"],
       Exec['systemd-reload'],

--- a/modules/ocf/manifests/systemd/service.pp
+++ b/modules/ocf/manifests/systemd/service.pp
@@ -4,18 +4,23 @@ define ocf::systemd::service(
   $ensure = 'running',
   $enable = true,
 ) {
+  if $content and $source {
+    fail('You may not supply both content and source parameters to ocf::systemd::service')
+  }
+  elsif $content == undef and $source == undef {
+    fail('You must supply either the content or source parameter to ocf::systemd::service')
+  }
+
   file { "/etc/systemd/system/${title}.service":
     source  => $source,
     content => $content,
     notify  => Exec['systemd-reload'],
     require => Package['systemd-sysv'],
-  }
-
+  } ~>
   service { $title:
     ensure    => $ensure,
     enable    => $enable,
     provider  => systemd,
-    subscribe => File["/etc/systemd/system/${title}.service"],
     require   => [
       Package['systemd-sysv'],
       File["/etc/systemd/system/${title}.service"],

--- a/modules/ocf/manifests/systemd/timer.pp
+++ b/modules/ocf/manifests/systemd/timer.pp
@@ -1,0 +1,51 @@
+# Creates two systemd units: a timer and service bearing the same
+# name, whereby the service will be activated once the timer elapses.
+define ocf::systemd::timer(
+  $timer_content = undef,
+  $service_content = undef,
+  $timer_source = undef,
+  $service_source = undef,
+  $ensure = 'running',
+  $enable = true,
+) {
+  # ocf::systemd::service will handle multiple timer sources
+  if $service_content and $service_source {
+    fail('You may not supply both content and source parameters to ocf::systemd::timer')
+  }
+  elsif $service_content == undef and $service_source == undef {
+    fail('You must supply either the content or source parameter to ocf::systemd::timer')
+  }
+  elsif $timer_content and $timer_source {
+    fail('You may not supply both content and source parameters to ocf::systemd::timer')
+  }
+  elsif $timer_content == undef and $timer_source == undef {
+    fail('You must supply either the content or source parameter to ocf::systemd::timer')
+  }
+
+  file {
+    "/etc/systemd/system/${title}.timer":
+      source  => $timer_source,
+      content => $timer_content,
+      notify  => Exec['systemd-reload'],
+      require => Package['systemd-sysv'];
+
+    "/etc/systemd/system/${title}.service":
+      source  => $service_source,
+      content => $service_content,
+      notify  => Exec['systemd-reload'],
+      require => [
+        Package['systemd-sysv'],
+        File["/etc/systemd/system/${title}.timer"],
+      ];
+  } ~>
+  service { "${title}.timer":
+    ensure   => $ensure,
+    enable   => $enable,
+    provider => systemd,
+    require  => [
+      Package['systemd-sysv'],
+      File["/etc/systemd/system/${title}.timer"],
+      Exec['systemd-reload'],
+    ],
+  }
+}

--- a/modules/ocf_mirrors/manifests/apache.pp
+++ b/modules/ocf_mirrors/manifests/apache.pp
@@ -16,11 +16,10 @@ class ocf_mirrors::apache {
     ts_path       => 'zzz/time.txt',
   }
 
-  cron {
+  ocf_mirrors::timer {
     'apache':
-      command => '/opt/mirrors/project/apache/sync-archive > /dev/null',
-      user    => 'mirrors',
-      hour    => '*/8',
-      minute  => '37';
+      exec_start => '/opt/mirrors/project/apache/sync-archive',
+      hour       => '0/8',
+      minute     => '37';
   }
 }

--- a/modules/ocf_mirrors/manifests/archlinux.pp
+++ b/modules/ocf_mirrors/manifests/archlinux.pp
@@ -15,11 +15,10 @@ class ocf_mirrors::archlinux {
     ts_path       => 'lastsync',
   }
 
-  cron {
+  ocf_mirrors::timer {
     'archlinux':
-      command => '/opt/mirrors/project/archlinux/sync-archive > /dev/null',
-      user    => 'mirrors',
-      hour    => '*/3',
-      minute  => '22';
+      exec_start => '/opt/mirrors/project/archlinux/sync-archive',
+      hour       => '0/3',
+      minute     => '22';
   }
 }

--- a/modules/ocf_mirrors/manifests/centos.pp
+++ b/modules/ocf_mirrors/manifests/centos.pp
@@ -15,11 +15,10 @@ class ocf_mirrors::centos {
       ts_path       => 'TIME';
   }
 
-  cron {
+  ocf_mirrors::timer {
     'centos':
-      command => '/opt/mirrors/project/centos/sync-archive > /dev/null',
-      user    => 'mirrors',
-      hour    => '*/3',
-      minute  => '22';
+      exec_start => '/opt/mirrors/project/centos/sync-archive',
+      hour       => '0/3',
+      minute     => '22';
   }
 }

--- a/modules/ocf_mirrors/manifests/centos_altarch.pp
+++ b/modules/ocf_mirrors/manifests/centos_altarch.pp
@@ -20,6 +20,6 @@ class ocf_mirrors::centos_altarch {
     'centos-altarch':
       exec_start => '/opt/mirrors/project/centos-altarch/sync-archive',
       hour       => '0/3',
-      minute     => '44';
+      minute     => '44',
   }
 }

--- a/modules/ocf_mirrors/manifests/centos_altarch.pp
+++ b/modules/ocf_mirrors/manifests/centos_altarch.pp
@@ -16,11 +16,10 @@ class ocf_mirrors::centos_altarch {
       ts_path       => 'TIME';
   }
 
-  cron {
+  ocf_mirrors::timer {
     'centos-altarch':
-      command => '/opt/mirrors/project/centos-altarch/sync-archive > /dev/null',
-      user    => 'mirrors',
-      hour    => '*/3',
-      minute  => '44';
+      exec_start => '/opt/mirrors/project/centos-altarch/sync-archive',
+      hour       => '0/3',
+      minute     => '44';
   }
 }

--- a/modules/ocf_mirrors/manifests/centos_debuginfo.pp
+++ b/modules/ocf_mirrors/manifests/centos_debuginfo.pp
@@ -16,11 +16,10 @@ class ocf_mirrors::centos_debuginfo {
       ts_path       => 'TIME';
   }
 
-  cron {
+  ocf_mirrors::timer {
     'centos-debuginfo':
-      command => '/opt/mirrors/project/centos-debuginfo/sync-archive > /dev/null',
-      user    => 'mirrors',
-      hour    => '*/3',
-      minute  => '56';
+      exec_start => '/opt/mirrors/project/centos-debuginfo/sync-archive',
+      hour       => '0/3',
+      minute     => '56';
   }
 }

--- a/modules/ocf_mirrors/manifests/finnix.pp
+++ b/modules/ocf_mirrors/manifests/finnix.pp
@@ -20,9 +20,8 @@ class ocf_mirrors::finnix {
       show_diff => false;
   }
 
-  cron { 'finnix':
-    command => '/opt/mirrors/project/finnix/sync-releases > /dev/null',
-    user    => 'mirrors',
-    minute  => '41';
+  ocf_mirrors::timer { 'finnix':
+    exec_start => '/opt/mirrors/project/finnix/sync-releases',
+    minute     => '41',
   }
 }

--- a/modules/ocf_mirrors/manifests/ftpsync.pp
+++ b/modules/ocf_mirrors/manifests/ftpsync.pp
@@ -45,14 +45,13 @@ define ocf_mirrors::ftpsync(
 
   if $use_systemd {
     ocf_mirrors::timer { "ftpsync-${title}":
-      exec_start   => "${project_path}/bin/ftpsync > /dev/null 2>&1",
+      exec_start   => "${project_path}/bin/ftpsync",
       environments => { 'BASEDIR' => $project_path },
       hour         => $cron_hour,
       minute       => $cron_minute,
       require      => File["${project_path}/bin", "${project_path}/etc/ftpsync.conf"],
     }
-  }
-  else {
+  } else {
     cron { "ftpsync-${title}":
       command => "BASEDIR=${project_path} ${project_path}/bin/ftpsync > /dev/null 2>&1",
       user    => 'mirrors',

--- a/modules/ocf_mirrors/manifests/ftpsync.pp
+++ b/modules/ocf_mirrors/manifests/ftpsync.pp
@@ -11,7 +11,7 @@ define ocf_mirrors::ftpsync(
     $mirror_name = 'mirrors.ocf.berkeley.edu',
     $mirror_path = "/opt/mirrors/ftp/${title}",
     $project_path = "/opt/mirrors/project/${title}",
-    $use_systemd = false,
+    $use_systemd = true,
   ) {
 
   file {

--- a/modules/ocf_mirrors/manifests/ftpsync.pp
+++ b/modules/ocf_mirrors/manifests/ftpsync.pp
@@ -11,6 +11,7 @@ define ocf_mirrors::ftpsync(
     $mirror_name = 'mirrors.ocf.berkeley.edu',
     $mirror_path = "/opt/mirrors/ftp/${title}",
     $project_path = "/opt/mirrors/project/${title}",
+    $use_systemd = false,
   ) {
 
   file {
@@ -42,11 +43,22 @@ define ocf_mirrors::ftpsync(
     require => File[$project_path];
   }
 
-  cron { "ftpsync-${title}":
-    command => "BASEDIR=${project_path} ${project_path}/bin/ftpsync > /dev/null 2>&1",
-    user    => 'mirrors',
-    minute  => $cron_minute,
-    hour    => $cron_hour,
-    require => File["${project_path}/bin", "${project_path}/etc/ftpsync.conf"];
+  if $use_systemd {
+    ocf_mirrors::timer { "ftpsync-${title}":
+      exec_start   => "${project_path}/bin/ftpsync > /dev/null 2>&1",
+      environments => { 'BASEDIR' => $project_path },
+      hour         => $cron_hour,
+      minute       => $cron_minute,
+      require      => File["${project_path}/bin", "${project_path}/etc/ftpsync.conf"],
+    }
+  }
+  else {
+    cron { "ftpsync-${title}":
+      command => "BASEDIR=${project_path} ${project_path}/bin/ftpsync > /dev/null 2>&1",
+      user    => 'mirrors',
+      minute  => $cron_minute,
+      hour    => $cron_hour,
+      require => File["${project_path}/bin", "${project_path}/etc/ftpsync.conf"];
+    }
   }
 }

--- a/modules/ocf_mirrors/manifests/gnu.pp
+++ b/modules/ocf_mirrors/manifests/gnu.pp
@@ -15,11 +15,9 @@ class ocf_mirrors::gnu {
     ts_path       => 'mirror-updated-timestamp.txt',
   }
 
-  cron {
-    'gnu':
-      command => '/opt/mirrors/project/gnu/sync-archive > /dev/null',
-      user    => 'mirrors',
-      hour    => '*/4',
-      minute  => '38';
+  ocf_mirrors::timer { 'gnu':
+    exec_start => '/opt/mirrors/project/gnu/sync-archive',
+    hour       => '0/4',
+    minute     => '38',
   }
 }

--- a/modules/ocf_mirrors/manifests/kali.pp
+++ b/modules/ocf_mirrors/manifests/kali.pp
@@ -3,7 +3,7 @@ class ocf_mirrors::kali {
     'kali':
       rsync_host  => 'archive.kali.org',
       cron_minute => '15',
-      cron_hour   => '*/3';
+      cron_hour   => '0/3';
 
     'kali-images':
       rsync_host  => 'archive.kali.org',

--- a/modules/ocf_mirrors/manifests/kde.pp
+++ b/modules/ocf_mirrors/manifests/kde.pp
@@ -9,11 +9,10 @@ class ocf_mirrors::kde {
       recurse => true;
   }
 
-  cron {
+  ocf_mirrors::timer {
     'kde':
-      command => '/opt/mirrors/project/kde/sync-archive > /dev/null',
-      user    => 'mirrors',
-      hour    => '*/2',
-      minute  => '0',
+      exec_start => '/opt/mirrors/project/kde/sync-archive > /dev/null',
+      hour       => '0/2',
+      minute     => '0',
   }
 }

--- a/modules/ocf_mirrors/manifests/kde_applicationdata.pp
+++ b/modules/ocf_mirrors/manifests/kde_applicationdata.pp
@@ -17,11 +17,10 @@ class ocf_mirrors::kde_applicationdata {
       ts_path       => 'last-updated';
   }
 
-  cron {
+  ocf_mirrors::timer {
     'kde-applicationdata':
-      command => '/opt/mirrors/project/kde-applicationdata/sync-archive > /dev/null',
-      user    => 'mirrors',
-      hour    => '*/2',
-      minute  => '0',
+      exec_start => '/opt/mirrors/project/kde-applicationdata/sync-archive',
+      hour       => '0/2',
+      minute     => '0',
   }
 }

--- a/modules/ocf_mirrors/manifests/manjaro.pp
+++ b/modules/ocf_mirrors/manifests/manjaro.pp
@@ -18,11 +18,10 @@ class ocf_mirrors::manjaro {
 
   # TODO: Change the rsync source to rsync://repo.manjaro.org/repos since we're
   # now an official mirror and should have access if we contact them about it.
-  cron {
+  ocf_mirrors::timer {
     'manjaro':
-      command => '/opt/mirrors/project/manjaro/sync-archive > /dev/null',
-      user    => 'mirrors',
-      hour    => '*/2',
-      minute  => '35';
+      exec_start => '/opt/mirrors/project/manjaro/sync-archive',
+      hour       => '0/2',
+      minute     => '35';
   }
 }

--- a/modules/ocf_mirrors/manifests/parrot.pp
+++ b/modules/ocf_mirrors/manifests/parrot.pp
@@ -15,11 +15,10 @@ class ocf_mirrors::parrot {
     ts_path       => 'last-sync.txt',
   }
 
-  cron {
+  ocf_mirrors::timer {
     'parrot':
-      command => '/opt/mirrors/project/parrot/sync > /dev/null',
-      user    => 'mirrors',
-      minute  => '15',
-      hour    => '*/3',
+      exec_start => '/opt/mirrors/project/parrot/sync',
+      minute     => '15',
+      hour       => '0/3',
   }
 }

--- a/modules/ocf_mirrors/manifests/puppetlabs.pp
+++ b/modules/ocf_mirrors/manifests/puppetlabs.pp
@@ -2,7 +2,8 @@ class ocf_mirrors::puppetlabs {
   ocf_mirrors::ftpsync { 'puppetlabs':
     rsync_host  => 'rsync.puppet.com',
     rsync_path  => 'packages/apt',
-    cron_minute => '55';
+    cron_minute => '55',
+    use_systemd => true;
   }
 
   ocf_mirrors::monitoring { 'puppetlabs':

--- a/modules/ocf_mirrors/manifests/puppetlabs.pp
+++ b/modules/ocf_mirrors/manifests/puppetlabs.pp
@@ -3,7 +3,6 @@ class ocf_mirrors::puppetlabs {
     rsync_host  => 'rsync.puppet.com',
     rsync_path  => 'packages/apt',
     cron_minute => '55',
-    use_systemd => true;
   }
 
   ocf_mirrors::monitoring { 'puppetlabs':

--- a/modules/ocf_mirrors/manifests/qt.pp
+++ b/modules/ocf_mirrors/manifests/qt.pp
@@ -16,11 +16,10 @@ class ocf_mirrors::qt {
     ts_path       => 'timestamp.txt',
   }
 
-  cron {
+  ocf_mirrors::timer {
     'qt':
-      command => '/opt/mirrors/project/qt/sync-archive > /dev/null',
-      user    => 'mirrors',
-      hour    => '*/4',
-      minute  => '5';
+      exec_start => '/opt/mirrors/project/qt/sync-archive',
+      hour       => '0/4',
+      minute     => '5',
   }
 }

--- a/modules/ocf_mirrors/manifests/raspbian.pp
+++ b/modules/ocf_mirrors/manifests/raspbian.pp
@@ -3,7 +3,6 @@ class ocf_mirrors::raspbian {
     rsync_host  => 'archive.raspbian.org',
     rsync_path  => 'archive',
     cron_minute => '45',
-    use_systemd => true,
   }
 
   ocf_mirrors::monitoring { 'raspbian':

--- a/modules/ocf_mirrors/manifests/raspbian.pp
+++ b/modules/ocf_mirrors/manifests/raspbian.pp
@@ -2,7 +2,8 @@ class ocf_mirrors::raspbian {
   ocf_mirrors::ftpsync { 'raspbian':
     rsync_host  => 'archive.raspbian.org',
     rsync_path  => 'archive',
-    cron_minute => '45';
+    cron_minute => '45',
+    use_systemd => true,
   }
 
   ocf_mirrors::monitoring { 'raspbian':

--- a/modules/ocf_mirrors/manifests/tails.pp
+++ b/modules/ocf_mirrors/manifests/tails.pp
@@ -16,10 +16,9 @@ class ocf_mirrors::tails {
     ts_path       => 'project/trace',
   }
 
-  cron {
+  ocf_mirrors::timer {
     'tails':
-      command => '/opt/mirrors/project/tails/sync > /dev/null',
-      user    => 'mirrors',
-      minute  => '15';
+      exec_start => '/opt/mirrors/project/tails/sync > /dev/null',
+      minute     => '15';
   }
 }

--- a/modules/ocf_mirrors/manifests/tanglu.pp
+++ b/modules/ocf_mirrors/manifests/tanglu.pp
@@ -1,7 +1,8 @@
 class ocf_mirrors::tanglu {
   ocf_mirrors::ftpsync { 'tanglu':
     rsync_host  => 'archive.tanglu.org',
-    cron_minute => '40';
+    cron_minute => '40',
+    use_systemd => true,
   }
 
   ocf_mirrors::monitoring { 'tanglu':
@@ -17,10 +18,9 @@ class ocf_mirrors::tanglu {
     group  => mirrors;
   }
 
-  cron { 'tanglu-releases':
-    command => '/opt/mirrors/project/tanglu/sync-releases > /dev/null',
-    user    => 'mirrors',
-    hour    => '*/2',
-    minute  => '53';
+  ocf_mirrors::timer { 'tanglu-releases':
+    exec_start => '/opt/mirrors/project/tanglu/sync-releases',
+    hour       => '0/2',
+    minute     => '53',
   }
 }

--- a/modules/ocf_mirrors/manifests/tanglu.pp
+++ b/modules/ocf_mirrors/manifests/tanglu.pp
@@ -2,7 +2,6 @@ class ocf_mirrors::tanglu {
   ocf_mirrors::ftpsync { 'tanglu':
     rsync_host  => 'archive.tanglu.org',
     cron_minute => '40',
-    use_systemd => true,
   }
 
   ocf_mirrors::monitoring { 'tanglu':

--- a/modules/ocf_mirrors/manifests/timer.pp
+++ b/modules/ocf_mirrors/manifests/timer.pp
@@ -1,0 +1,25 @@
+define ocf_mirrors::timer(
+  $minute = '*',
+  $hour = '*',
+  $day = '*',
+  $month = '*',
+  $year = '*',
+  $exec_user = 'mirrors',
+  $exec_start = '',
+  $environments = {},
+  $stdout = '',
+) {
+  # Any meaningful second precision requires AccuracySec to be set
+  $on_calendar = "${year}-${month}-${day} ${hour}:${minute}:00"
+
+  ocf::systemd::timer { $title:
+    service_content => template('ocf_mirrors/systemd/sync.service.erb'),
+    timer_content   => template('ocf_mirrors/systemd/sync.timer.erb'),
+  }
+
+  # Ensure there is no duplicate cron job
+  cron { $title:
+    ensure => absent,
+    user   => $exec_user,
+  }
+}

--- a/modules/ocf_mirrors/manifests/timer.pp
+++ b/modules/ocf_mirrors/manifests/timer.pp
@@ -7,7 +7,6 @@ define ocf_mirrors::timer(
   $exec_user = 'mirrors',
   $exec_start = '',
   $environments = {},
-  $stdout = '',
 ) {
   # Any meaningful second precision requires AccuracySec to be set
   $on_calendar = "${year}-${month}-${day} ${hour}:${minute}:00"

--- a/modules/ocf_mirrors/manifests/trisquel.pp
+++ b/modules/ocf_mirrors/manifests/trisquel.pp
@@ -3,15 +3,13 @@ class ocf_mirrors::trisquel {
     'trisquel':
       rsync_host  => 'rsync.trisquel.info',
       rsync_path  => 'trisquel.packages',
-      cron_minute => '45',
-      use_systemd => true;
+      cron_minute => '45';
 
     'trisquel-images':
       rsync_host  => 'rsync.trisquel.info',
       rsync_path  => 'trisquel.iso',
       rsync_extra => '--block-size=8192',
-      cron_minute => '55',
-      use_systemd => true;
+      cron_minute => '55';
   }
 
   ocf_mirrors::monitoring { 'trisquel':

--- a/modules/ocf_mirrors/manifests/trisquel.pp
+++ b/modules/ocf_mirrors/manifests/trisquel.pp
@@ -3,13 +3,15 @@ class ocf_mirrors::trisquel {
     'trisquel':
       rsync_host  => 'rsync.trisquel.info',
       rsync_path  => 'trisquel.packages',
-      cron_minute => '45';
+      cron_minute => '45',
+      use_systemd => true;
 
     'trisquel-images':
       rsync_host  => 'rsync.trisquel.info',
       rsync_path  => 'trisquel.iso',
       rsync_extra => '--block-size=8192',
-      cron_minute => '55';
+      cron_minute => '55',
+      use_systemd => true;
   }
 
   ocf_mirrors::monitoring { 'trisquel':

--- a/modules/ocf_mirrors/manifests/ubuntu.pp
+++ b/modules/ocf_mirrors/manifests/ubuntu.pp
@@ -17,10 +17,9 @@ class ocf_mirrors::ubuntu {
     group  => mirrors;
   }
 
-  cron { 'ubuntu-releases':
-    command => '/opt/mirrors/project/ubuntu/sync-releases > /dev/null',
-    user    => 'mirrors',
-    hour    => '*/7',
-    minute  => '18';
+  ocf_mirrors::timer { 'ubuntu-releases':
+    exec_start => '/opt/mirrors/project/ubuntu/sync-releases > /dev/null',
+    hour       => '0/7',
+    minute     => '18';
   }
 }

--- a/modules/ocf_mirrors/templates/systemd/sync.service.erb
+++ b/modules/ocf_mirrors/templates/systemd/sync.service.erb
@@ -1,0 +1,9 @@
+[Unit]
+Description=Sync service for <%= @title %>
+
+[Service]
+User=<%= @exec_user %>
+Type=simple
+Environment=<%= @environments.map{ | env, val | "\""+env+"="+val+"\"" }.join(' ') %>
+ExecStart=<%= @exec_start %>
+StandardOutput=<%= @stdout %>

--- a/modules/ocf_mirrors/templates/systemd/sync.service.erb
+++ b/modules/ocf_mirrors/templates/systemd/sync.service.erb
@@ -4,6 +4,7 @@ Description=Sync service for <%= @title %>
 [Service]
 User=<%= @exec_user %>
 Type=simple
-Environment=<%= @environments.map{ | env, val | "\""+env+"="+val+"\"" }.join(' ') %>
+<% @environments.each do |env, val| -%>
+Environment="<%= env %>=<%= val %>"
+<% end -%>
 ExecStart=<%= @exec_start %>
-StandardOutput=<%= @stdout %>

--- a/modules/ocf_mirrors/templates/systemd/sync.timer.erb
+++ b/modules/ocf_mirrors/templates/systemd/sync.timer.erb
@@ -1,0 +1,10 @@
+[Unit]
+Description=Sync timer for <%= @title %>
+After=network.target
+Wants=network.target
+
+[Timer]
+OnCalendar=<%= @on_calendar %>
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Looking for feedback.

I opted to create the service and timer together in a resource file since the unit file is activated by the timer of the same name, so this should ultimately lead to less code in the future.

I'm not sure if it's worth having the user pass in the template files to the timer, but for now I followed the form of the systemd::service. 