### PR TITLE
munin-mail-alert: compensate for adding cc to ocflib send_mail

### DIFF
--- a/modules/ocf_stats/files/munin/mail-munin-alert
+++ b/modules/ocf_stats/files/munin/mail-munin-alert
@@ -78,7 +78,7 @@ def send_alert(host, plugin, mail_to=MAIL_TO):
         ldap_entry=ldap_entry,
         dns_names=dns_names,
     )
-    send_mail(mail_to, subject, body, MAIL_FROM)
+    send_mail(to=mail_to, subject=subject, body=body, cc=None, sender=MAIL_FROM)
 
 
 def main(argv):


### PR DESCRIPTION
since https://github.com/ocf/ocflib/pull/114 was merged, munin alerts have been sent with from: help@ocf.berkeley.edu because that's the default in ocflib/misc/mail.py. This should fix that.