### PR TITLE
fish sudo bangbang

### DIFF
--- a/modules/ocf/files/shell/config.fish
+++ b/modules/ocf/files/shell/config.fish
@@ -32,6 +32,15 @@ alias rm "rm -I"
 alias leetfish "set -gx FISH swim"
 alias noobfish "set -gx FISH noob"
 
+# for sudo !!
+function sudo
+    if test "$argv" = !!
+        eval command sudo $history[1]
+    else
+        command sudo $argv
+    end
+end
+
 # Logout
 function on_exit --on-process %self
     if klist > /dev/null 2>&1


### PR DESCRIPTION
pretty jank but I only use `!!` for `sudo !!` in bash anyway so...

it's not hard to make an alias for `!!` that just does something with `$history[1]` anyway, but it won't work with `sudo` in that case

it's not in fish because they want you to press up and then home and then type `sudo`. and also because magic words can be dumb. but i like this magic word

if yall other fish users dont want it i can just put it in my personal configs