### PR TITLE
add wakeonlan to desktops

### DIFF
--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -45,6 +45,8 @@ class ocf_desktop::packages {
     ['preload']:;
     # security tools
     ['scdaemon']:;
+    # utilities
+    ['wakeonlan']:;
     # Xorg
     ['xclip', 'xsel', 'xserver-xorg', 'xscreensaver']:;
   }


### PR DESCRIPTION
i want to use `lab-wakeup` on desktops

i think this is generally useful for staff as well