### PR TITLE
ocf_kvm: Add virtual machine facts

### DIFF
--- a/modules/ocf_kvm/facts.d/vms
+++ b/modules/ocf_kvm/facts.d/vms
@@ -4,19 +4,20 @@ import subprocess
 
 
 def run_command(command_args):
-    output = subprocess.check_output(command_args).decode('utf-8').split('\n')
+    output = subprocess.check_output(command_args).decode('utf-8').splitlines()
 
     # Return the command output split by line with any empty lines removed
     return list(filter(None, output))
 
 
-vms_all = run_command(('/usr/bin/virsh', 'list', '--name', '--all'))
-vms_inactive = run_command(('/usr/bin/virsh', 'list', '--name', '--inactive'))
+if __name__ == '__main__':
+    vms_all = run_command(('/usr/bin/virsh', 'list', '--name', '--all'))
+    vms_inactive = run_command(('/usr/bin/virsh', 'list', '--name', '--inactive'))
 
-print(json.dumps(
-    {
-        'vms': vms_all,
-        'vms_off': vms_inactive,
-        'vms_on': list(set(vms_all) - set(vms_inactive)),
-    },
-))
+    print(json.dumps(
+        {
+            'vms': vms_all,
+            'vms_off': vms_inactive,
+            'vms_on': list(set(vms_all) - set(vms_inactive)),
+        },
+    ))

--- a/modules/ocf_kvm/facts.d/vms
+++ b/modules/ocf_kvm/facts.d/vms
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+
+
+def run_command(command_args):
+    output = subprocess.check_output(command_args).decode('utf-8').split('\n')
+
+    # Return the command output split by line with any empty lines removed
+    return list(filter(None, output))
+
+
+vms_all = run_command(('/usr/bin/virsh', 'list', '--name', '--all'))
+vms_inactive = run_command(('/usr/bin/virsh', 'list', '--name', '--inactive'))
+
+print(json.dumps(
+    {
+        'vms': vms_all,
+        'vms_off': vms_inactive,
+        'vms_on': list(set(vms_all) - set(vms_inactive)),
+    },
+))


### PR DESCRIPTION
Since [Facter 3.5, executable external facts can return structured data](https://puppet.com/docs/facter/3.5/release_notes.html#enhancements), so that's pretty cool. This script returns 3 different facts, [`vms`](https://puppet.ocf.berkeley.edu/fact/vms) for all virtual machines on a host, [`vms_off`](https://puppet.ocf.berkeley.edu/fact/vms_off) for VMs that are off/suspended/inactive, and [`vms_on`](https://puppet.ocf.berkeley.edu/fact/vms_on) for VMs that are on. I'm open to suggestions for other names, but I don't feel "active" and "inactive" give a sense of what a machine could be actually doing, so that's why I went with "off" and "on" instead.

This would ideally be used in combination with PuppetDB to make [https://ocf.io/servers](https://ocf.io/servers) more dynamic, since currently all the information on there is either fetched from LDAP, or hardcoded, so which VMs are on which hypervisors is often incorrect. We could also have a command or something to easily find which hypervisor a machine is on (or maybe we could put this somewhere in the motd when you log in to a server?)