### PR TITLE
Make Brave less needy

### DIFF
--- a/modules/ocf/manifests/packages/brave.pp
+++ b/modules/ocf/manifests/packages/brave.pp
@@ -1,9 +1,19 @@
 class ocf::packages::brave {
   include ocf::userns
 
+  $browser_homepage = lookup('browser_homepage')
+
   class { 'ocf::packages::brave::apt':
     stage =>  first,
   }
 
   package { 'brave':; }
+
+  # TODO: Change this to a global config
+  # if/when Brave adds support for it.
+  file {
+    '/etc/skel/.config/brave/session-store-1':
+      content => template('ocf/brave/session-store-1.erb'),
+      require => Package['brave'];
+  }
 }

--- a/modules/ocf/templates/brave/session-store-1.erb
+++ b/modules/ocf/templates/brave/session-store-1.erb
@@ -2,7 +2,7 @@
     "settings": {
       "general.check-default-on-startup": false,
       "general.is-default-browser": false,
-      "general.homepage": "https://www.ocf.berkeley.edu/about/lab/open-source",
+      "general.homepage": "<%= @browser_homepage %>",
       "general.startup-mode": "homePage",
       "shutdown.clear-cache": true,
       "shutdown.clear-all-site-cookies": true,

--- a/modules/ocf_desktop/files/skel/config/brave/session-store-1
+++ b/modules/ocf_desktop/files/skel/config/brave/session-store-1
@@ -1,0 +1,14 @@
+{
+    "settings":{
+      "general.check-default-on-startup":false,
+      "general.is-default-browser":false,
+      "general.homepage":"https://www.ocf.berkeley.edu/about/lab/open-source",
+      "general.startup-mode":"homePage",
+      "shutdown.clear-cache":true,
+      "shutdown.clear-all-site-cookies":true,
+      "shutdown.clear-autofill-data":true,
+      "shutdown.clear-downloads":true,
+      "shutdown.clear-autocomplete-data":true,
+      "shutdown.clear-history":true
+   }
+}

--- a/modules/ocf_desktop/files/skel/config/brave/session-store-1
+++ b/modules/ocf_desktop/files/skel/config/brave/session-store-1
@@ -1,14 +1,15 @@
 {
-    "settings":{
-      "general.check-default-on-startup":false,
-      "general.is-default-browser":false,
-      "general.homepage":"https://www.ocf.berkeley.edu/about/lab/open-source",
-      "general.startup-mode":"homePage",
-      "shutdown.clear-cache":true,
-      "shutdown.clear-all-site-cookies":true,
-      "shutdown.clear-autofill-data":true,
-      "shutdown.clear-downloads":true,
-      "shutdown.clear-autocomplete-data":true,
-      "shutdown.clear-history":true
+    "settings": {
+      "general.check-default-on-startup": false,
+      "general.is-default-browser": false,
+      "general.homepage": "https://www.ocf.berkeley.edu/about/lab/open-source",
+      "general.startup-mode": "homePage",
+      "shutdown.clear-cache": true,
+      "shutdown.clear-all-site-cookies": true,
+      "shutdown.clear-autofill-data": true,
+      "shutdown.clear-downloads": true,
+      "shutdown.clear-autocomplete-data": true,
+      "shutdown.clear-history": true,
+      "advanced.pdfjs-enabled": false
    }
 }


### PR DESCRIPTION
There was no documentation on this, so I was just deleting files in `~/.config/brave` until I found one that reset the browser settings. `~/.config/brave/session-store-1` is created after a user starts the browser, but I found that creating one with minimal settings will cause brave to keep these and add the other defaults on start.

Starts brave with [these settings](https://i.fluffy.cc/H3dJwg9SDLmlpgsSlVncqP6CvrdsmdQN.png), as recommended by someone in their Discord. It also closely mirrors the ephemeral mode we run our other browsers in. Lastly, gets rid of the annoying message where Brave asks to be the default browser and make OCF the default homepage.

Unfortunately I could not find a place to put this so that the settings are global. Again, very little documentation.  