### PR TITLE
Add grafana to dementors

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -10,6 +10,7 @@ mod 'alexharvey/firewall_multi',       '1.10.0'
 mod 'camptocamp-systemd',              '1.1.1' # Dependency of puppet-prometheus
 mod 'puppet-nginx',                    '0.12.0'
 mod 'puppet-archive',                  '3.0.0' # Dependency of puppet-prometheus
+mod 'puppet-grafana',                  '4.5.0'
 mod 'puppet-prometheus',               '5.0.0'
 mod 'puppetlabs-apache',               '3.1.0'
 mod 'puppetlabs-apt',                  '4.5.1'

--- a/modules/ocf/manifests/packages/grafana/apt.pp
+++ b/modules/ocf/manifests/packages/grafana/apt.pp
@@ -1,0 +1,13 @@
+class ocf::packages::grafana::apt {
+  apt::key { 'grafana':
+    id     => '418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB',
+    source => 'https://packagecloud.io/gpg.key',
+  }
+
+  apt::source { 'grafana':
+    location => 'https://packagecloud.io/grafana/stable/debian/',
+    release  => 'stretch',
+    repos    => 'main',
+    require  => Apt::Key['grafana'],
+  }
+}

--- a/modules/ocf_stats/manifests/grafana.pp
+++ b/modules/ocf_stats/manifests/grafana.pp
@@ -1,0 +1,62 @@
+# grafana config
+class ocf_stats::grafana {
+  class { 'ocf::packages::grafana::apt':
+    stage => first,
+  }
+
+  $canonical_url = $::host_env ? {
+    'dev'  => 'dev-prometheus',
+    'prod' => 'prometheus',
+  }
+
+  class { 'grafana':
+    install_method           => 'repo',
+
+    # Unfortunately, puppet-grafana requires that we specify a version number
+    # here.
+    version                  => '5.2.1',
+    manage_package_repo      => false,
+
+    cfg                      => {
+      app_mode         => 'production',
+      server           => {
+        http_addr => '127.0.0.1',
+        http_port => 8990,
+        domain    => "${canonical_url}.ocf.berkeley.edu",
+        root_url  => "https://${canonical_url}.ocf.berkeley.edu/grafana/",
+      },
+      database         => {
+        type => 'sqlite3',
+        path => 'grafana.db',
+      },
+      users            => {
+        auto_assign_org      => true,
+        allow_sign_up        => false,
+        auto_assign_org_role => 'Editor',
+      },
+      'auth.anonymous' => {
+        enabled  => true,
+      },
+      security         => {
+        disable_gravatar => true,
+      },
+    },
+
+    provisioning_datasources => {
+      apiVersion  => 1,
+      datasources => [
+        {
+          name      => 'Prometheus',
+          type      => 'prometheus',
+          access    => 'direct',
+          url       => 'https://prometheus.ocf.berkeley.edu/',
+          isDefault => true,
+        },
+      ],
+    },
+
+    # TODO: it's possible to save dashboards in Puppet with
+    # provisioning_dashboards. Once we settle on dashboards, we should put them
+    # here so they can be saved in VCS.
+  }
+}

--- a/modules/ocf_stats/manifests/grafana.pp
+++ b/modules/ocf_stats/manifests/grafana.pp
@@ -5,8 +5,8 @@ class ocf_stats::grafana {
   }
 
   $canonical_url = $::host_env ? {
-    'dev'  => 'dev-prometheus',
-    'prod' => 'prometheus',
+    'dev'  => 'dev-prometheus.ocf.berkeley.edu',
+    'prod' => 'prometheus.ocf.berkeley.edu',
   }
 
   class { 'grafana':
@@ -22,8 +22,8 @@ class ocf_stats::grafana {
       server           => {
         http_addr => '127.0.0.1',
         http_port => 8990,
-        domain    => "${canonical_url}.ocf.berkeley.edu",
-        root_url  => "https://${canonical_url}.ocf.berkeley.edu/grafana/",
+        domain    => $canonical_url,
+        root_url  => "https://${canonical_url}/grafana/",
       },
       database         => {
         type => 'sqlite3',
@@ -49,7 +49,7 @@ class ocf_stats::grafana {
           name      => 'Prometheus',
           type      => 'prometheus',
           access    => 'direct',
-          url       => 'https://prometheus.ocf.berkeley.edu/',
+          url       => "https://${canonical_url}/",
           isDefault => true,
         },
       ],

--- a/modules/ocf_stats/manifests/init.pp
+++ b/modules/ocf_stats/manifests/init.pp
@@ -5,6 +5,7 @@ class ocf_stats {
     default_vhost => false,
   }
 
+  include ocf_stats::grafana
   include ocf_stats::labstats
   include ocf_stats::munin
   include ocf_stats::prometheus

--- a/modules/ocf_stats/manifests/prometheus.pp
+++ b/modules/ocf_stats/manifests/prometheus.pp
@@ -71,6 +71,7 @@ class ocf_stats::prometheus {
       request_headers     => ['set X-Forwarded-Proto https'],
 
       rewrites            => [
+        {rewrite_rule => '^/grafana/(.*)$ http://127.0.0.1:8990/$1 [P]'},
         {rewrite_rule => '^/(.*)$ http://127.0.0.1:9090/$1 [P]'},
       ];
 


### PR DESCRIPTION
This PR adds Grafana. Some items of note:

* I haven't configured signin, since I think just letting everyone be anonymous should be good enough. If we decide we want some kind of LDAP integration, we can work on that later.
* Specifying the Grafana package and version number is silly, but the way they install the package is broken, so we have to do it this way.
* The `/grafana` HTTP subdir is defined in `prometheus.pp`, which is a bit wonky since I'd like it to be in `grafana.pp`. Suggestions for how to handle this better are welcome.