### PR TITLE
 Re-enable arrow alignment puppet-lint check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,6 @@ repos:
         -   --no-140chars-check
         -   --no-documentation-check
         -   --no-puppet_url_without_modules-check
-        -   --no-arrow_alignment-check
         -   --no-arrow_on_right_operand_line-check
         -   --no-variable_is_lowercase-check
 -   repo: https://github.com/pre-commit/pre-commit-hooks.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
     -   id: puppet-lint
         args:
         -   --fail-on-warnings
+        -   --fix
         -   --no-140chars-check
         -   --no-documentation-check
         -   --no-puppet_url_without_modules-check

--- a/modules/ocf/manifests/apt.pp
+++ b/modules/ocf/manifests/apt.pp
@@ -20,42 +20,42 @@ class ocf::apt($stage = 'first') {
 
   apt::source {
     'debian':
-      location  => 'http://mirrors/debian/',
-      release   => $dist,
-      repos     => $repos,
-      include   => {
+      location => 'http://mirrors/debian/',
+      release  => $dist,
+      repos    => $repos,
+      include  => {
         src => true
       };
 
     'debian-updates':
-      location  => 'http://mirrors/debian/',
-      release   => "${::lsbdistcodename}-updates",
-      repos     => $repos,
-      include   => {
+      location => 'http://mirrors/debian/',
+      release  => "${::lsbdistcodename}-updates",
+      repos    => $repos,
+      include  => {
         src => true
       };
 
     'debian-security':
-      location  => 'http://mirrors/debian-security/',
-      release   => "${dist}/updates",
-      repos     => $repos,
-      include   => {
+      location => 'http://mirrors/debian-security/',
+      release  => "${dist}/updates",
+      repos    => $repos,
+      include  => {
         src => true
       };
 
     'ocf':
-      location  => 'http://apt/',
-      release   => $dist,
-      repos     => 'main',
-      include   => {
+      location => 'http://apt/',
+      release  => $dist,
+      repos    => 'main',
+      include  => {
         src => true
       };
 
     'ocf-backports':
-      location  => 'http://apt/',
-      release   => "${::lsbdistcodename}-backports",
-      repos     => 'main',
-      include   => {
+      location => 'http://apt/',
+      release  => "${::lsbdistcodename}-backports",
+      repos    => 'main',
+      include  => {
         src => true
       };
   }

--- a/modules/ocf/manifests/apt/i386/first_stage.pp
+++ b/modules/ocf/manifests/apt/i386/first_stage.pp
@@ -9,6 +9,6 @@ class ocf::apt::i386::first_stage {
   exec { 'add-i386':
     command => 'dpkg --add-architecture i386',
     unless  => 'dpkg --print-foreign-architectures | grep i386',
-    notify => Exec['apt_update'],
+    notify  => Exec['apt_update'],
   }
 }

--- a/modules/ocf/manifests/extrapackages.pp
+++ b/modules/ocf/manifests/extrapackages.pp
@@ -271,8 +271,8 @@ class ocf::extrapackages {
   # install wp-cli
   # TODO: can we debian-package this?
   file { '/usr/local/sbin/download-wp-cli':
-    source  => 'puppet:///modules/ocf/packages/download-wp-cli',
-    mode    => '0755';
+    source => 'puppet:///modules/ocf/packages/download-wp-cli',
+    mode   => '0755';
   }
   cron { 'download-wp-cli':
     command => '/usr/local/sbin/download-wp-cli',

--- a/modules/ocf/manifests/hostkeys.pp
+++ b/modules/ocf/manifests/hostkeys.pp
@@ -1,22 +1,22 @@
 class ocf::hostkeys {
   file {
     '/etc/ssh/ssh_host_dsa_key':
-      mode    => '0600',
-      source  => 'puppet:///private/hostkeys/ssh_host_dsa_key';
+      mode   => '0600',
+      source => 'puppet:///private/hostkeys/ssh_host_dsa_key';
     '/etc/ssh/ssh_host_dsa_key.pub':
-      mode    => '0644',
-      source  => 'puppet:///private/hostkeys/ssh_host_dsa_key.pub';
+      mode   => '0644',
+      source => 'puppet:///private/hostkeys/ssh_host_dsa_key.pub';
     '/etc/ssh/ssh_host_rsa_key':
-      mode    => '0600',
-      source  => 'puppet:///private/hostkeys/ssh_host_rsa_key';
+      mode   => '0600',
+      source => 'puppet:///private/hostkeys/ssh_host_rsa_key';
     '/etc/ssh/ssh_host_rsa_key.pub':
-      mode    => '0644',
-      source  => 'puppet:///private/hostkeys/ssh_host_rsa_key.pub';
+      mode   => '0644',
+      source => 'puppet:///private/hostkeys/ssh_host_rsa_key.pub';
     '/etc/ssh/ssh_host_ecdsa_key':
-      mode    => '0600',
-      source  => 'puppet:///private/hostkeys/ssh_host_ecdsa_key';
+      mode   => '0600',
+      source => 'puppet:///private/hostkeys/ssh_host_ecdsa_key';
     '/etc/ssh/ssh_host_ecdsa_key.pub':
-      mode    => '0644',
-      source  => 'puppet:///private/hostkeys/ssh_host_ecdsa_key.pub';
+      mode   => '0644',
+      source => 'puppet:///private/hostkeys/ssh_host_ecdsa_key.pub';
   }
 }

--- a/modules/ocf/manifests/ldap.pp
+++ b/modules/ocf/manifests/ldap.pp
@@ -7,7 +7,7 @@ class ocf::ldap {
       require => Package['ldap-utils'];
 
     '/etc/ldap/ldap.conf':
-      ensure  => symlink,
-      target  => '/etc/ldap.conf';
+      ensure => symlink,
+      target => '/etc/ldap.conf';
   }
 }

--- a/modules/ocf/manifests/munin/plugin.pp
+++ b/modules/ocf/manifests/munin/plugin.pp
@@ -18,9 +18,9 @@ define ocf::munin::plugin($source, $user = undef) {
 
   file {
     "/etc/munin/plugins/${title}":
-      source  => $source,
-      mode    => '0755',
-      *       => $file_defaults;
+      source => $source,
+      mode   => '0755',
+      *      => $file_defaults;
   }
 
   if $user != undef {

--- a/modules/ocf/manifests/nginx_proxy.pp
+++ b/modules/ocf/manifests/nginx_proxy.pp
@@ -32,32 +32,32 @@ define ocf::nginx_proxy(
         proxy_redirect   => $proxy_redirect,
         proxy_set_header => concat($base_headers, $proxy_set_header),
 
-        listen_port => 443,
-        ssl         => true,
-        ssl_cert    => $ssl_cert,
-        ssl_key     => $ssl_key,
-        ssl_dhparam => $ssl_dhparam,
+        listen_port      => 443,
+        ssl              => true,
+        ssl_cert         => $ssl_cert,
+        ssl_key          => $ssl_key,
+        ssl_dhparam      => $ssl_dhparam,
 
-        add_header => merge({
+        add_header       => merge({
           # HSTS header
           'Strict-Transport-Security' => 'max-age=31536000',
         }, $headers),
 
-        * => $nginx_options;
+        *                => $nginx_options;
 
       "${title}-redirect":
         # We have to specify www_root even though we always redirect/proxy
-        www_root => '/var/www',
+        www_root          => '/var/www',
 
-        server_name => concat([$server_name], $server_aliases),
+        server_name       => concat([$server_name], $server_aliases),
 
         server_cfg_append => {
           'return' => "301 https://${server_name}\$request_uri"
         },
 
-        add_header => $headers,
+        add_header        => $headers,
 
-        * => $nginx_options;
+        *                 => $nginx_options;
     }
   } else {
     nginx::resource::server { $title:

--- a/modules/ocf/manifests/packages/docker.pp
+++ b/modules/ocf/manifests/packages/docker.pp
@@ -75,7 +75,7 @@ class ocf::packages::docker($admin_group = undef,
     }
     cron {
       'clean-docker-volumes':
-        ensure => $prune_volumes_ensure,
+        ensure  => $prune_volumes_ensure,
         command => 'chronic docker volume prune -f',
         hour    => 1,
         minute  => 30;

--- a/modules/ocf/manifests/packages/docker/apt.pp
+++ b/modules/ocf/manifests/packages/docker/apt.pp
@@ -7,12 +7,12 @@ class ocf::packages::docker::apt {
   }
 
   apt::source { 'docker':
-    location    => '[arch=amd64] https://download.docker.com/linux/debian',
-    release     => $::lsbdistcodename,
-    repos       => 'stable',
-    include   => {
+    location => '[arch=amd64] https://download.docker.com/linux/debian',
+    release  => $::lsbdistcodename,
+    repos    => 'stable',
+    include  => {
       src => false
     },
-    require     => [Apt::Key['docker'], Package['apt-transport-https']],
+    require  => [Apt::Key['docker'], Package['apt-transport-https']],
   }
 }

--- a/modules/ocf/manifests/packages/matplotlib.pp
+++ b/modules/ocf/manifests/packages/matplotlib.pp
@@ -18,7 +18,7 @@ class ocf::packages::matplotlib {
   }
 
   exec { "sed -i 's/^backend\s*:.*$/backend : ${backend}/' /etc/matplotlibrc":
-    unless => "grep -qE '^backend\s*:\s*${backend}' /etc/matplotlibrc",
+    unless  => "grep -qE '^backend\s*:\s*${backend}' /etc/matplotlibrc",
     require => Package[$packages];
   }
 }

--- a/modules/ocf/manifests/packages/shell.pp
+++ b/modules/ocf/manifests/packages/shell.pp
@@ -4,18 +4,18 @@ class ocf::packages::shell {
   file {
     # Bash system-wide config
     '/etc/bash.bashrc':
-      source => 'puppet:///modules/ocf/shell/bash.bashrc',
+      source  => 'puppet:///modules/ocf/shell/bash.bashrc',
       require => Package['bash'];
     '/etc/bash.bash_logout':
-      source => 'puppet:///modules/ocf/shell/bash.bash_logout',
+      source  => 'puppet:///modules/ocf/shell/bash.bash_logout',
       require => Package['bash'];
 
     # C shell system-wide config
     '/etc/csh.cshrc':
-      source => 'puppet:///modules/ocf/shell/csh.cshrc',
+      source  => 'puppet:///modules/ocf/shell/csh.cshrc',
       require => Package['tcsh'];
     '/etc/csh.logout':
-      source => 'puppet:///modules/ocf/shell/csh.logout',
+      source  => 'puppet:///modules/ocf/shell/csh.logout',
       require => Package['tcsh'];
 
     # Z shell system-wide config
@@ -31,7 +31,7 @@ class ocf::packages::shell {
 
     # Fish shell system-wide config
     '/etc/fish/config.fish':
-      source => 'puppet:///modules/ocf/shell/config.fish',
+      source  => 'puppet:///modules/ocf/shell/config.fish',
       require => Package['fish'];
 
     # termite terminfo
@@ -41,7 +41,7 @@ class ocf::packages::shell {
   }
 
   exec { 'compile-terminfo':
-    command => 'tic -x /usr/share/terminfo/x/xterm-termite',
+    command     => 'tic -x /usr/share/terminfo/x/xterm-termite',
     refreshonly => true;
   }
 }

--- a/modules/ocf/manifests/puppet.pp
+++ b/modules/ocf/manifests/puppet.pp
@@ -65,8 +65,8 @@ class ocf::puppet($stage = 'first') {
   file {
     # Trigger a puppet run by the agent
     '/usr/local/sbin/puppet-trigger':
-      mode    => '0755',
-      source  => 'puppet:///modules/ocf/puppet-trigger';
+      mode   => '0755',
+      source => 'puppet:///modules/ocf/puppet-trigger';
 
     # TODO: Remove this entirely once all hosts have this file removed
     '/usr/local/sbin/migrate-puppet-agent':

--- a/modules/ocf/manifests/repackage.pp
+++ b/modules/ocf/manifests/repackage.pp
@@ -18,7 +18,7 @@ define ocf::repackage(
     # dependencies would need to be pinned, which is excessive and prone to
     # breaking if a package's dependencies change.
     exec { "apt install ${package}":
-      command => "/usr/bin/apt-get -y -o Dpkg::Options::=--force-confold ${install_options[0]} -t ${dist} install ${package}",
+      command     => "/usr/bin/apt-get -y -o Dpkg::Options::=--force-confold ${install_options[0]} -t ${dist} install ${package}",
       logoutput   => on_failure,
       environment => [
         'DEBIAN_FRONTEND=noninteractive',

--- a/modules/ocf/manifests/staff_users.pp
+++ b/modules/ocf/manifests/staff_users.pp
@@ -14,10 +14,10 @@ class ocf::staff_users($noop = false) {
       ensure_resource('file', [$parent1, $parent2], {'ensure' => 'directory'})
 
       file { $homedir:
-        ensure  => directory,
-        owner   => $user,
-        mode    => '0700',
-        group   => ocfstaff;
+        ensure => directory,
+        owner  => $user,
+        mode   => '0700',
+        group  => ocfstaff;
       }
     }
   }

--- a/modules/ocf/manifests/systemd/service.pp
+++ b/modules/ocf/manifests/systemd/service.pp
@@ -5,10 +5,10 @@ define ocf::systemd::service(
   $enable = true,
 ) {
   file { "/etc/systemd/system/${title}.service":
-    source   => $source,
-    content  => $content,
-    notify   => Exec['systemd-reload'],
-    require  => Package['systemd-sysv'],
+    source  => $source,
+    content => $content,
+    notify  => Exec['systemd-reload'],
+    require => Package['systemd-sysv'],
   }
 
   service { $title:

--- a/modules/ocf_admin/manifests/create/app.pp
+++ b/modules/ocf_admin/manifests/create/app.pp
@@ -31,8 +31,8 @@ class ocf_admin::create::app {
 
     # TODO: ideally this file wouldn't be directly readable by staff
     '/etc/ocf-create/ocf-create.conf':
-      group  => ocfstaff,
-      mode   => '0440';
+      group => ocfstaff,
+      mode  => '0440';
 
     '/etc/ocf-create/create.keytab':
       mode   => '0400',

--- a/modules/ocf_admin/manifests/create/redis.pp
+++ b/modules/ocf_admin/manifests/create/redis.pp
@@ -17,9 +17,9 @@ class ocf_admin::create::redis {
   $redis_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], hiera('create::redis::password'))
 
   augeas { '/etc/redis/redis.conf':
-    lens    => 'Spacevars.simple_lns',
-    incl    => '/etc/redis/redis.conf',
-    changes =>  [
+    lens      => 'Spacevars.simple_lns',
+    incl      => '/etc/redis/redis.conf',
+    changes   =>  [
       'set port 6379',
       "set requirepass ${redis_password}",
 
@@ -33,8 +33,8 @@ class ocf_admin::create::redis {
       'rm save',
     ],
     show_diff => false,
-    require => File['/etc/redis/redis.conf'],
-    notify  => Service['redis-server'];
+    require   => File['/etc/redis/redis.conf'],
+    notify    => Service['redis-server'];
   }
 
   # We already have an OCF member with the username "hitch", so dpkg

--- a/modules/ocf_admin/manifests/init.pp
+++ b/modules/ocf_admin/manifests/init.pp
@@ -10,8 +10,8 @@ class ocf_admin {
   include ocf_admin::create
 
   class { 'ocf::nfs':
-    cron  => true,
-    web   => true;
+    cron => true,
+    web  => true;
   }
 
   class { 'ocf::packages::docker':

--- a/modules/ocf_apphost/manifests/lets_encrypt.pp
+++ b/modules/ocf_apphost/manifests/lets_encrypt.pp
@@ -3,9 +3,9 @@ class ocf_apphost::lets_encrypt {
 
   file {
     '/usr/local/bin/lets-encrypt-update':
-      source    => 'puppet:///modules/ocf_www/lets-encrypt-update',
-      mode      => '0755',
-      require   => File['/usr/local/bin/ocf-lets-encrypt'];
+      source  => 'puppet:///modules/ocf_www/lets-encrypt-update',
+      mode    => '0755',
+      require => File['/usr/local/bin/ocf-lets-encrypt'];
 
     '/etc/ssl/lets-encrypt/le-vhost.key':
       source    => 'puppet:///private/lets-encrypt-vhost.key',

--- a/modules/ocf_apphost/manifests/proxy.pp
+++ b/modules/ocf_apphost/manifests/proxy.pp
@@ -17,16 +17,16 @@ class ocf_apphost::proxy {
       notify  => Service['nginx'];
 
     '/usr/local/bin/build-vhosts':
-      source  => 'puppet:///modules/ocf_www/build-vhosts',
-      mode    => '0755';
+      source => 'puppet:///modules/ocf_www/build-vhosts',
+      mode   => '0755';
 
     '/opt/share/vhost-app.jinja':
-      source  => 'puppet:///modules/ocf_apphost/vhost-app.jinja';
+      source => 'puppet:///modules/ocf_apphost/vhost-app.jinja';
 
     # Generated SSL bundles go here
     '/etc/ssl/apphost':
-      ensure  => directory,
-      mode    => '0755';
+      ensure => directory,
+      mode   => '0755';
   }
 
   $build_args = $::host_env ? {

--- a/modules/ocf_apt/manifests/init.pp
+++ b/modules/ocf_apt/manifests/init.pp
@@ -16,8 +16,8 @@ class ocf_apt {
 
   file {
     default:
-      owner  => ocfapt,
-      group  => ocfapt;
+      owner => ocfapt,
+      group => ocfapt;
 
     ['/opt/apt', '/opt/apt/ftp', '/opt/apt/etc', '/opt/apt/db']:
       ensure => directory,
@@ -53,15 +53,15 @@ class ocf_apt {
       subscribe   => File['/opt/apt/etc/private.key'];
 
     'export-gpg-pubkey':
-      command     => 'gpg --output /opt/apt/ftp/pubkey.gpg --export D72A0AF4',
-      creates     => '/opt/apt/ftp/pubkey.gpg',
-      require     => Exec['import-apt-gpg'];
+      command => 'gpg --output /opt/apt/ftp/pubkey.gpg --export D72A0AF4',
+      creates => '/opt/apt/ftp/pubkey.gpg',
+      require => Exec['import-apt-gpg'];
 
     'initial-reprepro-export':
-      command     => '/opt/apt/bin/reprepro export',
-      user        => ocfapt,
-      creates     => '/opt/apt/ftp/dists',
-      require     => [
+      command => '/opt/apt/bin/reprepro export',
+      user    => ocfapt,
+      creates => '/opt/apt/ftp/dists',
+      require => [
         Ocf::Repackage['reprepro'],
         File['/opt/apt/bin', '/opt/apt/etc', '/opt/apt/db', '/opt/apt/ftp'],
         Exec['import-apt-gpg'],
@@ -70,11 +70,11 @@ class ocf_apt {
   }
 
   apache::vhost { 'apt.ocf.berkeley.edu':
-    serveraliases   => ['apt'],
-    port            => 80,
-    docroot         => '/opt/apt/ftp',
+    serveraliases     => ['apt'],
+    port              => 80,
+    docroot           => '/opt/apt/ftp',
 
-    directories     => [{
+    directories       => [{
       path          => '/opt/apt/ftp',
       options       => ['+Indexes', '+SymlinksIfOwnerMatch'],
       index_options => ['NameWidth=*', '+SuppressDescription']
@@ -85,11 +85,11 @@ class ocf_apt {
   }
 
   apache::vhost { 'apt.ocf.berkeley.edu-ssl':
-    servername      => 'apt.ocf.berkeley.edu',
-    port            => 443,
-    docroot         => '/opt/apt/ftp',
+    servername        => 'apt.ocf.berkeley.edu',
+    port              => 443,
+    docroot           => '/opt/apt/ftp',
 
-    directories     => [{
+    directories       => [{
       path          => '/opt/apt/ftp',
       options       => ['+Indexes', '+SymlinksIfOwnerMatch'],
       index_options => ['NameWidth=*', '+SuppressDescription']
@@ -98,9 +98,9 @@ class ocf_apt {
     access_log_format => 'io_count',
     custom_fragment   => "HeaderName README.html\nReadmeName FOOTER.html",
 
-    ssl       => true,
-    ssl_key   => "/etc/ssl/private/${::fqdn}.key",
-    ssl_cert  => "/etc/ssl/private/${::fqdn}.crt",
-    ssl_chain => '/etc/ssl/certs/incommon-intermediate.crt',
+    ssl               => true,
+    ssl_key           => "/etc/ssl/private/${::fqdn}.key",
+    ssl_cert          => "/etc/ssl/private/${::fqdn}.crt",
+    ssl_chain         => '/etc/ssl/certs/incommon-intermediate.crt',
   }
 }

--- a/modules/ocf_backups/manifests/rsnapshot.pp
+++ b/modules/ocf_backups/manifests/rsnapshot.pp
@@ -43,18 +43,18 @@ class ocf_backups::rsnapshot {
 
     # 12am Saturday mornings
     'rsnapshot-weekly':
-      command  => "${rsnapshot} weekly",
-      hour     => '0',
-      weekday  => '6';
+      command => "${rsnapshot} weekly",
+      hour    => '0',
+      weekday => '6';
 
     # 2am daily
     'rsnapshot-daily':
-      command  => "${rsnapshot} sync && ${rsnapshot} daily",
-      hour     => '2';
+      command => "${rsnapshot} sync && ${rsnapshot} daily",
+      hour    => '2';
 
     # check rsnapshot backups to ensure they're actually happening
     'check-rsnapshot-backups':
-      command  => '/opt/share/backups/check-rsnapshot-backups',
-      hour     => '10';
+      command => '/opt/share/backups/check-rsnapshot-backups',
+      hour    => '10';
   }
 }

--- a/modules/ocf_csgo/manifests/init.pp
+++ b/modules/ocf_csgo/manifests/init.pp
@@ -10,8 +10,8 @@ class ocf_csgo {
 
   file {
     default:
-      owner  => ocfcsgo,
-      group  => ocfcsgo;
+      owner => ocfcsgo,
+      group => ocfcsgo;
 
     ['/opt/csgo', '/opt/csgo/bin', '/opt/csgo/etc']:
       ensure => directory,

--- a/modules/ocf_decal/manifests/init.pp
+++ b/modules/ocf_decal/manifests/init.pp
@@ -30,9 +30,9 @@ class ocf_decal {
   }
 
   vcsrepo { '/opt/share/decal-utils':
-    ensure    => latest,
-    provider  => git,
-    revision  => 'master',
-    source    => 'https://github.com/0xcf/decal-util.git'
+    ensure   => latest,
+    provider => git,
+    revision => 'master',
+    source   => 'https://github.com/0xcf/decal-util.git'
   }
 }

--- a/modules/ocf_decal/manifests/website.pp
+++ b/modules/ocf_decal/manifests/website.pp
@@ -23,8 +23,8 @@ class ocf_decal::website {
       mode    => '0440',
       require => File['/srv/ssl/decal'];
     '/etc/ssl/certs/lets-encrypt.crt':
-      source  => 'puppet:///private/lets-encrypt.crt',
-      mode    => '0640';
+      source => 'puppet:///private/lets-encrypt.crt',
+      mode   => '0640';
   }
 
   apache::vhost { 'decal-http-redirect':
@@ -62,17 +62,17 @@ class ocf_decal::website {
 }
 
   apache::vhost { 'decal-ssl':
-    servername      => 'decal.ocf.berkeley.edu',
+    servername    => 'decal.ocf.berkeley.edu',
 
-    port            => 443,
-    docroot         => '/srv/www/decal',
-    docroot_owner   => 'ocfdecal',
-    docroot_group   => 'www-data',
-    override        => ['All'],
+    port          => 443,
+    docroot       => '/srv/www/decal',
+    docroot_owner => 'ocfdecal',
+    docroot_group => 'www-data',
+    override      => ['All'],
 
-    ssl             => true,
-    ssl_key         => '/srv/ssl/decal/decal.key',
-    ssl_cert        => '/srv/ssl/decal/decal.crt',
-    ssl_chain       => '/etc/ssl/certs/lets-encrypt.crt',
+    ssl           => true,
+    ssl_key       => '/srv/ssl/decal/decal.key',
+    ssl_cert      => '/srv/ssl/decal/decal.crt',
+    ssl_chain     => '/etc/ssl/certs/lets-encrypt.crt',
   }
 }

--- a/modules/ocf_desktop/manifests/defaults.pp
+++ b/modules/ocf_desktop/manifests/defaults.pp
@@ -11,7 +11,7 @@ class ocf_desktop::defaults {
   }
 
   file { '/usr/share/applications/pdfopen.desktop':
-    source => 'puppet:///modules/ocf_desktop/xsession/pdfopen.desktop',
+    source  => 'puppet:///modules/ocf_desktop/xsession/pdfopen.desktop',
     require => File['/usr/local/bin/pdf-open'];
   }
 }

--- a/modules/ocf_desktop/manifests/modprobe.pp
+++ b/modules/ocf_desktop/manifests/modprobe.pp
@@ -1,9 +1,9 @@
 class ocf_desktop::modprobe {
   file {
     '/etc/modprobe.d/ocf-blacklist.conf':
-      mode    => '0644',
-      owner   => root,
-      group   => root,
-      source  => 'puppet:///modules/ocf_desktop/modprobe.d/ocf-blacklist.conf';
+      mode   => '0644',
+      owner  => root,
+      group  => root,
+      source => 'puppet:///modules/ocf_desktop/modprobe.d/ocf-blacklist.conf';
   }
 }

--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -70,7 +70,7 @@ class ocf_desktop::packages {
     'gedit':
       recommends => false;
     ['libreoffice-calc', 'libreoffice-draw', 'libreoffice-gnome', 'libreoffice-gtk3', 'libreoffice-impress', 'libreoffice-pdfimport', 'libreoffice-writer', 'ure']:
-      recommends => false,
+      recommends  => false,
       backport_on => stretch;
     'thunar':
       recommends => false;

--- a/modules/ocf_desktop/manifests/stats.pp
+++ b/modules/ocf_desktop/manifests/stats.pp
@@ -27,9 +27,9 @@ class ocf_desktop::stats {
   }
 
   cron { 'labstats':
-    ensure   => present,
-    command  => '/opt/stats/update.sh > /dev/null',
-    user     => 'ocfstats',
-    minute   => '*';
+    ensure  => present,
+    command => '/opt/stats/update.sh > /dev/null',
+    user    => 'ocfstats',
+    minute  => '*';
   }
 }

--- a/modules/ocf_desktop/manifests/tmpfs.pp
+++ b/modules/ocf_desktop/manifests/tmpfs.pp
@@ -26,8 +26,8 @@ class ocf_desktop::tmpfs {
       mode   => '0755';
 
     '/usr/local/sbin/clean-temp-files':
-      source  => 'puppet:///modules/ocf_desktop/clean-temp-files',
-      mode    => '0755';
+      source => 'puppet:///modules/ocf_desktop/clean-temp-files',
+      mode   => '0755';
   }
 
   cron { 'clean-temp-files':

--- a/modules/ocf_desktop/manifests/udev.pp
+++ b/modules/ocf_desktop/manifests/udev.pp
@@ -2,7 +2,7 @@ class ocf_desktop::udev {
   package { ['u2f-host']:; }
 
   file { '/etc/udev/rules.d/70-u2f-fido.rules':
-    source    => 'puppet:///modules/ocf_desktop/70-u2f-fido.rules',
-    mode      => '0644',
+    source => 'puppet:///modules/ocf_desktop/70-u2f-fido.rules',
+    mode   => '0644',
   }
 }

--- a/modules/ocf_desktop/manifests/xsession.pp
+++ b/modules/ocf_desktop/manifests/xsession.pp
@@ -12,20 +12,20 @@ class ocf_desktop::xsession {
       require => File['/opt/share/xsession'];
     # printing and other notification script daemon
     '/opt/share/puppet/notify':
-      mode    => '0755',
-      source  => 'puppet:///modules/ocf_desktop/xsession/notify';
+      mode   => '0755',
+      source => 'puppet:///modules/ocf_desktop/xsession/notify';
     # script for warning users when the lab is about to close
     '/opt/share/puppet/lab-close-notify':
-      mode    => '0755',
-      source  => 'puppet:///modules/ocf_desktop/xsession/lab-close-notify';
+      mode   => '0755',
+      source => 'puppet:///modules/ocf_desktop/xsession/lab-close-notify';
     # script to tile multiple displays
     '/usr/local/bin/fix-displays':
-      mode    => '0755',
-      source  => 'puppet:///modules/ocf_desktop/xsession/fix-displays';
+      mode   => '0755',
+      source => 'puppet:///modules/ocf_desktop/xsession/fix-displays';
     # script to fix audio on login
     '/usr/local/bin/fix-audio':
-      mode    => '0755',
-      source  => 'puppet:///modules/ocf_desktop/xsession/fix-audio';
+      mode   => '0755',
+      source => 'puppet:///modules/ocf_desktop/xsession/fix-audio';
     # script for paper stats on panel
     '/usr/local/bin/paper-genmon':
       mode    => '0755',
@@ -73,12 +73,12 @@ class ocf_desktop::xsession {
     '/etc/X11/default-display-manager':
       content => "/usr/sbin/lightdm\n";
     '/etc/lightdm/session-setup':
-      mode    => '0755',
-      source  => 'puppet:///modules/ocf_desktop/xsession/lightdm/session-setup';
+      mode   => '0755',
+      source => 'puppet:///modules/ocf_desktop/xsession/lightdm/session-setup';
     # kill child processes on logout
     '/etc/lightdm/session-cleanup':
-      mode    => '0755',
-      source  => 'puppet:///modules/ocf_desktop/xsession/lightdm/session-cleanup';
+      mode   => '0755',
+      source => 'puppet:///modules/ocf_desktop/xsession/lightdm/session-cleanup';
   }
 
   # overwrite greeter strings with OCF ones
@@ -140,8 +140,8 @@ class ocf_desktop::xsession {
   file {
     # copy skel files
     '/etc/skel/.config':
-      ensure => directory,
-      source => 'puppet:///modules/ocf_desktop/skel/config',
+      ensure  => directory,
+      source  => 'puppet:///modules/ocf_desktop/skel/config',
       recurse => true;
   }
 

--- a/modules/ocf_dhcp/manifests/init.pp
+++ b/modules/ocf_dhcp/manifests/init.pp
@@ -6,9 +6,9 @@ class ocf_dhcp {
   package { 'isc-dhcp-server': }
   file {
     '/etc/dhcp/dhcpd.conf':
-      source   => 'puppet:///modules/ocf_dhcp/dhcpd.conf',
-      require  => [Package['isc-dhcp-server'], Exec['gen-desktop-leases']],
-      notify   => Service['isc-dhcp-server'];
+      source  => 'puppet:///modules/ocf_dhcp/dhcpd.conf',
+      require => [Package['isc-dhcp-server'], Exec['gen-desktop-leases']],
+      notify  => Service['isc-dhcp-server'];
 
     '/usr/local/sbin/gen-desktop-leases':
       source => 'puppet:///modules/ocf_dhcp/gen-desktop-leases',
@@ -27,10 +27,10 @@ class ocf_dhcp {
   }
 
   exec { 'gen-desktop-leases':
-    command    => '/usr/local/sbin/gen-desktop-leases > /etc/dhcp/desktop-leases.conf',
-    creates    => '/etc/dhcp/desktop-leases.conf',
-    require    => [File['/usr/local/sbin/gen-desktop-leases'], Package['python3-ocflib']],
-    notify     => Service['isc-dhcp-server'];
+    command => '/usr/local/sbin/gen-desktop-leases > /etc/dhcp/desktop-leases.conf',
+    creates => '/etc/dhcp/desktop-leases.conf',
+    require => [File['/usr/local/sbin/gen-desktop-leases'], Package['python3-ocflib']],
+    notify  => Service['isc-dhcp-server'];
   }
 
   service { 'isc-dhcp-server':

--- a/modules/ocf_docker/manifests/init.pp
+++ b/modules/ocf_docker/manifests/init.pp
@@ -3,8 +3,8 @@ class ocf_docker {
   require ocf_ssl::default_bundle
 
   class { 'nginx':
-    manage_repo => false,
-    confd_purge => true,
+    manage_repo  => false,
+    confd_purge  => true,
     server_purge => true,
   }
 
@@ -25,19 +25,19 @@ class ocf_docker {
   # docker.ocf.
   nginx::resource::server {
     default:
-      listen_port => 443,
+      listen_port       => 443,
 
-      ssl         => true,
-      ssl_cert    => "/etc/ssl/private/${::fqdn}.bundle",
-      ssl_key     => "/etc/ssl/private/${::fqdn}.key",
-      ssl_dhparam => '/etc/ssl/dhparam.pem',
+      ssl               => true,
+      ssl_cert          => "/etc/ssl/private/${::fqdn}.bundle",
+      ssl_key           => "/etc/ssl/private/${::fqdn}.key",
+      ssl_dhparam       => '/etc/ssl/dhparam.pem',
 
-      add_header  => {
+      add_header        => {
         'Strict-Transport-Security' => 'max-age=31536000',
       },
 
-      proxy            => 'http://docker-registry',
-      proxy_set_header => [
+      proxy             => 'http://docker-registry',
+      proxy_set_header  => [
         'X-Forwarded-Proto $scheme',
         'X-Forwarded-For $proxy_add_x_forwarded_for',
         'Host $http_host'
@@ -51,7 +51,7 @@ class ocf_docker {
       };
 
     'docker-ro':
-      server_name    => ['docker.ocf.berkeley.edu', 'docker', $::hostname, $::fqdn],
+      server_name         => ['docker.ocf.berkeley.edu', 'docker', $::hostname, $::fqdn],
 
       location_cfg_append => {
         # The `auth_required` is not needed, it's a hack so that the Puppet
@@ -60,20 +60,20 @@ class ocf_docker {
       };
 
     'docker-push':
-      server_name    => ['docker-push.ocf.berkeley.edu'],
+      server_name         => ['docker-push.ocf.berkeley.edu'],
 
       location_cfg_append => {
-        'auth_basic' => 'Restricted',
+        'auth_basic'           => 'Restricted',
         'auth_basic_user_file' => '/opt/share/docker.htpasswd',
       },
 
-      raw_append => [
+      raw_append          => [
         'location /_ping { auth_basic off; }',
         'location /v1/_ping { auth_basic off; }',
       ],
 
-      require   => File['/opt/share/docker.htpasswd'],
-      subscribe => File['/opt/share/docker.htpasswd'];
+      require             => File['/opt/share/docker.htpasswd'],
+      subscribe           => File['/opt/share/docker.htpasswd'];
   }
 
   file {

--- a/modules/ocf_irc/manifests/webirc.pp
+++ b/modules/ocf_irc/manifests/webirc.pp
@@ -7,8 +7,8 @@ class ocf_irc::webirc {
 
   # Nginx is used to proxy to Marathon and to supply a HTTP -> HTTPS redirect
   class { 'nginx':
-    manage_repo => false,
-    confd_purge => true,
+    manage_repo  => false,
+    confd_purge  => true,
     server_purge => true,
   }
 
@@ -17,7 +17,7 @@ class ocf_irc::webirc {
       $::hostname,
       $::fqdn,
     ],
-    proxy => 'http://lb.ocf.berkeley.edu:10008',
-    ssl   => true,
+    proxy          => 'http://lb.ocf.berkeley.edu:10008',
+    ssl            => true,
   }
 }

--- a/modules/ocf_jenkins/manifests/init.pp
+++ b/modules/ocf_jenkins/manifests/init.pp
@@ -155,7 +155,7 @@ class ocf_jenkins {
   }
 
   ocf::firewall::firewall46 { '899 allow jenkins to send mail':
-    opts => {
+    opts    => {
       chain  => 'PUPPET-OUTPUT',
       uid    => 'jenkins',
       proto  => 'tcp',

--- a/modules/ocf_jenkins/manifests/proxy.pp
+++ b/modules/ocf_jenkins/manifests/proxy.pp
@@ -11,8 +11,8 @@ class ocf_jenkins::proxy {
       $::hostname,
       $::fqdn
     ],
-    ssl              => true,
-    proxy            => 'http://localhost:8080',
-    proxy_redirect   => 'http://localhost:8080 https://jenkins.ocf.berkeley.edu',
+    ssl            => true,
+    proxy          => 'http://localhost:8080',
+    proxy_redirect => 'http://localhost:8080 https://jenkins.ocf.berkeley.edu',
   }
 }

--- a/modules/ocf_ldap/manifests/init.pp
+++ b/modules/ocf_ldap/manifests/init.pp
@@ -98,10 +98,10 @@ class ocf_ldap {
   }
 
   cron { 'ldap-lint':
-    command  => '/opt/share/utils/sbin/ldap-lint',
-    user     => root,
-    special  => 'daily',
-    require  => Vcsrepo['/opt/share/utils'];
+    command => '/opt/share/utils/sbin/ldap-lint',
+    user    => root,
+    special => 'daily',
+    require => Vcsrepo['/opt/share/utils'];
   }
 
   ocf::munin::plugin { 'slapd-open-files':

--- a/modules/ocf_mail/manifests/init.pp
+++ b/modules/ocf_mail/manifests/init.pp
@@ -22,9 +22,9 @@ class ocf_mail {
   }
 
   group { 'ocfmail':
-    ensure  => present,
-    name    => ocfmail,
-    system  => true,
+    ensure => present,
+    name   => ocfmail,
+    system => true,
   }
 
   file { '/etc/postfix/main.cf':

--- a/modules/ocf_mail/manifests/logging.pp
+++ b/modules/ocf_mail/manifests/logging.pp
@@ -2,13 +2,13 @@ class ocf_mail::logging {
   file {
     # outgoing nomail logging
     '/var/mail/nomail':
-      ensure  => directory,
-      mode    => '0755',
-      owner   => ocfmail,
-      group   => ocfmail;
+      ensure => directory,
+      mode   => '0755',
+      owner  => ocfmail,
+      group  => ocfmail;
     '/etc/logrotate.d/nomail':
-      ensure  => file,
-      source  => 'puppet:///modules/ocf_mail/site_ocf/logrotate/nomail';
+      ensure => file,
+      source => 'puppet:///modules/ocf_mail/site_ocf/logrotate/nomail';
   }
 
   ocf::munin::plugin { 'mails-past-hour':

--- a/modules/ocf_mail/manifests/site_ocf.pp
+++ b/modules/ocf_mail/manifests/site_ocf.pp
@@ -75,17 +75,17 @@ class ocf_mail::site_ocf {
 
     # aliases and hashes
     '/etc/aliases':
-      mode    => '0644',
-      source  => 'puppet:///modules/ocf_mail/site_ocf/aliases',
-      notify  => Exec['newaliases'];
+      mode   => '0644',
+      source => 'puppet:///modules/ocf_mail/site_ocf/aliases',
+      notify => Exec['newaliases'];
     '/usr/local/sbin/update-aliases':
-      mode    => '0755',
-      source  => 'puppet:///modules/ocf_mail/site_ocf/update-aliases';
+      mode   => '0755',
+      source => 'puppet:///modules/ocf_mail/site_ocf/update-aliases';
     '/usr/local/sbin/update-nomail-hashes':
-      mode    => '0755',
-      source  => 'puppet:///modules/ocf_mail/site_ocf/update-nomail-hashes';
+      mode   => '0755',
+      source => 'puppet:///modules/ocf_mail/site_ocf/update-nomail-hashes';
     '/usr/local/sbin/update-cred-cache':
-      mode    => '0755',
-      source  => 'puppet:///modules/ocf_mail/site_ocf/update-cred-cache';
+      mode   => '0755',
+      source => 'puppet:///modules/ocf_mail/site_ocf/update-cred-cache';
   }
 }

--- a/modules/ocf_mail/manifests/site_vhost.pp
+++ b/modules/ocf_mail/manifests/site_vhost.pp
@@ -19,8 +19,8 @@ class ocf_mail::site_vhost {
       require   => Ocf::Repackage['libpam-mysql'];
 
     '/etc/pam.d/smtp':
-      source    => 'puppet:///modules/ocf_mail/site_vhost/pam',
-      require   => Ocf::Repackage['libpam-mysql'];
+      source  => 'puppet:///modules/ocf_mail/site_vhost/pam',
+      require => Ocf::Repackage['libpam-mysql'];
   }
 
   # Configure the saslauthd instance used by Postfix.

--- a/modules/ocf_mail/manifests/spam.pp
+++ b/modules/ocf_mail/manifests/spam.pp
@@ -71,9 +71,9 @@ class ocf_mail::spam {
       notify  => Service['spamassassin'],
       require => Package['spamassassin'];
     '/var/spool/postfix/clamav':
-      ensure  => directory,
-      owner   => clamav,
-      group   => root;
+      ensure => directory,
+      owner  => clamav,
+      group  => root;
     '/etc/clamav/clamav-milter.conf':
       source  => 'puppet:///modules/ocf_mail/spam/clamav/clamav-milter.conf',
       notify  => Service['clamav-milter'],

--- a/modules/ocf_mesos/manifests/master/dns.pp
+++ b/modules/ocf_mesos/manifests/master/dns.pp
@@ -15,10 +15,10 @@ class ocf_mesos::master::dns(
   }
 
   ocf::systemd::service { 'mesos-dns':
-    ensure  => running,
-    source  => 'puppet:///modules/ocf_mesos/master/dns/mesos-dns.service',
-    enable  => true,
-    require => [
+    ensure    => running,
+    source    => 'puppet:///modules/ocf_mesos/master/dns/mesos-dns.service',
+    enable    => true,
+    require   => [
       Package['mesos-dns'],
       File['/opt/share/mesos/master/mesos-dns.json'],
     ],

--- a/modules/ocf_mesos/manifests/master/load_balancer.pp
+++ b/modules/ocf_mesos/manifests/master/load_balancer.pp
@@ -77,10 +77,10 @@ class ocf_mesos::master::load_balancer($marathon_http_password) {
   }
 
   ocf_mesos::master::load_balancer::http_vhost { 'ocfweb-static':
-    server_name    => 'static.ocf.berkeley.edu',
-    service_port   => 10004,
-    ssl            => true,
-    ssl_dir        => 'ocfweb',
+    server_name  => 'static.ocf.berkeley.edu',
+    service_port => 10004,
+    ssl          => true,
+    ssl_dir      => 'ocfweb',
   }
 
   ocf_mesos::master::load_balancer::http_vhost { 'ircbot':

--- a/modules/ocf_mesos/manifests/master/mesos.pp
+++ b/modules/ocf_mesos/manifests/master/mesos.pp
@@ -53,8 +53,8 @@ class ocf_mesos::master::mesos(
     content   => "${zookeeper_uri}/mesos\n",
     mode      => '0400',
     show_diff => false,
-    require => Package['mesos'],
-    notify  => Service['mesos-slave'],
+    require   => Package['mesos'],
+    notify    => Service['mesos-slave'],
   } ->
   augeas { '/etc/default/mesos-master':
     lens    => 'Shellvars.lns',

--- a/modules/ocf_mesos/manifests/master/zookeeper.pp
+++ b/modules/ocf_mesos/manifests/master/zookeeper.pp
@@ -38,7 +38,7 @@ class ocf_mesos::master::zookeeper($masters, $zookeeper_password) {
     '/etc/zookeeper/conf_ocf/log4j.properties':
       source  => 'puppet:///modules/ocf_mesos/master/zookeeper/log4j.properties';
     '/etc/zookeeper/conf':
-      ensure  => link,
-      target  => '/etc/zookeeper/conf_ocf';
+      ensure => link,
+      target => '/etc/zookeeper/conf_ocf';
   }
 }

--- a/modules/ocf_mesos/manifests/package.pp
+++ b/modules/ocf_mesos/manifests/package.pp
@@ -16,12 +16,12 @@ class ocf_mesos::package {
   $is_slave = tagged('ocf_mesos::slave') and !hiera('ocf_mesos::slave::disabled', false)
   service {
     'mesos-master':
-      ensure => $is_master,
-      enable => $is_master,
+      ensure  => $is_master,
+      enable  => $is_master,
       require => Ocf::Repackage['mesos'];
     'mesos-slave':
-      ensure => $is_slave,
-      enable => $is_slave,
+      ensure  => $is_slave,
+      enable  => $is_slave,
       require => Ocf::Repackage['mesos'];
   }
 }

--- a/modules/ocf_mesos/manifests/secrets.pp
+++ b/modules/ocf_mesos/manifests/secrets.pp
@@ -21,8 +21,8 @@ class ocf_mesos::secrets {
   # won't run jobs that require secrets. All masters have the class.
   file {
     '/opt/share/docker':
-      ensure  => directory,
-      mode    => '0700';
+      ensure => directory,
+      mode   => '0700';
 
     '/opt/share/docker/secrets':
       mode    => '0644',

--- a/modules/ocf_mesos/manifests/slave.pp
+++ b/modules/ocf_mesos/manifests/slave.pp
@@ -15,8 +15,8 @@ class ocf_mesos::slave($attributes = {}) {
     content   => "${zookeeper_uri}/mesos\n",
     mode      => '0400',
     show_diff => false,
-    require => Package['mesos'],
-    notify  => Service['mesos-slave'],
+    require   => Package['mesos'],
+    notify    => Service['mesos-slave'],
   } ->
   augeas { '/etc/default/mesos-slave':
     lens    => 'Shellvars.lns',

--- a/modules/ocf_mirrors/manifests/finnix.pp
+++ b/modules/ocf_mirrors/manifests/finnix.pp
@@ -5,12 +5,12 @@ class ocf_mirrors::finnix {
       group => mirrors;
 
     '/opt/mirrors/project/finnix':
-      ensure  => directory,
-      mode    => '0755';
+      ensure => directory,
+      mode   => '0755';
 
     '/opt/mirrors/project/finnix/sync-releases':
-      source  => 'puppet:///modules/ocf_mirrors/project/finnix/sync-releases',
-      mode    => '0755';
+      source => 'puppet:///modules/ocf_mirrors/project/finnix/sync-releases',
+      mode   => '0755';
 
     # we are registered with the Finnix project and have a password for the
     # master upstream mirror

--- a/modules/ocf_mirrors/manifests/ftpsync.pp
+++ b/modules/ocf_mirrors/manifests/ftpsync.pp
@@ -19,16 +19,16 @@ define ocf_mirrors::ftpsync(
       group => mirrors;
 
     [$project_path, "${project_path}/log", "${project_path}/etc"]:
-      ensure  => directory,
-      mode    => '0755';
+      ensure => directory,
+      mode   => '0755';
 
     "${project_path}/bin":
-      ensure  => link,
-      target  => "${project_path}/distrib/bin";
+      ensure => link,
+      target => "${project_path}/distrib/bin";
 
     "${project_path}/etc/common":
-      ensure  => link,
-      target  => "${project_path}/distrib/etc/common";
+      ensure => link,
+      target => "${project_path}/distrib/etc/common";
 
     "${project_path}/etc/ftpsync.conf":
       content => template('ocf_mirrors/ftpsync.conf.erb'),

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -98,12 +98,12 @@ class ocf_mirrors {
   }
 
   apache::vhost { 'mirrors.ocf.berkeley.edu':
-    serveraliases   => ['mirrors', 'dl.amnesia.boum.org', '*.dl.amnesia.boum.org'],
-    port            => 80,
-    default_vhost   => true,
-    docroot         => '/opt/mirrors/ftp',
+    serveraliases     => ['mirrors', 'dl.amnesia.boum.org', '*.dl.amnesia.boum.org'],
+    port              => 80,
+    default_vhost     => true,
+    docroot           => '/opt/mirrors/ftp',
 
-    directories     => [
+    directories       => [
       {
         path          => '/opt/mirrors/ftp',
         options       => ['+Indexes', '+SymlinksIfOwnerMatch'],
@@ -131,11 +131,11 @@ class ocf_mirrors {
   }
 
   apache::vhost { 'mirrors.ocf.berkeley.edu-ssl':
-    servername      => 'mirrors.ocf.berkeley.edu',
-    port            => 443,
-    docroot         => '/opt/mirrors/ftp',
+    servername        => 'mirrors.ocf.berkeley.edu',
+    port              => 443,
+    docroot           => '/opt/mirrors/ftp',
 
-    directories     => [
+    directories       => [
       {
         path          => '/opt/mirrors/ftp',
         options       => ['+Indexes', '+SymlinksIfOwnerMatch'],
@@ -150,10 +150,10 @@ class ocf_mirrors {
       ReadmeName FOOTER.html
     ",
 
-    ssl       => true,
-    ssl_key   => "/etc/ssl/private/${::fqdn}.key",
-    ssl_cert  => "/etc/ssl/private/${::fqdn}.crt",
-    ssl_chain => '/etc/ssl/certs/incommon-intermediate.crt',
+    ssl               => true,
+    ssl_key           => "/etc/ssl/private/${::fqdn}.key",
+    ssl_cert          => "/etc/ssl/private/${::fqdn}.crt",
+    ssl_chain         => '/etc/ssl/certs/incommon-intermediate.crt',
   }
 
   file { '/opt/mirrors/bin/report-sizes':
@@ -166,10 +166,10 @@ class ocf_mirrors {
   }
 
   file { '/opt/mirrors/bin/healthcheck':
-    source  => 'puppet:///modules/ocf_mirrors/healthcheck',
-    owner   => 'mirrors',
-    group   => 'mirrors',
-    mode    => '0755',
+    source => 'puppet:///modules/ocf_mirrors/healthcheck',
+    owner  => 'mirrors',
+    group  => 'mirrors',
+    mode   => '0755',
   }
 
   file { '/usr/local/sbin/process-mirrors-logs':
@@ -177,9 +177,9 @@ class ocf_mirrors {
     mode   => '0755',
   } ->
   cron { 'mirrors-stats':
-    command => '/usr/local/sbin/process-mirrors-logs --quiet',
-    minute  => 0,
-    hour    => 0,
+    command     => '/usr/local/sbin/process-mirrors-logs --quiet',
+    minute      => 0,
+    hour        => 0,
     environment => ["OCFSTATS_PWD=${ocfstats_password}"];
   }
 }

--- a/modules/ocf_mirrors/manifests/tanglu.pp
+++ b/modules/ocf_mirrors/manifests/tanglu.pp
@@ -11,10 +11,10 @@ class ocf_mirrors::tanglu {
   }
 
   file { '/opt/mirrors/project/tanglu/sync-releases':
-    source  => 'puppet:///modules/ocf_mirrors/project/tanglu/sync-releases',
-    mode    => '0755',
-    owner   => mirrors,
-    group   => mirrors;
+    source => 'puppet:///modules/ocf_mirrors/project/tanglu/sync-releases',
+    mode   => '0755',
+    owner  => mirrors,
+    group  => mirrors;
   }
 
   cron { 'tanglu-releases':

--- a/modules/ocf_mirrors/manifests/trisquel.pp
+++ b/modules/ocf_mirrors/manifests/trisquel.pp
@@ -1,14 +1,14 @@
 class ocf_mirrors::trisquel {
   ocf_mirrors::ftpsync {
     'trisquel':
-      rsync_host               => 'rsync.trisquel.info',
-      rsync_path               => 'trisquel.packages',
-      cron_minute              => '45';
+      rsync_host  => 'rsync.trisquel.info',
+      rsync_path  => 'trisquel.packages',
+      cron_minute => '45';
 
     'trisquel-images':
-      rsync_host               => 'rsync.trisquel.info',
-      rsync_path               => 'trisquel.iso',
-      rsync_extra              => '--block-size=8192',
-      cron_minute              => '55';
+      rsync_host  => 'rsync.trisquel.info',
+      rsync_path  => 'trisquel.iso',
+      rsync_extra => '--block-size=8192',
+      cron_minute => '55';
   }
 }

--- a/modules/ocf_mirrors/manifests/ubuntu.pp
+++ b/modules/ocf_mirrors/manifests/ubuntu.pp
@@ -11,10 +11,10 @@ class ocf_mirrors::ubuntu {
   }
 
   file { '/opt/mirrors/project/ubuntu/sync-releases':
-    source  => 'puppet:///modules/ocf_mirrors/project/ubuntu/sync-releases',
-    mode    => '0755',
-    owner   => mirrors,
-    group   => mirrors;
+    source => 'puppet:///modules/ocf_mirrors/project/ubuntu/sync-releases',
+    mode   => '0755',
+    owner  => mirrors,
+    group  => mirrors;
   }
 
   cron { 'ubuntu-releases':

--- a/modules/ocf_printhost/manifests/cups.pp
+++ b/modules/ocf_printhost/manifests/cups.pp
@@ -23,8 +23,8 @@ class ocf_printhost::cups {
       content => "# deny printing raw jobs\n";
 
     '/etc/cups/ppd':
-      ensure  => directory,
-      group   => 'lp';
+      ensure => directory,
+      group  => 'lp';
 
     ['/etc/cups/ppd/papercut-single.ppd', '/etc/cups/ppd/pagefault-single.ppd']:
       content => epp('ocf_printhost/cups/ppd/m806.ppd.epp', { 'double' => false });
@@ -45,8 +45,8 @@ class ocf_printhost::cups {
       source  => 'puppet:///modules/ocf_printhost/cups/classes.conf';
 
     '/usr/lib/cups/filter/ocfps/':
-      source  => 'puppet:///modules/ocf_printhost/ocfps',
-      mode    => '0755';
+      source => 'puppet:///modules/ocf_printhost/ocfps',
+      mode   => '0755';
   }
 
   mount { '/var/spool/cups':

--- a/modules/ocf_printhost/manifests/enforcer.pp
+++ b/modules/ocf_printhost/manifests/enforcer.pp
@@ -7,16 +7,16 @@ class ocf_printhost::enforcer {
       require => Package['cups-tea4cups'];
 
     '/usr/local/bin/enforcer':
-      source  => 'puppet:///modules/ocf_printhost/enforcer',
-      mode    => '0755';
+      source => 'puppet:///modules/ocf_printhost/enforcer',
+      mode   => '0755';
 
     '/usr/local/bin/enforcer-pc':
-      source  => 'puppet:///modules/ocf_printhost/enforcer-pc',
-      mode    => '0755';
+      source => 'puppet:///modules/ocf_printhost/enforcer-pc',
+      mode   => '0755';
 
     '/opt/share/enforcer':
-      ensure  => directory,
-      mode    => '0500';
+      ensure => directory,
+      mode   => '0500';
 
     '/opt/share/enforcer/enforcer.conf':
       source    => 'puppet:///private/enforcer/enforcer.conf',

--- a/modules/ocf_puppet/manifests/puppetboard.pp
+++ b/modules/ocf_puppet/manifests/puppetboard.pp
@@ -6,8 +6,8 @@ class ocf_puppet::puppetboard {
 
   # Nginx is used to proxy to Marathon and to supply a HTTP -> HTTPS redirect
   class { 'nginx':
-    manage_repo => false,
-    confd_purge => true,
+    manage_repo  => false,
+    confd_purge  => true,
     server_purge => true,
   }
 
@@ -19,7 +19,7 @@ class ocf_puppet::puppetboard {
       $::hostname,
       $::fqdn,
     ],
-    proxy => 'http://lb.ocf.berkeley.edu:10009',
-    ssl   => true,
+    proxy          => 'http://lb.ocf.berkeley.edu:10009',
+    ssl            => true,
   }
 }

--- a/modules/ocf_puppet/manifests/puppetmaster.pp
+++ b/modules/ocf_puppet/manifests/puppetmaster.pp
@@ -5,7 +5,7 @@ class ocf_puppet::puppetmaster {
 
   # This defines Service['puppetserver'], so we can't do it ourselves.
   class { 'puppetdb::master::config':
-    puppetdb_server => 'puppetdb',
+    puppetdb_server             => 'puppetdb',
 
     # Prevent hard Puppet failures if PuppetDB is not available
     puppetdb_soft_write_failure => true,
@@ -72,8 +72,8 @@ class ocf_puppet::puppetmaster {
       require => File['/opt/puppetlabs/shares'];
 
     '/opt/puppetlabs/scripts/update-prod':
-      source  => 'puppet:///modules/ocf_puppet/update-prod',
-      mode    => '0755';
+      source => 'puppet:///modules/ocf_puppet/update-prod',
+      mode   => '0755';
 
     # These are just links to the new locations, but keep them for staff to use
     # since they are much more convenient to type.

--- a/modules/ocf_ssh/manifests/init.pp
+++ b/modules/ocf_ssh/manifests/init.pp
@@ -7,8 +7,8 @@ class ocf_ssh {
   include ocf_ssl::default_bundle
 
   class { 'ocf::nfs':
-    cron   => true,
-    web    => true;
+    cron => true,
+    web  => true;
   }
 
   include ocf_ssh::makeservices

--- a/modules/ocf_ssh/manifests/webssh.pp
+++ b/modules/ocf_ssh/manifests/webssh.pp
@@ -7,8 +7,8 @@ class ocf_ssh::webssh {
   }
 
   class { 'nginx':
-    manage_repo => false,
-    confd_purge => true,
+    manage_repo  => false,
+    confd_purge  => true,
     server_purge => true,
   }
 
@@ -18,17 +18,17 @@ class ocf_ssh::webssh {
 
   nginx::resource::server {
     $webssh_fqdn:
-      server_name => [
+      server_name  => [
         $webssh_fqdn
       ],
 
-      proxy => 'http://webssh',
+      proxy        => 'http://webssh',
 
-      ssl        => true,
-      ssl_cert   => "/etc/ssl/private/${::fqdn}.bundle",
-      ssl_key    => "/etc/ssl/private/${::fqdn}.key",
+      ssl          => true,
+      ssl_cert     => "/etc/ssl/private/${::fqdn}.bundle",
+      ssl_key      => "/etc/ssl/private/${::fqdn}.key",
 
-      add_header => {
+      add_header   => {
         'Strict-Transport-Security' => 'max-age=31536000',
       },
 

--- a/modules/ocf_ssl/manifests/bundle.pp
+++ b/modules/ocf_ssl/manifests/bundle.pp
@@ -10,16 +10,16 @@ define ocf_ssl::bundle(
       group   => ssl-cert;
 
     "/etc/ssl/private/${title}.key":
-      source  => $key_source,
-      mode    => '0640';
+      source => $key_source,
+      mode   => '0640';
 
     "/etc/ssl/private/${title}.crt":
-      source  => $cert_source,
-      mode    => '0644';
+      source => $cert_source,
+      mode   => '0644';
 
     "/etc/ssl/private/${title}.intermediate":
-      source  => $intermediate_source,
-      mode    => '0644';
+      source => $intermediate_source,
+      mode   => '0644';
   }
 
   # ssl bundle (cert + intermediates)
@@ -30,8 +30,8 @@ define ocf_ssl::bundle(
 
   concat {
     default:
-      owner => root,
-      group => ssl-cert,
+      owner          => root,
+      group          => ssl-cert,
 
       ensure_newline => true;
     $bundle:

--- a/modules/ocf_ssl/manifests/init.pp
+++ b/modules/ocf_ssl/manifests/init.pp
@@ -12,17 +12,17 @@ class ocf_ssl {
       require => Package['ssl-cert'];
 
     '/etc/ssl/certs/incommon-intermediate.crt':
-      source  => 'puppet:///modules/ocf_ssl/incommon-intermediate.crt',
-      mode    => '0644';
+      source => 'puppet:///modules/ocf_ssl/incommon-intermediate.crt',
+      mode   => '0644';
 
     '/etc/ssl/certs/lets-encrypt.crt':
-      source  => 'puppet:///modules/ocf_ssl/lets-encrypt.crt',
-      mode    => '0644';
+      source => 'puppet:///modules/ocf_ssl/lets-encrypt.crt',
+      mode   => '0644';
 
     # 2048-bit dhparams for use by servers;
     # these are public numbers and can safely be shared across services
     '/etc/ssl/dhparam.pem':
-      source  => 'puppet:///modules/ocf_ssl/dhparam.pem',
-      mode    => '0444';
+      source => 'puppet:///modules/ocf_ssl/dhparam.pem',
+      mode   => '0444';
   }
 }

--- a/modules/ocf_stats/manifests/labstats.pp
+++ b/modules/ocf_stats/manifests/labstats.pp
@@ -28,17 +28,17 @@ class ocf_stats::labstats {
   # TODO: Remove this by moving the endpoint for desktop session updates to
   # ocfweb API (rt#6624)
   apache::vhost { 'labstats.ocf.berkeley.edu':
-    servername => 'labstats.ocf.berkeley.edu',
-    port       => 444,
-    docroot    => '/opt/stats/labstats/cgi/',
-    options    => ['-Indexes'],
+    servername  => 'labstats.ocf.berkeley.edu',
+    port        => 444,
+    docroot     => '/opt/stats/labstats/cgi/',
+    options     => ['-Indexes'],
 
-    ssl        => true,
-    ssl_key    => "/etc/ssl/private/${::fqdn}.key",
-    ssl_cert   => "/etc/ssl/private/${::fqdn}.crt",
-    ssl_chain  => '/etc/ssl/certs/incommon-intermediate.crt',
+    ssl         => true,
+    ssl_key     => "/etc/ssl/private/${::fqdn}.key",
+    ssl_cert    => "/etc/ssl/private/${::fqdn}.crt",
+    ssl_chain   => '/etc/ssl/certs/incommon-intermediate.crt',
 
-    directories   => [{
+    directories => [{
       path        => '/opt/stats/labstats/cgi/',
       options     => ['+ExecCGI'],
 

--- a/modules/ocf_stats/manifests/munin.pp
+++ b/modules/ocf_stats/manifests/munin.pp
@@ -17,11 +17,11 @@ class ocf_stats::munin {
       notify  => Service['munin'],
       require => Package['munin'];
     '/usr/local/bin/gen-munin-nodes':
-      source  => 'puppet:///modules/ocf_stats/munin/gen-munin-nodes',
-      mode    => '0755';
+      source => 'puppet:///modules/ocf_stats/munin/gen-munin-nodes',
+      mode   => '0755';
     '/usr/local/bin/mail-munin-alert':
-      source  => 'puppet:///modules/ocf_stats/munin/mail-munin-alert',
-      mode    => '0755';
+      source => 'puppet:///modules/ocf_stats/munin/mail-munin-alert',
+      mode   => '0755';
   }
 
   # Generate munin nodes on the 3rd minute of every hour to avoid conflicting
@@ -50,7 +50,7 @@ class ocf_stats::munin {
 
       headers       => ['always set Strict-Transport-Security max-age=31536000'],
 
-      rewrites => [
+      rewrites      => [
         {rewrite_rule => '^/favicon.ico /var/cache/munin/www/static/favicon.ico [L]'},
         {rewrite_rule => '^/static/(.*) /var/cache/munin/www/static/$1 [L]'},
         {rewrite_rule => '^(/.*\.html)?$ /munin-cgi/munin-cgi-html/$1 [PT]'},
@@ -72,7 +72,7 @@ class ocf_stats::munin {
         }
       ],
 
-      directories => [
+      directories   => [
         {
           path         => '/var/cache/munin/www/static/',
           auth_require => 'all granted',

--- a/modules/ocf_stats/manifests/prometheus.pp
+++ b/modules/ocf_stats/manifests/prometheus.pp
@@ -5,27 +5,31 @@ class ocf_stats::prometheus {
     extra_options  => '--web.listen-address="127.0.0.1:9090" --web.external-url=http://127.0.0.1/prom',
     alerts         => {},
     scrape_configs => [
-      { 'job_name' => 'prometheus',
+      {
+        'job_name'        => 'prometheus',
         'scrape_interval' => '10s',
         'scrape_timeout'  => '10s',
         'static_configs'  => [
-          { 'targets' => [ 'localhost:9090' ],
-            'labels'  => { 'alias' => 'Prometheus' }
-          }
-        ]
+          {
+            'targets' => [ 'localhost:9090' ],
+            'labels'  => { 'alias' => 'Prometheus' },
+          },
+        ],
       },
-      { 'job_name' => 'node',
+      {
+        'job_name'        => 'node',
         'scrape_interval' => '5s',
         'scrape_timeout'  => '5s',
         'static_configs'  => [
-          { 'targets' => [
-            # A list of all hosts to scrape.
-            # We should probably figure out a better way of enumerating all the
-            # hosts.
-            'leprosy:9100',
-          ]
-          }
-        ]
+          {
+            'targets' => [
+              # A list of all hosts to scrape.
+              # We should probably figure out a better way of enumerating all the
+              # hosts.
+              'leprosy:9100',
+            ],
+          },
+        ],
       }
     ]
   }

--- a/modules/ocf_tv/manifests/pulse.pp
+++ b/modules/ocf_tv/manifests/pulse.pp
@@ -5,7 +5,7 @@ class ocf_tv::pulse {
   # problems with the daemon not starting properly
   # or starting with the wrong environment
   ocf::systemd::service { 'pulseaudio':
-    source => 'puppet:///modules/ocf_tv/pulseaudio.service',
+    source  => 'puppet:///modules/ocf_tv/pulseaudio.service',
     require => [
       Package['pulseaudio'],
       User['ocftv'],

--- a/modules/ocf_www/manifests/init.pp
+++ b/modules/ocf_www/manifests/init.pp
@@ -18,8 +18,8 @@ class ocf_www {
   include ocf_ssl::default_bundle
 
   class { 'ocf::nfs':
-    cron   => false,
-    web    => false,
+    cron => false,
+    web  => false,
   }
 
   class {

--- a/modules/ocf_www/manifests/lets_encrypt.pp
+++ b/modules/ocf_www/manifests/lets_encrypt.pp
@@ -3,9 +3,9 @@ class ocf_www::lets_encrypt {
 
   file {
     '/usr/local/bin/lets-encrypt-update':
-      source    => 'puppet:///modules/ocf_www/lets-encrypt-update',
-      mode      => '0755',
-      require   => File['/usr/local/bin/ocf-lets-encrypt'];
+      source  => 'puppet:///modules/ocf_www/lets-encrypt-update',
+      mode    => '0755',
+      require => File['/usr/local/bin/ocf-lets-encrypt'];
 
     '/etc/ssl/lets-encrypt/le-vhost.key':
       source    => 'puppet:///private/lets-encrypt-vhost.key',

--- a/modules/ocf_www/manifests/mod/suexec.pp
+++ b/modules/ocf_www/manifests/mod/suexec.pp
@@ -8,8 +8,8 @@ class ocf_www::mod::suexec {
   }
 
   file { '/etc/alternatives/suexec':
-    ensure => link,
-    target => '/usr/lib/apache2/suexec-ocf',
+    ensure  => link,
+    target  => '/usr/lib/apache2/suexec-ocf',
     require => Package['apache2-suexec-ocf'],
   }
 }

--- a/modules/ocf_www/manifests/site/unavailable.pp
+++ b/modules/ocf_www/manifests/site/unavailable.pp
@@ -40,8 +40,8 @@ class ocf_www::site::unavailable {
   }
 
   apache::vhost { 'unavailable':
-    *         => $options,
-    port      => 80,
+    *    => $options,
+    port => 80,
   }
 
   apache::vhost { 'https-unavailable':

--- a/modules/ocf_www/manifests/site/www.pp
+++ b/modules/ocf_www/manifests/site/www.pp
@@ -39,7 +39,7 @@ class ocf_www::site::www {
     request_headers     => ['set X-Forwarded-Proto https'],
     proxy_preserve_host => true,
 
-    rewrites        => [
+    rewrites            => [
       {
         comment      => 'proxy to ocfweb',
         rewrite_cond => [
@@ -52,7 +52,7 @@ class ocf_www::site::www {
       }
     ],
 
-    directories     => [
+    directories         => [
       {
         path           => '/services/http/users',
         provider       => 'directories',
@@ -81,7 +81,7 @@ class ocf_www::site::www {
       }
     ],
 
-    custom_fragment => '
+    custom_fragment     => '
       UserDir /services/http/users/
       UserDir disabled root
     ',
@@ -96,8 +96,8 @@ class ocf_www::site::www {
   apache::vhost {
     # redirect HTTP -> canonical HTTPS
     'www-http-redirect':
-      servername      => 'www.ocf.berkeley.edu',
-      serveraliases   => [
+      servername           => 'www.ocf.berkeley.edu',
+      serveraliases        => [
         'www',
         'dev-www',
         'ocf.berkeley.edu',
@@ -134,9 +134,9 @@ class ocf_www::site::www {
       redirectmatch_regexp => '^(.*)',
       redirectmatch_dest   => $canonical_url,
 
-      ssl             => true,
-      ssl_key         => "/etc/ssl/private/${::fqdn}.key",
-      ssl_cert        => "/etc/ssl/private/${::fqdn}.crt",
-      ssl_chain       => '/etc/ssl/certs/incommon-intermediate.crt';
+      ssl                  => true,
+      ssl_key              => "/etc/ssl/private/${::fqdn}.key",
+      ssl_cert             => "/etc/ssl/private/${::fqdn}.crt",
+      ssl_chain            => '/etc/ssl/certs/incommon-intermediate.crt';
   }
 }


### PR DESCRIPTION
It used to give pathological results for things like

```puppet
thing => {
  a => b,
  b => c,
},
```

but it seems to have been fixed in newer versions of puppet-lint.

Also auto-fix Puppet style errors.