### PR TITLE
disallow wall access for non-root users

### DIFF
--- a/modules/ocf/files/shell/bash.bashrc
+++ b/modules/ocf/files/shell/bash.bashrc
@@ -11,6 +11,9 @@ export LC_ALL=en_US.UTF-8
 # Non-restrictive umask
 umask 022
 
+# ignore messages from others
+mesg n
+
 # Set up bash-completion
 [ -r /etc/bash_completion ] && source /etc/bash_completion
 

--- a/modules/ocf/files/shell/config.fish
+++ b/modules/ocf/files/shell/config.fish
@@ -25,6 +25,9 @@ set -x LC_ALL en_US.UTF-8
 # Non-restrictive umask
 umask 022
 
+# ignore messages from others
+mesg n
+
 # Aliases
 alias ls "ls -F --color=auto"
 alias quota "quota -Qs"

--- a/modules/ocf/files/shell/csh.cshrc
+++ b/modules/ocf/files/shell/csh.cshrc
@@ -9,6 +9,9 @@ setenv MAIL /var/mail/$USER
 # Non-restrictive umask
 umask 022
 
+# ignore messages from others
+mesg n
+
 alias ls ls -F
 alias quota quota -Qs
 alias rm rm -I

--- a/modules/ocf/files/shell/zshrc
+++ b/modules/ocf/files/shell/zshrc
@@ -67,5 +67,8 @@ fi
 
 PROMPT="%{$fg_bold[$PROMPT_COLOR]%}%n@%m%{$reset_color%}:%{$fg_bold[blue]%}%~%{$reset_color%}$PROMPT_SYMBOL "
 
+# ignore messages from others
+mesg n
+
 alias ls="ls --color"
 alias grep="grep --color"

--- a/modules/ocf/manifests/init.pp
+++ b/modules/ocf/manifests/init.pp
@@ -17,4 +17,5 @@ class ocf {
   include ocf::staff_users
   include ocf::systemd
   include ocf::utils
+  include ocf::walldeny
 }

--- a/modules/ocf/manifests/walldeny.pp
+++ b/modules/ocf/manifests/walldeny.pp
@@ -1,0 +1,10 @@
+class ocf::walldeny {
+
+  # disable wall command for all users except root
+  file {
+    '/usr/bin/wall':
+      owner => root,
+      mode  => '0700';
+  }
+
+}


### PR DESCRIPTION
Recently I noticed several users were promoting blockchain@berkeley using the wall utility to broadcast messages to all users on tsunami. Getting frivolous broadcast messages can be annoying for users, as it opens room for spam.

I considered running `mesg n` on shell login, but that means we have to add it to the start files for bash,zsh, etc. Restricting access to the utility would be a better way to prevent spam.