### PR TITLE
Add prometheus daemon and node_exporter to ocf_stats

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,7 +7,10 @@ moduledir 'vendor'
 # why they are not working properly.
 
 mod 'alexharvey/firewall_multi',       '1.10.0'
+mod 'camptocamp-systemd',              '1.1.1' # Dependency of puppet-prometheus
 mod 'puppet-nginx',                    '0.10.0'
+mod 'puppet-archive',                  '2.3.0' # Dependency of puppet-prometheus
+mod 'puppet-prometheus',               '5.0.0'
 mod 'puppetlabs-apache',               '2.3.1'
 mod 'puppetlabs-apt',                  '4.5.1'
 mod 'puppetlabs-concat',               '4.1.1'

--- a/hieradata/nodes/leprosy.yaml
+++ b/hieradata/nodes/leprosy.yaml
@@ -1,5 +1,6 @@
 classes:
     - ocf::packages::docker
     - ocf_ocfweb::dev_config
+    - ocf_stats::prometheus
 
 owner: dkessler

--- a/modules/ocf_stats/manifests/init.pp
+++ b/modules/ocf_stats/manifests/init.pp
@@ -11,5 +11,6 @@ class ocf_stats {
   include ocf::firewall::output_printers
   include ocf_stats::labstats
   include ocf_stats::munin
+  include ocf_stats::prometheus
   include ocf_stats::www
 }

--- a/modules/ocf_stats/manifests/init.pp
+++ b/modules/ocf_stats/manifests/init.pp
@@ -11,6 +11,5 @@ class ocf_stats {
   include ocf::firewall::output_printers
   include ocf_stats::labstats
   include ocf_stats::munin
-  include ocf_stats::prometheus
   include ocf_stats::www
 }

--- a/modules/ocf_stats/manifests/prometheus.pp
+++ b/modules/ocf_stats/manifests/prometheus.pp
@@ -2,6 +2,7 @@
 class ocf_stats::prometheus {
   class { '::prometheus':
     version        => '2.0.0',
+    extra_options  => '--web.listen-address="127.0.0.1:9090" --web.route-prefix=/prometheus'
     alerts         => {},
     scrape_configs => [
       { 'job_name' => 'prometheus',

--- a/modules/ocf_stats/manifests/prometheus.pp
+++ b/modules/ocf_stats/manifests/prometheus.pp
@@ -9,7 +9,7 @@ class ocf_stats::prometheus {
         'scrape_timeout'  => '10s',
         'static_configs'  => [
           { 'targets' => [ 'localhost:9090' ],
-          'labels'  => { 'alias' => 'Prometheus'}
+            'labels'  => { 'alias' => 'Prometheus' }
           }
         ]
       },

--- a/modules/ocf_stats/manifests/prometheus.pp
+++ b/modules/ocf_stats/manifests/prometheus.pp
@@ -2,7 +2,7 @@
 class ocf_stats::prometheus {
   class { '::prometheus':
     version        => '2.0.0',
-    extra_options  => '--web.listen-address="127.0.0.1:9090" --web.route-prefix=/prometheus'
+    extra_options  => '--web.listen-address="127.0.0.1:9090" --web.route-prefix=/prometheus',
     alerts         => {},
     scrape_configs => [
       { 'job_name' => 'prometheus',

--- a/modules/ocf_stats/manifests/prometheus.pp
+++ b/modules/ocf_stats/manifests/prometheus.pp
@@ -22,7 +22,6 @@ class ocf_stats::prometheus {
             # We should probably figure out a better way of enumerating all the
             # hosts.
             'leprosy:9100',
-            'dementors:9100',
           ]
           }
         ]

--- a/modules/ocf_stats/manifests/prometheus.pp
+++ b/modules/ocf_stats/manifests/prometheus.pp
@@ -1,0 +1,35 @@
+# prometheus daemon config
+class ocf_stats::prometheus {
+  class { '::prometheus':
+    version        => '2.0.0',
+    alerts         => {},
+    scrape_configs => [
+      { 'job_name' => 'prometheus',
+        'scrape_interval' => '10s',
+        'scrape_timeout'  => '10s',
+        'static_configs'  => [
+          { 'targets' => [ 'localhost:9090' ],
+          'labels'  => { 'alias' => 'Prometheus'}
+          }
+        ]
+      },
+      { 'job_name' => 'node',
+        'scrape_interval' => '5s',
+        'scrape_timeout'  => '5s',
+        'static_configs'  => [
+          { 'targets' => [
+            # A list of all hosts to scrape.
+            # We should probably figure out a better way of enumerating all the
+            # hosts.
+            'leprosy:9100',
+            'dementors:9100',
+          ]
+          }
+        ]
+      }
+    ]
+  }
+
+  # TODO: eventually roll out node exporting to all hosts, instead of just here
+  include prometheus::node_exporter
+}


### PR DESCRIPTION
This PR should add the Prometheus monitoring daemon to dementors. Since this is just a trial run, it's a minimal configuration that only monitors dementors itself and leprosy (my staffvm).

In the future, we'd want to install `node_exporter` on all hosts, and install specialized exporters for specific software (like Apache). I'll document other goals in the project (other goals include Grafana for more dashboards, alerting, etc)

Right now, this setup will run the `node_exporter` HTTP server on port 9100, and the Prometheus dashboard on port 9090 on dementors. I'd like to at least reverse proxy the dashboard through Apache (suggestions welcome on how to do this). We should also discuss the security model for this-- my intuition tells me that metrics should by firewalled off from the outside world, and the dashboard should be restricted to `ocfstaff` through HTTP auth, but dissent/discussion about these points is welcome.