### PR TITLE
[HPC] Autoadd SLURM users from LDAP.

### DIFF
--- a/modules/ocf_hpc/files/add_slurm_users
+++ b/modules/ocf_hpc/files/add_slurm_users
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-'''
+"""
 Script that adds users in the 'ocfhpc' LDAP group to SLURM as a SLURM user.
-'''
+"""
 import subprocess
+import sys
 
 from ocflib.account import search
 from ocflib.account import utils
@@ -11,23 +12,22 @@ DEFAULT_ACCOUNT = 'users'
 
 
 def main():
-    ocfhpc_ldap_user_set = set(utils.list_group('ocfhpc'))
-
     # This produces a newline-separated list of SLURM users.
     ocfhpc_slurm_user_list = subprocess.check_output(
         ('sacctmgr', '-noP', 'list', 'users', 'format=User'),
-        universal_newlines=True,
-    ).split('\n')[:-1]
-    ocfhpc_slurm_user_set = set(ocfhpc_slurm_user_list)
+    ).decode('utf-8').split('\n')[:-1]
 
-    users_to_be_added = ocfhpc_ldap_user_set.difference(ocfhpc_slurm_user_set)
+    ocfhpc_slurm_user_set = set(ocfhpc_slurm_user_list)
+    ocfhpc_ldap_user_set = set(utils.list_group('ocfhpc'))
+
+    users_to_be_added = ocfhpc_ldap_user_set - ocfhpc_slurm_user_set
 
     if not users_to_be_added:
         return
 
     for new_user in users_to_be_added:
         if not search.user_exists(new_user):
-            print('User {} in the HPC LDAP group does not exist.'.format(new_user))
+            print('User {} in the HPC LDAP group does not exist.'.format(new_user), file=sys.stderr)
             continue
 
         # Add a new user to SLURM and commit changes immediately.

--- a/modules/ocf_hpc/files/add_slurm_users
+++ b/modules/ocf_hpc/files/add_slurm_users
@@ -14,11 +14,10 @@ def main():
     ocfhpc_ldap_user_set = set(utils.list_group('ocfhpc'))
 
     # This produces a newline-separated list of SLURM users.
-    ocfhpc_slurm_user_list = subprocess.run(
-        ['sacctmgr', '-noP', 'list', 'users', 'format=User'],
-        stdout=subprocess.PIPE,
-        check=True
-    ).stdout.decode().split('\n')[:-1]
+    ocfhpc_slurm_user_list = subprocess.check_output(
+        ('sacctmgr', '-noP', 'list', 'users', 'format=User'),
+        universal_newlines=True,
+    ).split('\n')[:-1]
     ocfhpc_slurm_user_set = set(ocfhpc_slurm_user_list)
 
     users_to_be_added = ocfhpc_ldap_user_set.difference(ocfhpc_slurm_user_set)
@@ -27,13 +26,12 @@ def main():
         return
 
     for new_user in users_to_be_added:
-
         if not search.user_exists(new_user):
             print('User {} in the HPC LDAP group does not exist.'.format(new_user))
             continue
 
         # Add a new user to SLURM and commit changes immediately.
-        subprocess.run(['sacctmgr', '-i', 'add', 'user', new_user, 'account={}'.format(DEFAULT_ACCOUNT)])
+        subprocess.run(('sacctmgr', '-i', 'add', 'user', new_user, 'account={}'.format(DEFAULT_ACCOUNT)))
 
 
 if __name__ == '__main__':

--- a/modules/ocf_hpc/files/add_slurm_users.py
+++ b/modules/ocf_hpc/files/add_slurm_users.py
@@ -4,14 +4,14 @@ Script that adds users in the 'ocfhpc' LDAP group to SLURM as a SLURM user.
 '''
 import subprocess
 
-from ocflib.account.utils import list_group
-
+from ocflib.account import search
+from ocflib.account import utils
 
 DEFAULT_ACCOUNT = 'users'
 
 
 def main():
-    ocfhpc_ldap_user_set = set(list_group('ocfhpc'))
+    ocfhpc_ldap_user_set = set(utils.list_group('ocfhpc'))
 
     # This produces a newline-separated list of SLURM users.
     ocfhpc_slurm_user_list = subprocess.run(
@@ -27,6 +27,11 @@ def main():
         return
 
     for new_user in users_to_be_added:
+
+        if not search.user_exists(new_user):
+            print('User {} in the HPC LDAP group does not exist.'.format(new_user))
+            continue
+
         # Add a new user to SLURM and commit changes immediately.
         subprocess.run(['sacctmgr', '-i', 'add', 'user', new_user, 'account={}'.format(DEFAULT_ACCOUNT)])
 

--- a/modules/ocf_hpc/files/add_slurm_users.py
+++ b/modules/ocf_hpc/files/add_slurm_users.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+'''
+Script that adds users in the 'ocfhpc' LDAP group to SLURM as a SLURM user.
+'''
+import subprocess
+
+from ocflib.account.utils import list_group
+
+
+DEFAULT_ACCOUNT = 'users'
+
+
+def main():
+    ocfhpc_ldap_user_set = set(list_group('ocfhpc'))
+
+    # This produces a newline-separated list of SLURM users.
+    ocfhpc_slurm_user_list = subprocess.run(
+        ['sacctmgr', '-noP', 'list', 'users', 'format=User'],
+        stdout=subprocess.PIPE,
+        check=True
+    ).stdout.decode().split('\n')[:-1]
+    ocfhpc_slurm_user_set = set(ocfhpc_slurm_user_list)
+
+    users_to_be_added = ocfhpc_ldap_user_set.difference(ocfhpc_slurm_user_set)
+
+    if not users_to_be_added:
+        return
+
+    for new_user in users_to_be_added:
+        # Add a new user to SLURM and commit changes immediately.
+        subprocess.run(['sacctmgr', '-i', 'add', 'user', new_user, 'account={}'.format(DEFAULT_ACCOUNT)])
+
+
+if __name__ == '__main__':
+    main()

--- a/modules/ocf_hpc/manifests/controller.pp
+++ b/modules/ocf_hpc/manifests/controller.pp
@@ -26,12 +26,12 @@ class ocf_hpc::controller {
   }
 
   # Set up script to autoadd LDAP group members to SLURM.
-  file { '/usr/local/bin/add_slurm_users.py':
+  file { '/usr/local/bin/add_slurm_users':
     source => 'puppet:///modules/ocf_hpc/add_slurm_users.py',
     owner  => 'slurm',
     mode   => '0755',
   } -> cron { 'add_slurm_users':
-    command => '/usr/local/bin/add_slurm_users.py',
+    command => '/usr/local/bin/add_slurm_users',
     user    => 'slurm',
     minute  => '*/15',
   }

--- a/modules/ocf_hpc/manifests/controller.pp
+++ b/modules/ocf_hpc/manifests/controller.pp
@@ -28,7 +28,7 @@ class ocf_hpc::controller {
   # Set up script to autoadd LDAP group members to SLURM.
   file { '/usr/local/bin/add_slurm_users':
     source => 'puppet:///modules/ocf_hpc/add_slurm_users',
-    owner  => 'slurm',
+    owner  => 'root',
     mode   => '0755',
   } -> cron { 'add_slurm_users':
     command => '/usr/local/bin/add_slurm_users',

--- a/modules/ocf_hpc/manifests/controller.pp
+++ b/modules/ocf_hpc/manifests/controller.pp
@@ -27,7 +27,7 @@ class ocf_hpc::controller {
 
   # Set up script to autoadd LDAP group members to SLURM.
   file { '/usr/local/bin/add_slurm_users':
-    source => 'puppet:///modules/ocf_hpc/add_slurm_users.py',
+    source => 'puppet:///modules/ocf_hpc/add_slurm_users',
     owner  => 'slurm',
     mode   => '0755',
   } -> cron { 'add_slurm_users':

--- a/modules/ocf_hpc/manifests/controller.pp
+++ b/modules/ocf_hpc/manifests/controller.pp
@@ -24,4 +24,15 @@ class ocf_hpc::controller {
       File['/etc/slurm-llnl/cgroup.conf']
     ],
   }
+
+  # Set up script to autoadd LDAP group members to SLURM.
+  file { '/usr/local/bin/add_slurm_users.py':
+    source => 'puppet:///modules/ocf_hpc/add_slurm_users.py',
+    owner  => 'slurm',
+    mode   => '0755',
+  } -> cron { 'add_slurm_users':
+    command => '/usr/local/bin/add_slurm_users.py',
+    user    => 'slurm',
+    minute  => '*/15',
+  }
 }


### PR DESCRIPTION
Compares which users are in SLURM and which are in the "ocfhpc" LDAP group; adds new users to SLURM. Since user-account combinations are unique, the script is idempotent.

Instead of using a variable in the script to set which account new users go under, would it be better to use a command-line flag?

Being tested right now on segfault; "guser" and "jvp" were successfully added on the script's last run.