### PR TITLE
ocf_stats: set docroot owner and group for munin

### DIFF
--- a/modules/ocf_stats/manifests/munin.pp
+++ b/modules/ocf_stats/manifests/munin.pp
@@ -48,6 +48,8 @@ class ocf_stats::munin {
       servername    => "${cname}.ocf.berkeley.edu",
       port          => 443,
       docroot       => '/var/cache/munin/www/static/',
+      docroot_owner => 'munin',
+      docroot_group => 'munin',
 
       ssl           => true,
       ssl_key       => "/etc/ssl/private/${::fqdn}.key",
@@ -97,7 +99,9 @@ class ocf_stats::munin {
           sethandler   => 'fcgid-script',
           auth_require => 'all granted',
         }
-      ];
+      ],
+
+      require       => Package['munin'];
 
     'munin-redirect':
       servername      => "${cname}.ocf.berkeley.edu",


### PR DESCRIPTION
By default the Puppet apache module creates the docroot and sets
its ownership to root:root. This prevents munin from subsequently
copying files into the docroot upon its first run, because the
permissions do not allow for it.

Set the owner and group correctly to fix this.