### PR TITLE
Centralize logging for all VMs

### DIFF
--- a/modules/ocf/manifests/init.pp
+++ b/modules/ocf/manifests/init.pp
@@ -7,6 +7,7 @@ class ocf {
   include ocf::kerberos
   include ocf::ldap
   include ocf::locale
+  include ocf::logging
   include ocf::motd
   include ocf::munin::node
   include ocf::networking

--- a/modules/ocf/manifests/logging.pp
+++ b/modules/ocf/manifests/logging.pp
@@ -1,0 +1,21 @@
+class ocf::logging {
+  package { 'rsyslog': }
+
+  service { 'rsyslog':
+    require => Package['rsyslog'],
+  }
+
+  augeas { 'remote-syslog':
+    context => '/files/etc/rsyslog.conf',
+    changes => [
+      'set entry[last()+1]/selector/facility *',
+      'set entry[last()]/selector/level *',
+      'set entry[last()]/action/protocol @@',
+      'set entry[last()]/action/hostname syslog',
+      'set entry[last()]/action/port 514',
+    ],
+    onlyif  => "match entry[action/hostname = 'syslog'] size == 0",
+    notify  => Service['rsyslog'],
+    require => Package['rsyslog'],
+  }
+}

--- a/modules/ocf_syslog/files/logrotate
+++ b/modules/ocf_syslog/files/logrotate
@@ -1,4 +1,4 @@
-/var/log/remote/*.log {
+/var/log/remote/*/*/*.log {
     daily
     missingok
     rotate 14

--- a/modules/ocf_syslog/files/ocf.conf
+++ b/modules/ocf_syslog/files/ocf.conf
@@ -5,6 +5,16 @@ input(type="imtcp" port="514" ruleset="ocf-remote")
 module(load="imudp")
 input(type="imudp" port="514" ruleset="ocf-remote")
 
+# global options when writing to or creating files
+module(
+  load="builtin:omfile"
+  template="ocf-remote"
+  fileGroup="ocfstaff"
+  fileCreateMode="0640"
+  dirGroup="ocfstaff"
+  dirCreateMode="0750"
+)
+
 # template for remote log lines
 template(name="ocf-remote" type="list") {
     property(name="timegenerated" dateFormat="rfc3339")
@@ -15,41 +25,46 @@ template(name="ocf-remote" type="list") {
     constant(value="\n")
 }
 
-# template for errored remote log lines
-template(name="ocf-errors" type="list") {
-    constant(value="ERRORED_TAG[")
-    property(name="syslogtag")
-    constant(value="]  MESSAGE[")
-    property(name="timegenerated" dateFormat="rfc3339")
-    constant(value=" ")
-    property(name="hostname")
-    constant(value=":  ")
-    property(name="msg")
-    constant(value="]\n")
+# template for remote docker log filenames
+template(name="ocf-docker-file" type="list") {
+    constant(value="/var/log/remote/services/")
+    # in jessie, syslogtag has a weird ":" appended, so we have to regex that out;
+    # the regex bits can be removed when we're totally on stretch.
+    property(name="syslogtag" regex.Expression="^[^:]+" regex.Type="ERE" regex.Match="0" securepath="replace")
+    constant(value="/")
+    property(name="syslogtag" regex.Expression="^[^:]+" regex.Type="ERE" regex.Match="0" securepath="replace")
+    constant(value=".log")
 }
 
 # template for remote log filenames
 template(name="ocf-remote-file" type="list") {
     constant(value="/var/log/remote/")
-    # in jessie, syslogtag has a weird ":" appended, so we have to regex that out;
-    # the regex bits can be removed when we're totally on stretch.
-    property(name="syslogtag" regex.Expression="^[^:]+" regex.Type="ERE" regex.Match="0" SecurePath="replace")
+    property(name="hostname" securepath="replace")
+    constant(value="/")
+    property(name="programname" caseconversion="lower" securepath="replace")
+    constant(value="/")
+    property(name="programname" caseconversion="lower" securepath="replace")
     constant(value=".log")
 }
 
 # rules for storing the logs
 ruleset(name="ocf-remote") {
-    # This regex was fiendish, since the hyphen must be next to the end bracket
-    # for it to work.
+    # The regex for the syslogtag was fiendish, since the hyphen must be next
+    # to the end bracket for it to work.
     #
     # It uses POSIX ERE (http://www.regular-expressions.info/posixbrackets.html)
     # and has a tester at http://www.rsyslog.com/regex/
     #
     # Make sure this at least matches all the items let through in the regex in
     # the stdin2syslog script so that real logs aren't put in errors.log
-    if re_match($syslogtag, '^[a-zA-Z0-9:_-]+$') then {
-        action(type="omfile" dynaFile="ocf-remote-file" template="ocf-remote" fileGroup="ocfstaff" fileCreateMode="0640")
+    #
+    # The hostname matches docker-based hostnames only (12 hex characters) to
+    # separate them out into service logs instead of per host since we go
+    # through docker hosts quite quickly and we want to group logs by service
+    # for docker, not by host.
+    if re_match($hostname, '^[a-f0-9]{12}$') and re_match($syslogtag, '^[a-zA-Z0-9:_-]+$') then {
+        action(type="omfile" dynaFile="ocf-docker-file")
     } else {
-        action(type="omfile" file="/var/log/remote/errors.log" template="ocf-errors" fileGroup="ocfstaff" fileCreateMode="0640")
+        action(type="omfile" dynaFile="ocf-remote-file")
     }
 }

--- a/modules/ocf_syslog/manifests/init.pp
+++ b/modules/ocf_syslog/manifests/init.pp
@@ -1,12 +1,5 @@
 class ocf_syslog {
-  package { 'rsyslog': }
-
-  service { 'rsyslog':
-    require => [
-      Package['rsyslog'],
-      File['/etc/rsyslog.d/ocf.conf'],
-    ],
-  }
+  # rsyslog package and service are already defined in ocf::logging
 
   file {
     '/var/log/remote':


### PR DESCRIPTION
Also organize syslog to group by host and by service, since before all of the logs were just put into one directory, so with logrotate it got a little crazy.