### PR TITLE
Add scdaemon to desktops

### DIFF
--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -42,6 +42,8 @@ class ocf_desktop::packages {
     ['libnotify-bin', 'notification-daemon']:;
     # performance improvements
     ['preload']:;
+    # security tools
+    ['scdaemon']:;
     # Xorg
     ['xserver-xorg', 'xclip', 'xscreensaver']:;
   }


### PR DESCRIPTION
scdaemon allows for `gpg --edit-card` and other tools to query smart cards for information. This is useful for e.g. my yubikey and other hardware 2FA with gpg.

Also I'm not familiar with Puppet, so apologies if I'm an idiot.