### PR TITLE
ocf_irc: fix whowas typo in inspircd.conf

### DIFF
--- a/modules/ocf_irc/templates/inspircd.conf.erb
+++ b/modules/ocf_irc/templates/inspircd.conf.erb
@@ -144,7 +144,7 @@
      level="verbose"
      target="/var/log/inspircd.log">
 
-<whowas goupsize="10" maxgroups="100000" maxkeep="2w">
+<whowas groupsize="10" maxgroups="100000" maxkeep="2w">
 
 <badnick nick="Global" reason="Reserved For Services">
 <badnick nick="*Serv" reason="Reserved For Services">


### PR DESCRIPTION
Thanks to dwc for noticing the command wasn't working and waf for finding the typo. This should fix whowas being disabled.