### PR TITLE
Add Timestamp Healthchecks

### DIFF
--- a/modules/ocf_mirrors/files/healthcheck
+++ b/modules/ocf_mirrors/files/healthcheck
@@ -25,20 +25,24 @@ def update_func(healthcheck):
         return get_updated_debian
     elif healthcheck == 'ts':
         return get_updated_ts
+    elif healthcheck == 'datetime':
+        return get_updated_datetime
     else:
-        return get_updated_debian
+        raise ValueError('Unsupported type: {}'.format(healthcheck))
+
+
+def get_updated_datetime(mirror_url):
+    """Find the time the host was last synced"""
+    req = requests.get(mirror_url)
+    req.raise_for_status()
+    return dateutil.parser.parse(req.text.splitlines()[0])
 
 
 def get_updated_ts(mirror_url):
     """Find the time the host was last synced"""
-
     req = requests.get(mirror_url)
     req.raise_for_status()
-    try:
-        return datetime.utcfromtimestamp(int(req.text.split()[0]))
-    except (TypeError, ValueError):
-        # UTC Timestamp ... parrot
-        return dateutil.parser.parse(req.text.splitlines()[0])
+    return datetime.utcfromtimestamp(int(req.text.split()[0]))
 
 
 def get_updated_debian(mirror_url):
@@ -55,7 +59,6 @@ def get_updated_debian(mirror_url):
 def get_mirrors(url_first, url_second, get_updated):
     """Given two mirror urls, return two Mirror
     namedtuples ordered (asc) by sync date."""
-
     mirror_first = Mirror(url_first, get_updated(url_first))
     mirror_second = Mirror(url_second, get_updated(url_second))
     return (min(mirror_first, mirror_second, key=lambda z: z.updated_at),

--- a/modules/ocf_mirrors/files/healthcheck
+++ b/modules/ocf_mirrors/files/healthcheck
@@ -23,7 +23,7 @@ Mirror = namedtuple('Mirror', ['url', 'updated_at'])
 def update_func(healthcheck):
     if healthcheck == 'debian':
         return get_updated_debian
-    elif healthcheck == 'ts':
+    elif healthcheck == 'unix_timestamp':
         return get_updated_ts
     elif healthcheck == 'datetime':
         return get_updated_datetime

--- a/modules/ocf_mirrors/files/healthcheck
+++ b/modules/ocf_mirrors/files/healthcheck
@@ -24,7 +24,7 @@ def update_func(healthcheck):
     if healthcheck == 'debian':
         return get_updated_debian
     elif healthcheck == 'unix_timestamp':
-        return get_updated_ts
+        return get_updated_unix_timestamp
     elif healthcheck == 'datetime':
         return get_updated_datetime
     else:
@@ -32,23 +32,32 @@ def update_func(healthcheck):
 
 
 def get_updated_datetime(mirror_url):
-    """Find the time the host was last synced"""
+    """Find the time the host was last synced.
+    The first line on the page should be a datetime, e.g. Fri Jan 19 20:15:01 UTC 2018.
+    >>> get_updated_datetime(mirror_url)
+    datetime.datetime(2018, 1, 19, 20, 15, 1, tzinfo=tzutc())
+    """
     req = requests.get(mirror_url)
     req.raise_for_status()
     return dateutil.parser.parse(req.text.splitlines()[0])
 
 
-def get_updated_ts(mirror_url):
-    """Find the time the host was last synced"""
+def get_updated_unix_timestamp(mirror_url):
+    """Find the time the host was last synced.
+    The first line on the page should be a unix timestamp, e.g. 1516392227.
+    >>> get_updated_unix_timestamp(mirror_url)
+    datetime.datetime(2018, 1, 19, 20, 3, 47)
+    """
     req = requests.get(mirror_url)
     req.raise_for_status()
     return datetime.utcfromtimestamp(int(req.text.split()[0]))
 
 
 def get_updated_debian(mirror_url):
-    """Find the time the host was last updated.
-    >>> get_updated(args.local_url)
-    datetime.datetime(2015, 12, 26, 9, 9, 42, tzinfo=tzutc())
+    """Find the time the host was last synced.
+    The page of should have a line of the form "Date: Fri, 19 Jan 2018 19:26:41 UTC"
+    >>> get_updated_debian(mirror_url)
+    datetime.datetime(2018, 1, 19, 19, 26, 41, tzinfo=tzutc())
     """
     req = requests.get(mirror_url)
     req.raise_for_status()

--- a/modules/ocf_mirrors/files/healthcheck
+++ b/modules/ocf_mirrors/files/healthcheck
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Test if the Debian-style mirror hasn't been updated recently.
+"""Test if the Debian-style or timestamp mirror hasn't been updated recently.
 
 This detects most problems caused by both failed syncs to our direct upstream
 as well as cases where the upstream is out-of-date.
@@ -11,6 +11,7 @@ mirrors.kernel.org).
 import argparse
 import sys
 from collections import namedtuple
+from datetime import datetime
 from datetime import timedelta
 
 import dateutil.parser
@@ -19,9 +20,29 @@ import requests
 Mirror = namedtuple('Mirror', ['url', 'updated_at'])
 
 
-def get_updated(mirror_url):
-    """Find the time the host was last updated.
+def update_func(healthcheck):
+    if healthcheck == 'debian':
+        return get_updated_debian
+    elif healthcheck == 'ts':
+        return get_updated_ts
+    else:
+        return get_updated_debian
 
+
+def get_updated_ts(mirror_url):
+    """Find the time the host was last synced"""
+
+    req = requests.get(mirror_url)
+    req.raise_for_status()
+    try:
+        return datetime.utcfromtimestamp(int(req.text.split()[0]))
+    except (TypeError, ValueError):
+        # UTC Timestamp ... parrot
+        return dateutil.parser.parse(req.text.splitlines()[0])
+
+
+def get_updated_debian(mirror_url):
+    """Find the time the host was last updated.
     >>> get_updated(args.local_url)
     datetime.datetime(2015, 12, 26, 9, 9, 42, tzinfo=tzutc())
     """
@@ -31,9 +52,9 @@ def get_updated(mirror_url):
     return dateutil.parser.parse(updated_line.split(': ', 1)[1])
 
 
-def get_mirrors(url_first, url_second):
-    """Given two mirror urls, returns two Mirror
-    namedtuples ordered (asc) by update date."""
+def get_mirrors(url_first, url_second, get_updated):
+    """Given two mirror urls, return two Mirror
+    namedtuples ordered (asc) by sync date."""
 
     mirror_first = Mirror(url_first, get_updated(url_first))
     mirror_second = Mirror(url_second, get_updated(url_second))
@@ -44,10 +65,10 @@ def get_mirrors(url_first, url_second):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
-    # urls of local and upstream mirrors
     parser.add_argument('project', type=str, help='Project title')
     parser.add_argument('url_first', type=str, help='URL of local or upstream mirror')
     parser.add_argument('url_second', type=str, help='URL of local or upstream mirror')
+    parser.add_argument('-t', '--type', type=str, default='debian')
 
     # ensure we aren't comparing a mirror against itself
     args = parser.parse_args()
@@ -55,7 +76,8 @@ if __name__ == '__main__':
         print('Local and upstream urls cannot be equal... Exiting!')
         sys.exit(1)
 
-    local_mirror, upstream_mirror = get_mirrors(args.url_first, args.url_second)
+    # Assume our mirror is out of date
+    local_mirror, upstream_mirror = get_mirrors(args.url_first, args.url_second, update_func(args.type))
 
     # instead of comparing against current time, compare against the master server;
     # this helps avoid flaky monitoring if the upstream archive isn't updated

--- a/modules/ocf_mirrors/manifests/apache.pp
+++ b/modules/ocf_mirrors/manifests/apache.pp
@@ -9,6 +9,13 @@ class ocf_mirrors::apache {
       recurse => true;
   }
 
+  ocf_mirrors::monitoring { 'apache':
+    type          => 'ts',
+    upstream_host => 'archive.apache.org',
+    upstream_path => '/dist',
+    ts_path       => 'zzz/time.txt',
+  }
+
   cron {
     'apache':
       command => '/opt/mirrors/project/apache/sync-archive > /dev/null',

--- a/modules/ocf_mirrors/manifests/apache.pp
+++ b/modules/ocf_mirrors/manifests/apache.pp
@@ -10,7 +10,7 @@ class ocf_mirrors::apache {
   }
 
   ocf_mirrors::monitoring { 'apache':
-    type          => 'ts',
+    type          => 'unix_timestamp',
     upstream_host => 'archive.apache.org',
     upstream_path => '/dist',
     ts_path       => 'zzz/time.txt',

--- a/modules/ocf_mirrors/manifests/archlinux.pp
+++ b/modules/ocf_mirrors/manifests/archlinux.pp
@@ -10,7 +10,7 @@ class ocf_mirrors::archlinux {
   }
 
   ocf_mirrors::monitoring { 'archlinux':
-    type          => 'ts',
+    type          => 'unix_timestamp',
     upstream_host => 'mirrors.kernel.org',
     ts_path       => 'lastsync',
   }

--- a/modules/ocf_mirrors/manifests/archlinux.pp
+++ b/modules/ocf_mirrors/manifests/archlinux.pp
@@ -9,6 +9,12 @@ class ocf_mirrors::archlinux {
       recurse => true;
   }
 
+  ocf_mirrors::monitoring { 'archlinux':
+    type          => 'ts',
+    upstream_host => 'mirrors.kernel.org',
+    ts_path       => 'lastsync',
+  }
+
   cron {
     'archlinux':
       command => '/opt/mirrors/project/archlinux/sync-archive > /dev/null',

--- a/modules/ocf_mirrors/manifests/centos.pp
+++ b/modules/ocf_mirrors/manifests/centos.pp
@@ -8,6 +8,12 @@ class ocf_mirrors::centos {
     recurse => true,
   }
 
+  ocf_mirrors::monitoring { 'centos':
+      type          => 'ts',
+      upstream_host => 'mirror.centos.org',
+      ts_path       => 'TIME',
+  }
+
   cron {
     'centos':
       command => '/opt/mirrors/project/centos/sync-archive > /dev/null',

--- a/modules/ocf_mirrors/manifests/centos.pp
+++ b/modules/ocf_mirrors/manifests/centos.pp
@@ -9,7 +9,7 @@ class ocf_mirrors::centos {
   }
 
   ocf_mirrors::monitoring { 'centos':
-      type          => 'ts',
+      type          => 'unix_timestamp',
       upstream_host => 'mirror.centos.org',
       ts_path       => 'TIME',
   }

--- a/modules/ocf_mirrors/manifests/gnu.pp
+++ b/modules/ocf_mirrors/manifests/gnu.pp
@@ -9,6 +9,12 @@ class ocf_mirrors::gnu {
       recurse => true;
   }
 
+  ocf_mirrors::monitoring { 'gnu':
+    type          => 'ts',
+    upstream_host => 'ftp.gnu.org',
+    ts_path       => 'mirror-updated-timestamp.txt',
+  }
+
   cron {
     'gnu':
       command => '/opt/mirrors/project/gnu/sync-archive > /dev/null',

--- a/modules/ocf_mirrors/manifests/gnu.pp
+++ b/modules/ocf_mirrors/manifests/gnu.pp
@@ -10,7 +10,7 @@ class ocf_mirrors::gnu {
   }
 
   ocf_mirrors::monitoring { 'gnu':
-    type          => 'ts',
+    type          => 'unix_timestamp',
     upstream_host => 'ftp.gnu.org',
     ts_path       => 'mirror-updated-timestamp.txt',
   }

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -178,8 +178,8 @@ class ocf_mirrors {
     special => 'daily',
   }
 
-  file { '/opt/mirrors/bin/debian-healthcheck':
-    source  => 'puppet:///modules/ocf_mirrors/debian-healthcheck',
+  file { '/opt/mirrors/bin/healthcheck':
+    source  => 'puppet:///modules/ocf_mirrors/healthcheck',
     owner   => 'mirrors',
     group   => 'mirrors',
     mode    => '0755',

--- a/modules/ocf_mirrors/manifests/monitoring.pp
+++ b/modules/ocf_mirrors/manifests/monitoring.pp
@@ -9,14 +9,15 @@ define ocf_mirrors::monitoring(
     $ts_path = undef,
     $ensure = 'present',
   ) {
+  $local_base = "http://mirrors.ocf.berkeley.edu${local_path}"
+  $upstream_base = "${upstream_protocol}://${upstream_host}${upstream_path}"
 
   if $type == 'debian' {
-    $local_url = "http://mirrors.ocf.berkeley.edu${local_path}/dists/${dist_to_check}/Release"
-    $upstream_url = "${upstream_protocol}://${upstream_host}${upstream_path}/dists/${dist_to_check}/Release"
-  }
-  elsif $type == 'ts' {
-    $local_url ="http://mirrors.ocf.berkeley.edu${local_path}/${ts_path}"
-    $upstream_url = "${upstream_protocol}://${upstream_host}${upstream_path}/${ts_path}"
+    $local_url = "${local_base}/dists/${dist_to_check}/Release"
+    $upstream_url = "${upstream_base}/dists/${dist_to_check}/Release"
+  } elsif $type == 'ts' or $type == 'datetime' {
+    $local_url ="${local_base}/${ts_path}"
+    $upstream_url = "${upstream_base}/${ts_path}"
   }
   if $ensure == 'present' {
     file { "${project_path}/health":

--- a/modules/ocf_mirrors/manifests/monitoring.pp
+++ b/modules/ocf_mirrors/manifests/monitoring.pp
@@ -15,7 +15,7 @@ define ocf_mirrors::monitoring(
   if $type == 'debian' {
     $local_url = "${local_base}/dists/${dist_to_check}/Release"
     $upstream_url = "${upstream_base}/dists/${dist_to_check}/Release"
-  } elsif $type == 'ts' or $type == 'datetime' {
+  } elsif $type == 'unix_timestamp' or $type == 'datetime' {
     $local_url ="${local_base}/${ts_path}"
     $upstream_url = "${upstream_base}/${ts_path}"
   }

--- a/modules/ocf_mirrors/manifests/monitoring.pp
+++ b/modules/ocf_mirrors/manifests/monitoring.pp
@@ -19,6 +19,7 @@ define ocf_mirrors::monitoring(
     $local_url ="${local_base}/${ts_path}"
     $upstream_url = "${upstream_base}/${ts_path}"
   }
+
   if $ensure == 'present' {
     file { "${project_path}/health":
       ensure => link,

--- a/modules/ocf_mirrors/manifests/monitoring.pp
+++ b/modules/ocf_mirrors/manifests/monitoring.pp
@@ -6,19 +6,27 @@ define ocf_mirrors::monitoring(
     $local_path = "/${title}",
     $upstream_path = "/${title}",
     $upstream_protocol = 'http',
+    $ts_path = undef,
     $ensure = 'present',
   ) {
-  $local_url = "http://mirrors.ocf.berkeley.edu${local_path}/dists/${dist_to_check}/Release"
-  $upstream_url = "${upstream_protocol}://${upstream_host}${upstream_path}/dists/${dist_to_check}/Release"
+
+  if $type == 'debian' {
+    $local_url = "http://mirrors.ocf.berkeley.edu${local_path}/dists/${dist_to_check}/Release"
+    $upstream_url = "${upstream_protocol}://${upstream_host}${upstream_path}/dists/${dist_to_check}/Release"
+  }
+  elsif $type == 'ts' {
+    $local_url ="http://mirrors.ocf.berkeley.edu${local_path}/${ts_path}"
+    $upstream_url = "${upstream_protocol}://${upstream_host}${upstream_path}/${ts_path}"
+  }
   if $ensure == 'present' {
     file { "${project_path}/health":
       ensure => link,
-      target => "/opt/mirrors/bin/${type}-healthcheck",
+      target => '/opt/mirrors/bin/healthcheck',
       owner  => mirrors,
       group  => mirrors,
     } ->
     cron { "${title}-health":
-      command => "${project_path}/health ${title} ${local_url} ${upstream_url}",
+      command => "${project_path}/health ${title} ${local_url} ${upstream_url} --type=${type}",
       user    => mirrors,
       hour    => '*/6',
       minute  => '0';

--- a/modules/ocf_mirrors/manifests/parrot.pp
+++ b/modules/ocf_mirrors/manifests/parrot.pp
@@ -9,6 +9,12 @@ class ocf_mirrors::parrot {
       recurse => true;
   }
 
+  ocf_mirrors::monitoring { 'parrot':
+    type          => 'ts',
+    upstream_host => 'archive2.parrotsec.org',
+    ts_path       => 'last-sync.txt',
+  }
+
   cron {
     'parrot':
       command => '/opt/mirrors/project/parrot/sync > /dev/null',

--- a/modules/ocf_mirrors/manifests/parrot.pp
+++ b/modules/ocf_mirrors/manifests/parrot.pp
@@ -10,7 +10,7 @@ class ocf_mirrors::parrot {
   }
 
   ocf_mirrors::monitoring { 'parrot':
-    type          => 'ts',
+    type          => 'datetime',
     upstream_host => 'archive2.parrotsec.org',
     ts_path       => 'last-sync.txt',
   }

--- a/modules/ocf_mirrors/manifests/qt.pp
+++ b/modules/ocf_mirrors/manifests/qt.pp
@@ -10,7 +10,7 @@ class ocf_mirrors::qt {
   }
 
   ocf_mirrors::monitoring { 'qt':
-    type          => 'ts',
+    type          => 'unix_timestamp',
     upstream_host => 'download.qt.io',
     upstream_path => '',
     ts_path       => 'timestamp.txt',

--- a/modules/ocf_mirrors/manifests/qt.pp
+++ b/modules/ocf_mirrors/manifests/qt.pp
@@ -9,6 +9,13 @@ class ocf_mirrors::qt {
       recurse => true;
   }
 
+  ocf_mirrors::monitoring { 'qt':
+    type          => 'ts',
+    upstream_host => 'download.qt.io',
+    upstream_path => '',
+    ts_path       => 'timestamp.txt',
+  }
+
   cron {
     'qt':
       command => '/opt/mirrors/project/qt/sync-archive > /dev/null',

--- a/modules/ocf_mirrors/manifests/tails.pp
+++ b/modules/ocf_mirrors/manifests/tails.pp
@@ -11,7 +11,8 @@ class ocf_mirrors::tails {
 
   ocf_mirrors::monitoring { 'tails':
     type          => 'ts',
-    upstream_host => 'mirrors.kernel.org',
+    upstream_host => 'archive.torproject.org',
+    upstream_path => '/amnesia.boum.org/tails',
     ts_path       => 'project/trace',
   }
 

--- a/modules/ocf_mirrors/manifests/tails.pp
+++ b/modules/ocf_mirrors/manifests/tails.pp
@@ -9,6 +9,12 @@ class ocf_mirrors::tails {
       recurse => true;
   }
 
+  ocf_mirrors::monitoring { 'tails':
+    type          => 'ts',
+    upstream_host => 'mirrors.kernel.org',
+    ts_path       => 'project/trace',
+  }
+
   cron {
     'tails':
       command => '/opt/mirrors/project/tails/sync > /dev/null',

--- a/modules/ocf_mirrors/manifests/tails.pp
+++ b/modules/ocf_mirrors/manifests/tails.pp
@@ -10,7 +10,7 @@ class ocf_mirrors::tails {
   }
 
   ocf_mirrors::monitoring { 'tails':
-    type          => 'ts',
+    type          => 'unix_timestamp',
     upstream_host => 'archive.torproject.org',
     upstream_path => '/amnesia.boum.org/tails',
     ts_path       => 'project/trace',


### PR DESCRIPTION
Made the healthcheck script and ocf_mirrors::monitoring more generalized.

Healthchecks for apache, arch, centos, gnu, parrot, qt, tails.