### PR TITLE
Bugfixes etc. for firewall rules on pestilence

### DIFF
--- a/hieradata/nodes/pestilence.yaml
+++ b/hieradata/nodes/pestilence.yaml
@@ -2,6 +2,3 @@ classes:
     - ocf_dhcp
     - ocf_ns
     - ocf_rancid
-
-# TODO: temporary, remove
-ocf::firewall::reject_unrecognized_input: false

--- a/modules/ocf/manifests/firewall/post.pp
+++ b/modules/ocf/manifests/firewall/post.pp
@@ -1,6 +1,18 @@
 class ocf::firewall::post {
   require ocf::networking
 
+  # Allow outgoing traffic for connections initiated by special devices
+  ocf::firewall::firewall46 {
+    '995 allow outgoing RELATED and ESTABLISHED traffic':
+      opts   => {
+        'chain'  => 'PUPPET-OUTPUT',
+        'proto'  => 'all',
+        'state'  => ['RELATED', 'ESTABLISHED'],
+        'action' => 'accept',
+      },
+      before => undef;
+  }
+
   # Only allow root and postfix to connect to anthrax port 25; everyone else
   # must use the sendmail interface.
   # firewall-multi doesn't multiplex this so we have to do it manually :(

--- a/modules/ocf_dhcp/manifests/init.pp
+++ b/modules/ocf_dhcp/manifests/init.pp
@@ -52,11 +52,20 @@ class ocf_dhcp {
       require => [File['/usr/local/sbin/gen-desktop-leases'], Package['python3-ocflib']];
   }
 
-  # Allow DHCP server traffic
-  firewall_multi { '101 allow dhcp server':
-    chain  => 'PUPPET-INPUT',
-    proto  => 'udp',
-    dport  => 67,
-    action => 'accept',
+  firewall_multi {
+    '101 allow incoming dhcp':
+      chain  => 'PUPPET-INPUT',
+      proto  => 'udp',
+      dport  => 67,
+      action => 'accept';
+
+    # Allow outgoing DHCP to any special devices that may be configured to use it
+    # Conntrack may not be able to track DHCP due to the unusual IP address
+    # rules it uses. Thus we specially add a rule here.
+    '101 allow outgoing dhcp':
+      chain  => 'PUPPET-OUTPUT',
+      proto  => 'udp',
+      sport  => 67,
+      action => 'accept';
   }
 }

--- a/modules/ocf_dhcp/manifests/init.pp
+++ b/modules/ocf_dhcp/manifests/init.pp
@@ -52,20 +52,11 @@ class ocf_dhcp {
       require => [File['/usr/local/sbin/gen-desktop-leases'], Package['python3-ocflib']];
   }
 
-  # Allow BOOTP (IPv4 only)
-  firewall_multi { '101 allow bootps':
+  # Allow DHCP server traffic
+  firewall_multi { '101 allow dhcp server':
     chain  => 'PUPPET-INPUT',
     proto  => 'udp',
     dport  => 67,
     action => 'accept',
-  }
-
-  # Allow DHCP Server (IPv6 only)
-  firewall_multi { '101 allow dhcpv6-server':
-    provider => 'ip6tables',
-    chain    => 'PUPPET-INPUT',
-    proto    => 'udp',
-    dport    => 547,
-    action   => 'accept',
   }
 }

--- a/modules/ocf_ns/manifests/init.pp
+++ b/modules/ocf_ns/manifests/init.pp
@@ -36,29 +36,12 @@ class ocf_ns {
     source => 'puppet:///modules/ocf_ns/ping-report',
   }
 
-  # firewall input rules, allow domain (53 t/u), bootps (67 t/u), tftp (69 u)
   ocf::firewall::firewall46 {
     '101 allow domain':
       opts => {
         chain  => 'PUPPET-INPUT',
         proto  => ['tcp', 'udp'],
         dport  => 53,
-        action => 'accept',
-      };
-
-    '102 allow bootps':
-      opts => {
-        chain  => 'PUPPET-INPUT',
-        proto  => ['tcp', 'udp'],
-        dport  => 67,
-        action => 'accept',
-      };
-
-    '103 allow tftp':
-      opts => {
-        chain  => 'PUPPET-INPUT',
-        proto  => 'udp',
-        dport  => 69,
         action => 'accept',
       };
   }


### PR DESCRIPTION
This PR removes some duplicate rules and allows pestilence to reply to DNS and DHCP requests from special devices.

(More generally, it allows any server to reply to an accepted request from a special device.)