### PR TITLE
bashrc: append to history file instead of overwriting it

### DIFF
--- a/modules/ocf/files/shell/bash.bashrc
+++ b/modules/ocf/files/shell/bash.bashrc
@@ -21,6 +21,9 @@ mesg n
 HISTCONTROL=ignoreboth
 HISTTIMEFORMAT="%F %T "
 
+# Append to history file instead of overwriting it
+shopt -s histappend
+
 # Check the window size after each command, and update LINES and COLUMNS if
 # needed
 shopt -s checkwinsize


### PR DESCRIPTION
This comes from Debian's default bashrc. Thoughts?