### PR TITLE
Generate desktop leases periodically (rt#7106)

### DIFF
--- a/modules/ocf_dhcp/files/gen-desktop-leases
+++ b/modules/ocf_dhcp/files/gen-desktop-leases
@@ -1,11 +1,24 @@
 #!/usr/bin/env python3
+import subprocess
+
 from ocflib.infra.hosts import hosts_by_filter
+
+DESKTOP_LEASES_FILE = '/etc/dhcp/desktop-leases.conf'
 
 desktops = hosts_by_filter('(type=desktop)')
 
-for desktop in desktops:
-    print('host {} {{ hardware ethernet {}; fixed-address {}; }}'.format(
+with open(DESKTOP_LEASES_FILE, 'r') as f:
+    old_contents = sorted([line.strip() for line in f])
+
+new_contents = []
+for desktop in sorted(desktops, key=lambda d: d['cn'][0]):
+    new_contents.append('host {} {{ hardware ethernet {}; fixed-address {}; }}'.format(
         desktop['cn'][0],
         desktop['macAddress'][0],
         desktop['ipHostNumber'][0],
     ))
+
+if new_contents and new_contents != old_contents:
+    with open(DESKTOP_LEASES_FILE, 'w') as f:
+        f.write('\n'.join(new_contents) + '\n')
+    subprocess.check_call(('systemctl', 'restart', 'isc-dhcp-server'))

--- a/modules/ocf_dhcp/manifests/init.pp
+++ b/modules/ocf_dhcp/manifests/init.pp
@@ -7,7 +7,7 @@ class ocf_dhcp {
   file {
     '/etc/dhcp/dhcpd.conf':
       source  => 'puppet:///modules/ocf_dhcp/dhcpd.conf',
-      require => [Package['isc-dhcp-server'], Exec['gen-desktop-leases']],
+      require => Package['isc-dhcp-server'],
       notify  => Service['isc-dhcp-server'];
 
     '/usr/local/sbin/gen-desktop-leases':
@@ -24,13 +24,6 @@ class ocf_dhcp {
         "set INTERFACES '\"${ocf::networking::iface}\"'",
       ],
       require => Package['isc-dhcp-server'];
-  }
-
-  exec { 'gen-desktop-leases':
-    command => '/usr/local/sbin/gen-desktop-leases > /etc/dhcp/desktop-leases.conf',
-    creates => '/etc/dhcp/desktop-leases.conf',
-    require => [File['/usr/local/sbin/gen-desktop-leases'], Package['python3-ocflib']],
-    notify  => Service['isc-dhcp-server'];
   }
 
   service { 'isc-dhcp-server':
@@ -52,6 +45,11 @@ class ocf_dhcp {
       command => '/usr/local/bin/lab-wakeup -q',
       minute  => '*/15',
       require => File['/usr/local/bin/lab-wakeup'];
+
+    'gen-desktop-leases':
+      command => '/usr/local/sbin/gen-desktop-leases',
+      minute  => '*/15',
+      require => [File['/usr/local/sbin/gen-desktop-leases'], Package['python3-ocflib']];
   }
 
   # Allow BOOTP (IPv4 only)


### PR DESCRIPTION
If pestilence was rebuilt without access to LDAP (for instance), then it would not have a list of any desktops, and any new desktops were also not added to the list of leases. Same with if a desktop MAC address changes and then needs to be rebuilt, so this fixes those problems by regenerating the desktop leases list periodically.

Potentially could use python sets here instead of sorting the lists, but I think having the output file sorted by hostname also makes it a bit easier to read through if that is ever necessary.