### PR TITLE
Proposal: set apache::default_vhost to false in hieradata

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -50,3 +50,6 @@ staffvm_src_range_4: 169.229.226.200-169.229.226.252
 internal_zone_range_6: 2607:f140:8801::1:5-2607:f140:8801::1:90
 desktop_src_range_6: 2607:f140:8801::1:100-2607:f140:8801::1:139
 staffvm_src_range_6: 2607:f140:8801::1:200-2607:f140:8801::1:252
+
+# Don't configure the default Apache vhost unless otherwise specified
+apache::default_vhost: false

--- a/modules/ocf_decal/manifests/init.pp
+++ b/modules/ocf_decal/manifests/init.pp
@@ -1,10 +1,6 @@
 class ocf_decal {
-
+  include apache
   include ocf_decal::website
-
-  class { 'apache':
-    default_vhost => false;
-  }
 
   user { 'ocfdecal':
     comment => 'DeCal management account',

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -57,14 +57,13 @@ class ocf_mirrors {
 
   class {
     '::apache':
-      default_vhost => false,
-      keepalive     => 'on',
-      log_formats   => {
+      keepalive   => 'on',
+      log_formats => {
         # A custom log format that counts bytes transferred by accesses (mod_logio)
         io_count => '%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O',
       },
       # "false" lets us define the class below with custom args
-      mpm_module    => false;
+      mpm_module  => false;
 
     '::apache::mod::worker':
       startservers    => 8,

--- a/modules/ocf_stats/manifests/init.pp
+++ b/modules/ocf_stats/manifests/init.pp
@@ -1,9 +1,6 @@
 class ocf_stats {
+  include apache
   include ocf::ssl::default
-
-  class { '::apache':
-    default_vhost => false,
-  }
 
   include ocf_stats::labstats
   include ocf_stats::munin

--- a/modules/ocf_www/manifests/init.pp
+++ b/modules/ocf_www/manifests/init.pp
@@ -25,13 +25,12 @@ class ocf_www {
 
   class {
     '::apache':
-      default_vhost => false,
-      log_formats   => {
+      log_formats => {
         # Log vhost name
         combined => '%v %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"'
       },
       # "false" lets us define the class below with custom args
-      mpm_module    => false;
+      mpm_module  => false;
 
     '::apache::mod::worker':
       startservers    => 8,


### PR DESCRIPTION
It seems that we always set `apache::default_vhost` to `false` whenever we include the `apache` module. Setting it in hieradata would allow us to eliminate some duplicate code (and also make it easier to split munin and prometheus into separate modules).

What do you all think? Is this a worthwhile change? Would this be an abuse of hiera?