### PR TITLE
Remove bash startup/logout files in /etc/skel

### DIFF
--- a/modules/ocf/manifests/packages/shell.pp
+++ b/modules/ocf/manifests/packages/shell.pp
@@ -45,6 +45,12 @@ class ocf::packages::shell {
       require => Package['bash'];
   }
 
+  # Settings in these files are handled by our custom bash.bashrc and bash.bash_logout
+  file {
+    ['/etc/skel/.bashrc', '/etc/skel/.profile', '/etc/skel/.bash_logout']:
+      ensure => absent;
+  }
+
   exec { 'compile-terminfo':
     command     => 'tic -x /usr/share/terminfo/x/xterm-termite',
     refreshonly => true;


### PR DESCRIPTION
Since we moved to creating home directories via `pam_mkhomedir`, the default `.bashrc`, `.profile`, and `.bash_logout` have been getting copied into new home directories. These files unfortunately tend to interfere with what we already set up globally in `/etc/bash.bashrc` etc. (For example, the settings in `.bashrc` overwrite our custom bash prompt.) Thus, we should remove these files.