### PR TITLE
Add fallback for PuppetDB failure.

### DIFF
--- a/modules/ocf/facts.d/puppetdb-running
+++ b/modules/ocf/facts.d/puppetdb-running
@@ -1,8 +1,13 @@
 #!/bin/bash
-set -euo pipefail
+set -uo pipefail
+fqdn=$(hostname -f)
 
-curl http://puppetdb:8081/pdb/query/v4/nodes
-if [[ "$?" -eq 0 ]]; then
+# Due to differences between the puppet and puppet-agent packages, the SSL directory may be in /etc/puppetlabs/puppet or /var/lib/puppet
+puppet_ssl_path=$(puppet config print ssldir)
+
+curl 'https://puppetdb:8081/pdb/query/v4/nodes' -s --tlsv1 --cacert $puppet_ssl_path/certs/ca.pem --cert $puppet_ssl_path/certs/$fqdn.pem --key $puppet_ssl_path/private_keys/$fqdn.pem > /dev/null
+
+if [[ $? -eq 0 ]]; then
     echo 'puppetdb_running=true'
 else
     echo 'puppetdb_running=false'

--- a/modules/ocf/facts.d/puppetdb-running
+++ b/modules/ocf/facts.d/puppetdb-running
@@ -1,13 +1,16 @@
 #!/bin/bash
-set -uo pipefail
-fqdn=$(hostname -f)
+set -euo pipefail
 
-# Due to differences between the puppet and puppet-agent packages, the SSL directory may be in /etc/puppetlabs/puppet or /var/lib/puppet
+fqdn=$(hostname -f)
+# Due to differences between the puppet and puppet-agent packages,
+# the SSL directory may be in /etc/puppetlabs/puppet or /var/lib/puppet.
 puppet_ssl_path=$(puppet config print ssldir)
 
-curl 'https://puppetdb:8081/pdb/query/v4/nodes' -s --tlsv1 --cacert $puppet_ssl_path/certs/ca.pem --cert $puppet_ssl_path/certs/$fqdn.pem --key $puppet_ssl_path/private_keys/$fqdn.pem > /dev/null
-
-if [[ $? -eq 0 ]]; then
+if curl 'https://puppetdb:8081/pdb/meta/v1/version' -s --tlsv1 \
+        --cacert "$puppet_ssl_path/certs/ca.pem" \
+        --cert "$puppet_ssl_path/certs/$fqdn.pem" \
+        --key "$puppet_ssl_path/private_keys/$fqdn.pem" \
+        > /dev/null; then
     echo 'puppetdb_running=true'
 else
     echo 'puppetdb_running=false'

--- a/modules/ocf/facts.d/puppetdb-running
+++ b/modules/ocf/facts.d/puppetdb-running
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+curl http://puppetdb:8081/pdb/query/v4/nodes
+if [[ "$?" -eq 0 ]]; then
+    echo 'puppetdb_running=true'
+else
+    echo 'puppetdb_running=false'
+fi

--- a/modules/ocf/manifests/auth.pp
+++ b/modules/ocf/manifests/auth.pp
@@ -143,14 +143,16 @@ class ocf::auth($glogin = [], $ulogin = [[]], $gsudo = [], $usudo = [], $nopassw
     $::ipaddress6,
   ), '')
 
-  # Export SSH keys from every host, and use them to populate the global list
-  # in /etc/ssh/ssh_known_hosts
-  @@sshkey { $::hostname:
-    host_aliases => $ssh_aliases,
-    key          => $::sshecdsakey,
-    type         => ecdsa-sha2-nistp256,
+  # Export SSH keys from every host if PuppetDB is running, and use them to populate the global list
+  # in /etc/ssh/ssh_known_hosts.
+  if str2bool($::puppetdb_running) {
+    @@sshkey { $::hostname:
+      host_aliases => $ssh_aliases,
+      key          => $::sshecdsakey,
+      type         => ecdsa-sha2-nistp256,
+    }
+    Sshkey <<| |>>
   }
-  Sshkey <<| |>>
 
   file { '/etc/ssh/ssh_known_hosts':
     mode => '0644',

--- a/modules/ocf/manifests/auth.pp
+++ b/modules/ocf/manifests/auth.pp
@@ -143,8 +143,8 @@ class ocf::auth($glogin = [], $ulogin = [[]], $gsudo = [], $usudo = [], $nopassw
     $::ipaddress6,
   ), '')
 
-  # Export SSH keys from every host if PuppetDB is running, and use them to populate the global list
-  # in /etc/ssh/ssh_known_hosts.
+  # Export SSH keys from every host if PuppetDB is running, and use them
+  # to populate the global list in /etc/ssh/ssh_known_hosts.
   if str2bool($::puppetdb_running) {
     @@sshkey { $::hostname:
       host_aliases => $ssh_aliases,
@@ -152,10 +152,10 @@ class ocf::auth($glogin = [], $ulogin = [[]], $gsudo = [], $usudo = [], $nopassw
       type         => ecdsa-sha2-nistp256,
     }
     Sshkey <<| |>>
-  }
 
-  file { '/etc/ssh/ssh_known_hosts':
-    mode => '0644',
+    file { '/etc/ssh/ssh_known_hosts':
+      mode => '0644',
+    }
   }
 
   # sudo user/group access controls


### PR DESCRIPTION
During the recent outage, we were unable to puppet new hosts since PuppetDB had failed. This caused Puppet to completely fail, since it depends on PuppetDB to collect all SSH keys for known_hosts. This fix adds a custom fact script to check if PuppetDB is running, and only collects/exports SSH keys if it is up.

In the future, if more features utilizing exported resources are added, they'll have to be wrapped in an if block with this variable.