### PR TITLE
Simplify ftpsync health checks

### DIFF
--- a/modules/ocf_mirrors/files/debian-healthcheck
+++ b/modules/ocf_mirrors/files/debian-healthcheck
@@ -10,22 +10,35 @@ mirrors.kernel.org).
 """
 import argparse
 import sys
+from collections import namedtuple
 from datetime import timedelta
 
 import dateutil.parser
 import requests
 
+Mirror = namedtuple('Mirror', ['url', 'updated_at'])
+
 
 def get_updated(mirror_url):
     """Find the time the host was last updated.
 
-    >>> get_updated(args.local_url, 'jessie')
+    >>> get_updated(args.local_url)
     datetime.datetime(2015, 12, 26, 9, 9, 42, tzinfo=tzutc())
     """
     req = requests.get(mirror_url)
     req.raise_for_status()
     updated_line, = [line for line in req.text.splitlines() if line.startswith('Date: ')]
     return dateutil.parser.parse(updated_line.split(': ', 1)[1])
+
+
+def get_mirrors(url_first, url_second):
+    """Given two mirror urls, returns two Mirror
+    namedtuples ordered (asc) by update date."""
+
+    mirror_first = Mirror(url_first, get_updated(url_first))
+    mirror_second = Mirror(url_second, get_updated(url_second))
+    return (min(mirror_first, mirror_second, key=lambda z: z.updated_at),
+            max(mirror_first, mirror_second, key=lambda z: z.updated_at))
 
 
 if __name__ == '__main__':
@@ -42,20 +55,17 @@ if __name__ == '__main__':
         print('Local and upstream urls cannot be equal... Exiting!')
         sys.exit(1)
 
+    local_mirror, upstream_mirror = get_mirrors(args.url_first, args.url_second)
+
     # instead of comparing against current time, compare against the master server;
     # this helps avoid flaky monitoring if the upstream archive isn't updated
-    mirror_first = get_updated(args.url_first), args.url_first
-    mirror_second = get_updated(args.url_second), args.url_second
-    local_mirror = min(mirror_first, mirror_second, key=lambda z: z[0])
-    upstream_mirror = max(mirror_first, mirror_second, key=lambda z: z[0])
-
-    delta = upstream_mirror[0] - local_mirror[0]
+    delta = upstream_mirror.updated_at - local_mirror.updated_at
     if delta > timedelta(hours=24):
         print('Warning: {} has not been updated in {}'.format(args.project, delta))
-        print('    Local mirror: {}'.format(local_mirror[0]))
-        print('        {}'.format(local_mirror[1]))
-        print('    Upstream mirror: {}'.format(upstream_mirror[0]))
-        print('        {}'.format(upstream_mirror[1]))
+        print('    Local mirror: {}'.format(local_mirror.updated_at))
+        print('        {}'.format(local_mirror.url))
+        print('    Upstream mirror: {}'.format(upstream_mirror.updated_at))
+        print('        {}'.format(upstream_mirror.url))
         sys.exit(1)
 
 # vim: ft=python

--- a/modules/ocf_mirrors/files/debian-healthcheck
+++ b/modules/ocf_mirrors/files/debian-healthcheck
@@ -4,7 +4,7 @@
 This detects most problems caused by both failed syncs to our direct upstream
 as well as cases where the upstream is out-of-date.
 
-Ideally, "args.upstream_url" should refer to the *actual* upstream (e.g. Debian's
+Ideally, the upstream url argument should refer to the *actual* upstream (e.g. Debian's
 authoritative archive) and not just our upstream mirror (e.g.
 mirrors.kernel.org).
 """
@@ -31,24 +31,31 @@ def get_updated(mirror_url):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
-    # order doesn't actually matter but we'll impose one for clarity's sake
-    parser.add_argument('local_url', type=str, help='URL of local mirror')
-    parser.add_argument('upstream_url', type=str, help='URL of upstream mirror')
+    # urls of local and upstream mirrors
+    parser.add_argument('project', type=str, help='Project title')
+    parser.add_argument('url_first', type=str, help='URL of local or upstream mirror')
+    parser.add_argument('url_second', type=str, help='URL of local or upstream mirror')
 
+    # ensure we aren't comparing a mirror against itself
     args = parser.parse_args()
+    if args.url_first == args.url_second:
+        print('Local and upstream urls cannot be equal... Exiting!')
+        sys.exit(1)
 
     # instead of comparing against current time, compare against the master server;
     # this helps avoid flaky monitoring if the upstream archive isn't updated
-    local_mirror = get_updated(args.local_url)
-    upstream_mirror = get_updated(args.upstream_url)
+    mirror_first = get_updated(args.url_first), args.url_first
+    mirror_second = get_updated(args.url_second), args.url_second
+    local_mirror = min(mirror_first, mirror_second, key=lambda z: z[0])
+    upstream_mirror = max(mirror_first, mirror_second, key=lambda z: z[0])
 
-    delta = upstream_mirror - local_mirror
+    delta = upstream_mirror[0] - local_mirror[0]
     if delta > timedelta(hours=24):
-        print('Warning: <%= @title %> has not been updated in {}'.format(delta))
-        print('    Local mirror: {}'.format(local_mirror))
-        print('        {}'.format(args.local_url))
-        print('    Upstream mirror: {}'.format(upstream_mirror))
-        print('        {}'.format(args.upstream_url))
+        print('Warning: {} has not been updated in {}'.format(args.project, delta))
+        print('    Local mirror: {}'.format(local_mirror[0]))
+        print('        {}'.format(local_mirror[1]))
+        print('    Upstream mirror: {}'.format(upstream_mirror[0]))
+        print('        {}'.format(upstream_mirror[1]))
         sys.exit(1)
 
 # vim: ft=python

--- a/modules/ocf_mirrors/files/debian-healthcheck
+++ b/modules/ocf_mirrors/files/debian-healthcheck
@@ -4,7 +4,7 @@
 This detects most problems caused by both failed syncs to our direct upstream
 as well as cases where the upstream is out-of-date.
 
-Ideally, "UPSTREAM_MIRROR" should refer to the *actual* upstream (e.g. Debian's
+Ideally, "args.upstream_url" should refer to the *actual* upstream (e.g. Debian's
 authoritative archive) and not just our upstream mirror (e.g.
 mirrors.kernel.org).
 """
@@ -19,12 +19,11 @@ import requests
 def get_updated(mirror_url):
     """Find the time the host was last updated.
 
-    >>> get_updated(LOCAL_MIRROR, 'jessie')
+    >>> get_updated(args.local_url, 'jessie')
     datetime.datetime(2015, 12, 26, 9, 9, 42, tzinfo=tzutc())
     """
     req = requests.get(mirror_url)
-    if req.status_code != 200:
-        return -1
+    req.raise_for_status()
     updated_line, = [line for line in req.text.splitlines() if line.startswith('Date: ')]
     return dateutil.parser.parse(updated_line.split(': ', 1)[1])
 
@@ -33,37 +32,23 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
     # order doesn't actually matter but we'll impose one for clarity's sake
-    parser.add_argument('local_url',
-                        type=str,
-                        help='URL of local mirror'
-                        )
-    parser.add_argument('upstream_url',
-                        type=str,
-                        help='URL of upstream mirror'
-                        )
+    parser.add_argument('local_url', type=str, help='URL of local mirror')
+    parser.add_argument('upstream_url', type=str, help='URL of upstream mirror')
 
     args = parser.parse_args()
-    LOCAL_MIRROR = args.local_url
-    UPSTREAM_MIRROR = args.upstream_url
 
     # instead of comparing against current time, compare against the master server;
     # this helps avoid flaky monitoring if the upstream archive isn't updated
-    local_mirror = get_updated(LOCAL_MIRROR)
-    if local_mirror == -1:
-        print('Invalid mirror: {}'.format(LOCAL_MIRROR))
-        sys.exit(1)
-    upstream_mirror = get_updated(UPSTREAM_MIRROR)
-    if upstream_mirror == -1:
-        print('Invalid mirror: {}'.format(UPSTREAM_MIRROR))
-        sys.exit(1)
+    local_mirror = get_updated(args.local_url)
+    upstream_mirror = get_updated(args.upstream_url)
 
     delta = upstream_mirror - local_mirror
     if delta > timedelta(hours=24):
         print('Warning: <%= @title %> has not been updated in {}'.format(delta))
         print('    Local mirror: {}'.format(local_mirror))
-        print('        {}'.format(LOCAL_MIRROR))
+        print('        {}'.format(args.local_url))
         print('    Upstream mirror: {}'.format(upstream_mirror))
-        print('        {}'.format(UPSTREAM_MIRROR))
+        print('        {}'.format(args.upstream_url))
         sys.exit(1)
 
 # vim: ft=python

--- a/modules/ocf_mirrors/files/health
+++ b/modules/ocf_mirrors/files/health
@@ -8,62 +8,62 @@ Ideally, "UPSTREAM_MIRROR" should refer to the *actual* upstream (e.g. Debian's
 authoritative archive) and not just our upstream mirror (e.g.
 mirrors.kernel.org).
 """
+import argparse
+import sys
 from datetime import timedelta
 
 import dateutil.parser
 import requests
-import sys
 
 
-DIST_TO_CHECK = '<%= @dist_to_check %>'
-
-LOCAL_MIRROR = (
-    'mirrors.ocf.berkeley.edu',
-    '<%= @local_path %>',
-    'http',
-)
-
-UPSTREAM_MIRROR = (
-    '<%= @upstream_host %>',
-    '<%= @upstream_path %>',
-    '<%= @upstream_protocol %>',
-)
-
-
-def release_url(mirror):
-    host, path, protocol = mirror
-    return '{protocol}://{host}{path}/dists/{dist}/Release'.format(
-        protocol=protocol,
-        host=host,
-        path=path,
-        dist=DIST_TO_CHECK,
-    )
-
-
-def get_updated(mirror):
+def get_updated(mirror_url):
     """Find the time the host was last updated.
 
     >>> get_updated(LOCAL_MIRROR, 'jessie')
     datetime.datetime(2015, 12, 26, 9, 9, 42, tzinfo=tzutc())
     """
-    req = requests.get(release_url(mirror))
+    req = requests.get(mirror_url)
+    if req.status_code != 200:
+        return -1
     updated_line, = [line for line in req.text.splitlines() if line.startswith('Date: ')]
     return dateutil.parser.parse(updated_line.split(': ', 1)[1])
 
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    # order doesn't actually matter but we'll impose one for clarity's sake
+    parser.add_argument('local_url',
+                        type=str,
+                        help='URL of local mirror'
+                        )
+    parser.add_argument('upstream_url',
+                        type=str,
+                        help='URL of upstream mirror'
+                        )
+
+    args = parser.parse_args()
+    LOCAL_MIRROR = args.local_url
+    UPSTREAM_MIRROR = args.upstream_url
+
     # instead of comparing against current time, compare against the master server;
     # this helps avoid flaky monitoring if the upstream archive isn't updated
     local_mirror = get_updated(LOCAL_MIRROR)
+    if local_mirror == -1:
+        print('Invalid mirror: {}'.format(LOCAL_MIRROR))
+        sys.exit(1)
     upstream_mirror = get_updated(UPSTREAM_MIRROR)
+    if upstream_mirror == -1:
+        print('Invalid mirror: {}'.format(UPSTREAM_MIRROR))
+        sys.exit(1)
 
     delta = upstream_mirror - local_mirror
     if delta > timedelta(hours=24):
         print('Warning: <%= @title %> has not been updated in {}'.format(delta))
         print('    Local mirror: {}'.format(local_mirror))
-        print('        {}'.format(release_url(LOCAL_MIRROR)))
+        print('        {}'.format(LOCAL_MIRROR))
         print('    Upstream mirror: {}'.format(upstream_mirror))
-        print('        {}'.format(release_url(UPSTREAM_MIRROR)))
+        print('        {}'.format(UPSTREAM_MIRROR))
         sys.exit(1)
 
 # vim: ft=python

--- a/modules/ocf_mirrors/manifests/debian.pp
+++ b/modules/ocf_mirrors/manifests/debian.pp
@@ -17,12 +17,12 @@ class ocf_mirrors::debian {
 
   ocf_mirrors::monitoring {
     'debian':
-      type          => 'ftpsync',
+      type          => 'debian',
       dist_to_check => 'stable',
       upstream_host => 'ftp.us.debian.org';
 
     'debian-security':
-      type          => 'ftpsync',
+      type          => 'debian',
       dist_to_check => 'stable/updates',
       upstream_host => 'security.debian.org',
       upstream_path => '';

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -178,6 +178,13 @@ class ocf_mirrors {
     special => 'daily',
   }
 
+  file { '/opt/mirrors/bin/health':
+    source  => 'puppet:///modules/ocf_mirrors/health',
+    owner   => 'mirrors',
+    group   => 'mirrors',
+    mode    => '0755',
+  }
+
   file { '/usr/local/sbin/process-mirrors-logs':
     source => 'puppet:///modules/ocf_mirrors/process-mirrors-logs',
     mode   => '0755',

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -178,8 +178,8 @@ class ocf_mirrors {
     special => 'daily',
   }
 
-  file { '/opt/mirrors/bin/health':
-    source  => 'puppet:///modules/ocf_mirrors/health',
+  file { '/opt/mirrors/bin/debian-healthcheck':
+    source  => 'puppet:///modules/ocf_mirrors/debian-healthcheck',
     owner   => 'mirrors',
     group   => 'mirrors',
     mode    => '0755',

--- a/modules/ocf_mirrors/manifests/kali.pp
+++ b/modules/ocf_mirrors/manifests/kali.pp
@@ -12,7 +12,7 @@ class ocf_mirrors::kali {
   }
 
   ocf_mirrors::monitoring { 'kali':
-    type          => 'ftpsync',
+    type          => 'debian',
     dist_to_check => 'kali-rolling',
     upstream_host => 'archive.kali.org';
   }

--- a/modules/ocf_mirrors/manifests/monitoring.pp
+++ b/modules/ocf_mirrors/manifests/monitoring.pp
@@ -1,5 +1,5 @@
 define ocf_mirrors::monitoring(
-    $type = 'ftpsync',
+    $type = 'debian',
     $project_path = "/opt/mirrors/project/${title}",
     $upstream_host = undef,
     $dist_to_check = undef,
@@ -13,11 +13,13 @@ define ocf_mirrors::monitoring(
   if $ensure == 'present' {
     file { "${project_path}/health":
       ensure => link,
-      target => '/opt/mirrors/bin/health',
+      target => "/opt/mirrors/bin/${type}-healthcheck",
+      owner  => mirrors,
+      group  => mirrors,
     }->
     cron { "${title}-health":
       command => "${project_path}/health ${local_url} ${upstream_url}",
-      user    => 'mirrors',
+      user    => mirrors,
       hour    => '*/6',
       minute  => '0';
     }

--- a/modules/ocf_mirrors/manifests/monitoring.pp
+++ b/modules/ocf_mirrors/manifests/monitoring.pp
@@ -18,7 +18,7 @@ define ocf_mirrors::monitoring(
       group  => mirrors,
     } ->
     cron { "${title}-health":
-      command => "${project_path}/health ${local_url} ${upstream_url}",
+      command => "${project_path}/health ${title} ${local_url} ${upstream_url}",
       user    => mirrors,
       hour    => '*/6',
       minute  => '0';

--- a/modules/ocf_mirrors/manifests/monitoring.pp
+++ b/modules/ocf_mirrors/manifests/monitoring.pp
@@ -8,15 +8,15 @@ define ocf_mirrors::monitoring(
     $upstream_protocol = 'http',
     $ensure = 'present',
   ) {
-
+  $local_url = "http://mirrors.ocf.berkeley.edu${local_path}/dists/${dist_to_check}/Release"
+  $upstream_url = "${upstream_protocol}://${upstream_host}${upstream_path}/dists/${dist_to_check}/Release"
   if $ensure == 'present' {
     file { "${project_path}/health":
-      content => template("ocf_mirrors/monitoring/${type}-health.erb"),
-      mode    => '0755';
-    }
-
+      ensure => link,
+      target => '/opt/mirrors/bin/health',
+    }->
     cron { "${title}-health":
-      command => "${project_path}/health",
+      command => "${project_path}/health ${local_url} ${upstream_url}",
       user    => 'mirrors',
       hour    => '*/6',
       minute  => '0';

--- a/modules/ocf_mirrors/manifests/monitoring.pp
+++ b/modules/ocf_mirrors/manifests/monitoring.pp
@@ -16,7 +16,7 @@ define ocf_mirrors::monitoring(
       target => "/opt/mirrors/bin/${type}-healthcheck",
       owner  => mirrors,
       group  => mirrors,
-    }->
+    } ->
     cron { "${title}-health":
       command => "${project_path}/health ${local_url} ${upstream_url}",
       user    => mirrors,
@@ -29,7 +29,8 @@ define ocf_mirrors::monitoring(
     }
 
     cron { "${title}-health":
-      ensure => absent;
+      ensure => absent,
+      user   => mirrors;
     }
   }
 }

--- a/modules/ocf_mirrors/manifests/puppetlabs.pp
+++ b/modules/ocf_mirrors/manifests/puppetlabs.pp
@@ -6,7 +6,7 @@ class ocf_mirrors::puppetlabs {
   }
 
   ocf_mirrors::monitoring { 'puppetlabs':
-    type          => 'ftpsync',
+    type          => 'debian',
     dist_to_check => 'jessie',
     local_path    => '/puppetlabs/apt',
     upstream_host => 'apt.puppetlabs.com',

--- a/modules/ocf_mirrors/manifests/raspbian.pp
+++ b/modules/ocf_mirrors/manifests/raspbian.pp
@@ -6,7 +6,7 @@ class ocf_mirrors::raspbian {
   }
 
   ocf_mirrors::monitoring { 'raspbian':
-    type          => 'ftpsync',
+    type          => 'debian',
     dist_to_check => 'jessie',
     local_path    => '/raspbian/raspbian',
     upstream_host => 'archive.raspbian.org';

--- a/modules/ocf_mirrors/manifests/tanglu.pp
+++ b/modules/ocf_mirrors/manifests/tanglu.pp
@@ -5,7 +5,7 @@ class ocf_mirrors::tanglu {
   }
 
   ocf_mirrors::monitoring { 'tanglu':
-    type          => 'ftpsync',
+    type          => 'debian',
     dist_to_check => 'staging',
     upstream_host => 'archive.tanglu.org';
   }

--- a/modules/ocf_mirrors/manifests/ubuntu.pp
+++ b/modules/ocf_mirrors/manifests/ubuntu.pp
@@ -5,7 +5,7 @@ class ocf_mirrors::ubuntu {
   }
 
   ocf_mirrors::monitoring { 'ubuntu':
-    type          => 'ftpsync',
+    type          => 'debian',
     dist_to_check => 'devel',
     upstream_host => 'archive.ubuntu.com';
   }


### PR DESCRIPTION
Use one script that takes command line args for health checks as opposed to
creating a unique script for every mirror using a template. This way we take
advantage of the ocf_mirrors::monitoring defined type to handle url building
instead of doing it the exact same way in python.

In the spirit of the old style, each mirror has a health symlink pointing to
the actual script at /opt/mirrors/bin/health.