### PR TITLE
Switch to using a declarative Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,17 @@ pipeline {
       }
     }
   }
+
+  post {
+    failure {
+      emailNotification()
+    }
+    always {
+      node(label: 'slave') {
+        ircNotification()
+      }
+    }
+  }
 }
 
 // vim: ft=groovy

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,52 +1,41 @@
-try {
-    node('slave') {
-        step([$class: 'WsCleanup'])
+pipeline {
+  agent {
+    label 'slave'
+  }
 
-        stage('check-out-code') {
-            checkout scm
-        }
+  options {
+    ansiColor('xterm')
+    timeout(time: 1, unit: 'HOURS')
+  }
 
-        stage('install-dependencies') {
-            sh 'make vendor'
-        }
-
-        stage('test') {
-            sh 'make test'
-        }
-
-        stash 'src'
+  stages {
+    stage('install-dependencies') {
+      steps {
+        sh 'make vendor'
+      }
     }
 
-
-    if (env.BRANCH_NAME == 'master') {
-        node('deploy') {
-            step([$class: 'WsCleanup'])
-            unstash 'src'
-
-            stage('update-prod') {
-                sh '''
-                    kinit -t /opt/jenkins/deploy/ocfdeploy.keytab ocfdeploy
-                        ssh ocfdeploy@puppet 'sudo /opt/puppetlabs/scripts/update-prod'
-                '''
-            }
-        }
+    stage('test') {
+      steps {
+        sh 'make test'
+      }
     }
 
-} catch (err) {
-    def subject = "${env.JOB_NAME} - Build #${env.BUILD_NUMBER} - Failure!"
-    def message = "${env.JOB_NAME} (#${env.BUILD_NUMBER}) failed: ${env.BUILD_URL}"
-
-    if (env.BRANCH_NAME == 'master') {
-        slackSend color: '#FF0000', message: message
-        mail to: 'root@ocf.berkeley.edu', subject: subject, body: message
-    } else {
-        mail to: emailextrecipients([
-            [$class: 'CulpritsRecipientProvider'],
-            [$class: 'DevelopersRecipientProvider']
-        ]), subject: subject, body: message
+    stage('update-prod') {
+      when {
+        branch 'master'
+      }
+      agent {
+        label 'deploy'
+      }
+      steps {
+        sh '''
+            kinit -t /opt/jenkins/deploy/ocfdeploy.keytab ocfdeploy
+                ssh ocfdeploy@puppet 'sudo /opt/puppetlabs/scripts/update-prod'
+        '''
+      }
     }
-
-    throw err
+  }
 }
 
 // vim: ft=groovy


### PR DESCRIPTION
This follows a similar idea as ocf/dns#20 and ocf/ocflib#131 in switching the Jenkinsfile to being declarative. It also starts using our [shared pipeline library](https://github.com/ocf/shared-pipeline), which is nice because it means we don't have to keep copying the same stuff into each Jenkinsfile we set up like email notifications, IRC notifications, checking out of the repo, and any [shared steps](https://github.com/ocf/shared-pipeline/tree/master/vars).