### PR TITLE
Add LibreOffice 6.x from stretch-backports

### DIFF
--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -67,8 +67,9 @@ class ocf_desktop::packages {
       recommends => false;
     'gedit':
       recommends => false;
-    ['libreoffice-calc', 'libreoffice-draw', 'libreoffice-gnome', 'libreoffice-impress', 'libreoffice-pdfimport', 'libreoffice-writer', 'ure']:
-      recommends => false;
+    ['libreoffice-calc', 'libreoffice-draw', 'libreoffice-gnome', 'libreoffice-gtk3', 'libreoffice-impress', 'libreoffice-pdfimport', 'libreoffice-writer', 'ure']:
+      recommends => false,
+      backport_on => stretch;
     'thunar':
       recommends => false;
     ['virt-manager', 'virt-viewer']:


### PR DESCRIPTION
Updating from LibreOffice 5.2.x -> LibreOffice 6.x.
Added libreoffice-gtk3 so we don't look like the Obsolete Computing Facility.