### PR TITLE
Only try to resolve IPv6 addresses when IPv6 is active

### DIFF
--- a/modules/ocf/manifests/firewall/firewall46.pp
+++ b/modules/ocf/manifests/firewall/firewall46.pp
@@ -7,12 +7,17 @@ define ocf::firewall::firewall46($opts,) {
     *         => $opts,
   }
 
-  firewall { "${title} (IPv6)":
-    provider  => 'ip6tables',
-    require   => $require,
-    subscribe => $subscribe,
-    before    => $before,
-    notify    => $notify,
-    *         => $opts,
+  # Ruby's Resolv class doesn't think it should resolve IPv6 addresses if the
+  # local host doesn't have a public IPv6 address. Thus we only try to apply
+  # IPv6 firewall rules here if the host already has an IPv6 address.
+  if $::ipaddress6 {
+    firewall { "${title} (IPv6)":
+      provider  => 'ip6tables',
+      require   => $require,
+      subscribe => $subscribe,
+      before    => $before,
+      notify    => $notify,
+      *         => $opts,
+    }
   }
 }

--- a/modules/ocf_desktop/manifests/firewall_output.pp
+++ b/modules/ocf_desktop/manifests/firewall_output.pp
@@ -1,24 +1,24 @@
 # allow desktops to send packets to papercut, pagefault, radiation
 class ocf_desktop::firewall_output {
 
-  $devices = ['pagefault', 'papercut', 'radiation']
+  $devices_ipv4_only = ['pagefault', 'papercut']
+  $devices = ['radiation']
 
-  $devices_ipv6 = ['radiation']
-
-  $devices.each |String $d| {
-    firewall { "899 allow desktop output to ${d} (IPv4)":
+  $devices_ipv4_only.each |String $d| {
+    firewall { "899 allow desktop output to ${d}":
       chain       => 'PUPPET-OUTPUT',
       action      => 'accept',
       destination => $d,
     }
   }
 
-  $devices_ipv6.each |String $d| {
-    firewall { "899 allow desktop output to ${d} (IPv6)":
-      chain       => 'PUPPET-OUTPUT',
-      action      => 'accept',
-      destination => $d,
-      provider    => 'ip6tables',
+  $devices.each |String $d| {
+    ocf::firewall::firewall46 { "899 allow desktop output to ${d}":
+      opts => {
+        chain       => 'PUPPET-OUTPUT',
+        action      => 'accept',
+        destination => $d,
+      },
     }
   }
 }


### PR DESCRIPTION
puppetlabs-firewall uses the ruby Resolv class to resolve hostnames. Resolv [only resolves IPv6 addresses when there is a public IPv6 address][resolv]. So, only try to apply IPv6 firewall rules with host names when the local host has an IPv6 address configured.

[resolv]: https://github.com/ruby/ruby/blob/a1a20cfaa2cf73ae8daaf2123d7c5b513427162e/lib/resolv.rb#L412