### PR TITLE
Add fluffy CLI to our hosts

### DIFF
--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -79,6 +79,7 @@ class ocf::packages {
     'dnsutils',
     'dtach',
     'finger',
+    'fluffy',
     'gist',
     'hexedit',
     'htop',


### PR DESCRIPTION
I'd like to propose adding the fluffy CLI tools to our hosts. This uses the Debian package from https://github.com/chriskuehl/fluffy. The package is extremely lightweight (the .deb is ~3100 bytes):

```bash
$ dpkg -L fluffy
/.
/usr
/usr/bin
/usr/bin/fpb
/usr/bin/fput
/usr/share
/usr/share/doc
/usr/share/doc/fluffy
/usr/share/doc/fluffy/changelog.gz
```

(I've already uploaded this to our apt repo for jessie + stretch in order to test this branch.)

Obviously fluffy is not any kind of "official" pastebin/file-hosting for OCF, but we use it frequently enough that, in my humble and totally biased opinion, it's worth installing these CLI tools on our hosts.

We do already have `gist`, but people seem to prefer fluffy (and again, in my totally and completely biased opinion, I think fluffy's pastebin feature is better in many ways).

Here are some ways you can use these command-line tools:

```bash
# you can paste files
$ fpb setup.py
https://i.fluffy.cc/9dd7zcfqML2JGcbZKhs2Xpzzpf9pctXW.html

# you can pipe text to it
$ git show | fpb
https://i.fluffy.cc/7BRxK6wz7JShdMJPgzPl5Gj0KRQQJ1HC.html

# you can use "-r" to regex highlight lines (especially useful for logfiles)
$ fpb -r '^def ' ocflib/account/search.py
https://i.fluffy.cc/hd7WwrlkQ8zzpDhK65K1cKnH9Jcwv7tb.html#L11,L23,L29,L35,L54,L59,L64,L69
```

Here are some examples for uploading files:

```bash
$ fput my-file.png
$ fput assets/*.css assets/*.png
```

I chose `ocf::packages` instead of extrapackages because I pretty frequently want to pastebin lines from random servers (e.g. a couple days ago I was manually copy-pasting lines from firestorm). Given the very small package size, I don't think there is much cost to installing this everywhere, but it could make our lives easier.