### PR TITLE
shorturl for printer issue log

### DIFF
--- a/modules/ocf_www/manifests/site/shorturl.pp
+++ b/modules/ocf_www/manifests/site/shorturl.pp
@@ -76,6 +76,7 @@ class ocf_www::site::shorturl {
       {rewrite_rule => '^/opstaff-schedule$ https://docs.google.com/spreadsheets/d/1LUyU2AFY6YV403UkKUf_DhYn_-iqJGIO91JRRchGM8A/edit?usp=sharing [R]'},
       {rewrite_rule => '^/os$ https://docs.google.com/spreadsheets/d/1LUyU2AFY6YV403UkKUf_DhYn_-iqJGIO91JRRchGM8A/edit?usp=sharing [R]'},
       {rewrite_rule => '^/password$ https://www.ocf.berkeley.edu/account/password [R]'},
+      {rewrite_rule => '^/printerlog$ https://docs.google.com/spreadsheets/d/1f4rLSmVt11oeFmO1yUUcXa-JcyFmDtloTWrYYPfYJoU/edit?usp=sharing [R]'},
       {rewrite_rule => '^/printing$ https://www.ocf.berkeley.edu/announcements/2016-02-09/printing [R]'},
       {rewrite_rule => '^/rt$ https://rt.ocf.berkeley.edu/ [R]'},
       {rewrite_rule => '^/rt/([0-9]+)$ https://rt.ocf.berkeley.edu/Ticket/Display.html?id=$1 [R]'},


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1f4rLSmVt11oeFmO1yUUcXa-JcyFmDtloTWrYYPfYJoU/edit?usp=sharing

Have been wanting this for a while, especially useful recently because we keep taking things in/out of rotation without telling anyone why. Need to be OCF to edit. Should also share with opstaff so they can use it.
