### PR TITLE
Only do SSH GSSAPI key exchange with hosts in OCF network

### DIFF
--- a/modules/ocf/files/ssh_config
+++ b/modules/ocf/files/ssh_config
@@ -1,3 +1,7 @@
-GSSAPIAuthentication yes
-GSSAPIKeyExchange yes
-GSSAPIDelegateCredentials no
+CanonicalizeHostname yes
+CanonicalDomains ocf.berkeley.edu
+
+Host *.ocf.berkeley.edu 169.229.226.* 2607:f140:8801::*
+     GSSAPIAuthentication yes
+     GSSAPIKeyExchange yes
+     GSSAPIDelegateCredentials no


### PR DESCRIPTION
This should hopefully solve the issue of it taking forever to SSH into
hosts outside the OCF network because those hosts attempt to
contact their nonexistent Kerberos servers or whatever it is