### PR TITLE
ocf_mail: raise max message size to 25MiB

### DIFF
--- a/modules/ocf_mail/templates/postfix/main.cf.erb
+++ b/modules/ocf_mail/templates/postfix/main.cf.erb
@@ -42,6 +42,9 @@ default_privs = ocfmail
 virtual_alias_expansion_limit = 300
 virtual_alias_recursion_limit = 5
 
+# set max message size to 25MiB
+message_size_limit = 26214400
+
 # environment variables for LDAP GSSAPI bind
 import_environment = MAIL_CONFIG MAIL_DEBUG MAIL_LOGTAG TZ XAUTHORITY DISPLAY
     LANG=C KRB5CCNAME=FILE:/var/spool/postfix/krb5-cred


### PR DESCRIPTION
A member was trying to send attachments with a size of slightly larger than 10MB, and found that his emails were getting truncated and not going through.

Gmail and probably other mail providers use 25MB as the max attachment size, so let's use that instead.