### PR TITLE
Enable HTTPS for dev apphosts

### DIFF
--- a/modules/ocf_apphost/files/default
+++ b/modules/ocf_apphost/files/default
@@ -1,9 +1,9 @@
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
-	server_name apphost.ocf.berkeley.edu;
+    server_name apphost.ocf.berkeley.edu;
 
-	location / {
-		deny all;
-	}
+    location / {
+        deny all;
+    }
 }

--- a/modules/ocf_apphost/files/default
+++ b/modules/ocf_apphost/files/default
@@ -1,9 +1,0 @@
-server {
-    listen 80 default_server;
-    listen [::]:80 default_server;
-    server_name apphost.ocf.berkeley.edu;
-
-    location / {
-        deny all;
-    }
-}

--- a/modules/ocf_apphost/manifests/proxy.pp
+++ b/modules/ocf_apphost/manifests/proxy.pp
@@ -15,7 +15,7 @@ class ocf_apphost::proxy {
 
     '/etc/nginx/sites-enabled/default':
       ensure  => file, # originally a link
-      source  => 'puppet:///modules/ocf_apphost/default',
+      content => template('ocf_apphost/default-vhost.erb'),
       require => Package['nginx'],
       notify  => Service['nginx'];
 

--- a/modules/ocf_apphost/manifests/proxy.pp
+++ b/modules/ocf_apphost/manifests/proxy.pp
@@ -1,7 +1,10 @@
 class ocf_apphost::proxy {
+  include ocf::ssl::default
+
   package { 'nginx':; }
   service { 'nginx':
-    require => Package['nginx'];
+    require   => Package['nginx'],
+    subscribe => Class['ocf::ssl::default'],
   }
 
   file {
@@ -29,15 +32,21 @@ class ocf_apphost::proxy {
       mode   => '0755';
   }
 
-  $build_args = $::host_env ? {
-    'dev'  => '--dev',
-    'prod' => '',
+  # TODO: Remove this once vampires has taken the place of werewolves and no
+  # longer needs to be the dev host
+  if $::hostname == 'vampires' {
+    $build_args = '--dev'
+  } else {
+    $build_args = $::host_env ? {
+      'dev'  => '--dev',
+      'prod' => '',
+    }
   }
 
   cron {
     'build-vhosts':
       command => "chronic /usr/local/bin/build-vhosts ${build_args} app",
       minute  => '*/10',
-      require => Package['nginx'];
+      require => [Package['nginx'], Class['ocf::ssl::default']];
   }
 }

--- a/modules/ocf_apphost/templates/default-vhost.erb
+++ b/modules/ocf_apphost/templates/default-vhost.erb
@@ -1,0 +1,25 @@
+# HTTP default vhost
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name apphost.ocf.berkeley.edu;
+
+    location / {
+        deny all;
+    }
+}
+
+# HTTPS default vhost
+server {
+    listen 443 default_server;
+    listen [::]:443 default_server;
+    server_name apphost.ocf.berkeley.edu;
+
+    ssl on;
+    ssl_certificate /etc/ssl/private/<%= @fqdn %>.bundle;
+    ssl_certificate_key /etc/ssl/private/<%= @fqdn %>.key;
+
+    location / {
+        deny all;
+    }
+}

--- a/modules/ocf_www/files/build-vhosts
+++ b/modules/ocf_www/files/build-vhosts
@@ -55,7 +55,7 @@ class SSL(namedtuple('SSL', ('fqdn',))):
         return str(SSL_BUNDLE / (self.fqdn + '.bundle'))
 
 
-class System_SSL(namedtuple('System_SSL', ('fqdn',))):
+class SystemSSL(namedtuple('SystemSSL', ('fqdn',))):
     """Tells where to find the standard OCF SSL files for this host (wildcards,
     fqdn.o.b.e, etc.).
     """
@@ -180,7 +180,7 @@ def build_config(src_vhosts, template, dev_config=False):
                 fqdn=dev_alias,
                 user=user,
                 comment='{} (dev alias of {})'.format(dev_alias, domain),
-                ssl=System_SSL(getfqdn()),
+                ssl=SystemSSL(getfqdn()),
                 bind_type='socket',
                 bind_dest=vhost['socket'],
             ))

--- a/modules/ocf_www/files/build-vhosts
+++ b/modules/ocf_www/files/build-vhosts
@@ -9,6 +9,7 @@ import tempfile
 from collections import namedtuple
 from itertools import chain
 from pathlib import Path
+from socket import getfqdn
 
 import jinja2
 from ocflib.account.search import user_is_sorried
@@ -23,6 +24,7 @@ NGINX_SITE_CONFIG = '/etc/nginx/sites-enabled/virtual'
 
 LETS_ENCRYPT_SSL = Path('/services/http/ssl')
 SSL_BUNDLE = Path('/etc/ssl/apphost')
+SYSTEM_SSL = Path('/etc/ssl/private')
 
 APP_DIR = Path('/srv/apps')
 
@@ -51,6 +53,20 @@ class SSL(namedtuple('SSL', ('fqdn',))):
     @property
     def bundle(self):
         return str(SSL_BUNDLE / (self.fqdn + '.bundle'))
+
+
+class System_SSL(namedtuple('System_SSL', ('fqdn',))):
+    """Tells where to find the standard OCF SSL files for this host (wildcards,
+    fqdn.o.b.e, etc.).
+    """
+
+    @property
+    def bundle(self):
+        return str(SYSTEM_SSL / (self.fqdn + '.bundle'))
+
+    @property
+    def key(self):
+        return str(SYSTEM_SSL / (self.fqdn + '.key'))
 
 
 class VirtualHost(namedtuple('VirtualHost', (
@@ -157,22 +173,32 @@ def build_config(src_vhosts, template, dev_config=False):
         )
         vhosts.add(primary)
 
-        # for app vhosts, define a dev vhost as well (HTTP only)
+        # for app vhosts, define a dev vhost as well
         if bind_type == 'socket':
             dev_alias = primary.dev_alias(dev_config)
             vhosts.add(VirtualHost(
                 fqdn=dev_alias,
                 user=user,
                 comment='{} (dev alias of {})'.format(dev_alias, domain),
-                ssl=None,
+                ssl=System_SSL(getfqdn()),
                 bind_type='socket',
                 bind_dest=vhost['socket'],
+            ))
+
+            vhosts.add(VirtualHost(
+                fqdn=dev_alias,
+                user=user,
+                comment='{0} (dev alias of {1}, redirect to {0})'.format(dev_alias, domain),
+                ssl=None,
+                bind_type='redirect',
+                bind_dest='https://' + dev_alias,
             ))
 
         redirects = set()
         if use_ssl:
             # Redirect from http://{domain} to https://{domain}
             redirects.add((primary.fqdn, None))
+
         for alias in vhost['aliases']:
             # Redirect from http://{alias} to http(s)://{domain}
             redirects.add((alias, None))


### PR DESCRIPTION
This enables HTTPS on sites like https://dev-app-ocf-berkeley-edu.apphost.ocf.berkeley.edu/ and https://hkn-eecs-berkeley-edu.apphost.ocf.berkeley.edu/, which is mostly just useful for when groups are setting up their apphost but don't have the DNS set up for it yet.

Maybe we should redirect these dev hosts to the actual domains if the DNS is working for their domain? It's a little strange to have multiple domains that work to access a site, but we've also had it like that for quite a while without any problems, so I don't think it needs to be done right now.

I believe this is actually the last non-HTTPS set of sites we offer! (I'm probably wrong on that, but I can't think of any others)