### PR TITLE
ocf_desktop: fix parsing of who command

### DIFF
--- a/modules/ocf_desktop/files/stats/update.sh
+++ b/modules/ocf_desktop/files/stats/update.sh
@@ -3,7 +3,7 @@
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=842226
 [ "$(imvirt 2>/dev/null)" == "Physical" ] || exit 0 # only count hours on desktops
 
-CUR_USER=$(who | awk '$5 == "(:0)" { print $1 }')
+CUR_USER=$(who | awk '$NF == "(:0)" { print $1 }')
 DATA="state=inactive"
 
 if [ -n "$CUR_USER" ]; then


### PR DESCRIPTION
The number of spaces in the time field varies with the
locale setting. To deal with this variation, find the display
using the last field of the output rather than by hardcoding
a field number.