### PR TITLE
Squelch ISP false positives about outdated Apache

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -53,3 +53,5 @@ staffvm_src_range_6: 2607:f140:8801::1:200-2607:f140:8801::1:252
 
 # Don't configure the default Apache vhost unless otherwise specified
 apache::default_vhost: false
+# Avoid ISP alerts about supposedly outdated Apache
+apache::server_tokens: Minor


### PR DESCRIPTION
By hiding the minimal version number, it might be possible to prevent ISP's security scanners from getting the impression that we run an outdated version of Apache.

What do you all think about doing this? Yea? Nay?