### PR TITLE
Pin marathon-lb to a specific version (rt#6870)

### DIFF
--- a/modules/ocf_mesos/files/master/load_balancer/ocf-lb.service
+++ b/modules/ocf_mesos/files/master/load_balancer/ocf-lb.service
@@ -4,7 +4,7 @@ After=docker.service
 Wants=docker.service
 
 [Service]
-ExecStart=/usr/bin/docker run -v /opt/share/mesos/master/marathon-lb:/srv:ro --rm -e PORTS=9090 --net=host mesosphere/marathon-lb:v1.11.3 sse -m http://localhost:8080 --group lb --dont-bind-http-https --marathon-auth-credential-file /srv/credential
+ExecStart=/usr/bin/docker run -v /opt/share/mesos/master/marathon-lb:/srv:ro --rm -e PORTS=9090 --net=host mesosphere/marathon-lb:v1.11.5 sse -m http://localhost:8080 --group lb --dont-bind-http-https --marathon-auth-credential-file /srv/credential
 Restart=always
 RestartSec=15
 SyslogIdentifier=ocf-lb

--- a/modules/ocf_mesos/files/master/load_balancer/ocf-lb.service
+++ b/modules/ocf_mesos/files/master/load_balancer/ocf-lb.service
@@ -4,7 +4,7 @@ After=docker.service
 Wants=docker.service
 
 [Service]
-ExecStart=/usr/bin/docker run -v /opt/share/mesos/master/marathon-lb:/srv:ro --rm -e PORTS=9090 --net=host mesosphere/marathon-lb sse -m http://localhost:8080 --group lb --dont-bind-http-https --marathon-auth-credential-file /srv/credential
+ExecStart=/usr/bin/docker run -v /opt/share/mesos/master/marathon-lb:/srv:ro --rm -e PORTS=9090 --net=host mesosphere/marathon-lb:v1.11.3 sse -m http://localhost:8080 --group lb --dont-bind-http-https --marathon-auth-credential-file /srv/credential
 Restart=always
 RestartSec=15
 SyslogIdentifier=ocf-lb


### PR DESCRIPTION
This will make updating marathon-lb possible instead of the current problem where upgrading marathon-lb is a very manual process, because restarting ocf-lb doesn't work because it'll use the current version downloaded already instead of fetching a new version. Pinning to a specific version makes this both more stable and makes it possible to upgrade when wanted, and I think it's better than having a cronjob that upgrades for us since that'll be more unpredictable about when we might get breaking changes.