### PR TITLE
ocf: don't reject logins if homedir can't be created

### DIFF
--- a/modules/ocf/files/auth/pam/mkhomedir
+++ b/modules/ocf/files/auth/pam/mkhomedir
@@ -4,4 +4,4 @@ Priority: 0
 Session-Interactive-Only: yes
 Session-Type: Additional
 Session-Final:
-	required	pam_mkhomedir.so silent skel=/etc/skel/ umask=0077
+	optional	pam_mkhomedir.so silent skel=/etc/skel/ umask=0077


### PR DESCRIPTION
Right now no one can log into corruption because `/home` is readonly