### PR TITLE
backup-mysql: make a file per database

### DIFF
--- a/modules/ocf_backups/files/backup-mysql
+++ b/modules/ocf_backups/files/backup-mysql
@@ -1,10 +1,20 @@
 #!/bin/bash -eu
-# Creates a MySQL backup in the current directory. Intended to be called by
-# rsnapshot.
-set -o pipefail
-mysqldump \
-    --defaults-file=/opt/share/backups/my.cnf \
-    --events \
-    --triggers \
-    --all-databases --single-transaction | \
-    pigz > "mysql-$(date +%F).sql.gz"
+# Creates a MySQL backup in the current directory, with one file per database.
+# Intended to be called by rsnapshot.
+
+# credit:
+# https://mensfeld.pl/2013/04/backup-mysql-dump-all-your-mysql-databases-in-separate-files/
+
+set -euo pipefail
+
+databases=$(mysql --defaults-file=/opt/share/backups/my.cnf -e "SHOW databases;" | \
+		   grep -Ev "(Database|information_schema|performance_schema)")
+
+parallel -i \
+    sh -c 'mysqldump \
+             --defaults-file=/opt/share/backups/my.cnf \
+             --events \
+             --triggers \
+             --routines \
+             --single-transaction \
+             --databases {} | pigz > "mysql-{}-$(date +%F).sql.gz"' -- $databases


### PR DESCRIPTION
This implements one of the items on the post-1/17/18-outage to-do list, which is to make more granular backups of mysql. This makes one file per mysql database. At the time of writing, that means 1845 files, about 2.8GB total.

[Here](https://i.fluffy.cc/N8GZgF3kNF9rzC1tqtc7ztM9jqqwLq8H.html) is an rough alternative that only separates the dump into ocf/non-ocf databases. 

Some statistics:
1. The script in this PR:

        root@hal:/opt/backups/scratch/mysqltest# time ../backup-mysql

        real    2m59.271s
        user    22m51.684s
        sys     4m20.868s

2. The alternative script (ocf/non-ocf)

        root@hal:/opt/backups/scratch/mysqltest# time ../backup-mysql-alt

        real    11m33.717s
        user    22m14.784s
        sys     3m37.496s

3. The existing script:

        root@hal:/opt/backups/scratch/mysqltest# time /opt/share/backups/backup-mysql

        real    11m19.520s
        user    22m8.972s
        sys     3m41.952s

I also changed the user in my.cnf to a read-only root user named `root_ro`, with the password in the usual location. 

Feedback is appreciated.