### PR TITLE
[HPC] Automatically configure NVIDIA GPU generic resources in SLURM.

### DIFF
--- a/modules/ocf_hpc/facts.d/nvidia_gpu_info
+++ b/modules/ocf_hpc/facts.d/nvidia_gpu_info
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import re
+import shutil
+import subprocess
+
+
+def main():
+    if not shutil.which('nvidia-smi'):
+        return
+
+    try:
+        nvidia_smi_output = subprocess.run(['nvidia-smi', '--query-gpu=name,index', '--format=csv,noheader'],
+                                           stdout=subprocess.PIPE,
+                                           universal_newlines=True,
+                                           check=True,
+                                           ).stdout
+    except subprocess.CalledProcessError:
+        return
+
+    nvidia_gpu_list = nvidia_smi_output.split('\n')[:-1]
+
+    nvidia_gpu_info_dict = {}
+
+    for gpu_string in nvidia_gpu_list:
+        # Used for determining what the numbers of the GPU's device files in /dev
+        gpu_index = int(gpu_string.split(',')[1])
+        # Strip all except numbers and add 'nv' in front to distinguish from number of GPUs
+        # when specifying type in SLURM.
+        gpu_model_number = 'nv' + re.sub('[^0-9]', '', gpu_string.split(',')[0])
+        nvidia_gpu_info_dict[gpu_index] = gpu_model_number
+
+    print('nvidia_gpu_info={}'.format(nvidia_gpu_info_dict))
+
+
+if __name__ == '__main__':
+    main()

--- a/modules/ocf_hpc/facts.d/nvidia_gpu_info
+++ b/modules/ocf_hpc/facts.d/nvidia_gpu_info
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import json
 import re
 import shutil
 import subprocess
@@ -29,7 +30,7 @@ def main():
         gpu_model_number = 'nv' + re.sub('[^0-9]', '', gpu_string.split(',')[0])
         nvidia_gpu_info_dict[gpu_index] = gpu_model_number
 
-    print('nvidia_gpu_info={}'.format(nvidia_gpu_info_dict))
+    print('nvidia_gpu_info={}'.format(json.dumps(nvidia_gpu_info_dict)))
 
 
 if __name__ == '__main__':

--- a/modules/ocf_hpc/facts.d/nvidia_gpu_info
+++ b/modules/ocf_hpc/facts.d/nvidia_gpu_info
@@ -5,30 +5,27 @@ import shutil
 import subprocess
 
 
+def strip_non_ints(string):
+    return re.sub('[^0-9]', '', string)
+
+
 def main():
     if not shutil.which('nvidia-smi'):
+        print('NVIDIA drivers not installed; machine probably does not have NVIDIA GPUs.')
         return
 
-    try:
-        nvidia_smi_output = subprocess.run(['nvidia-smi', '--query-gpu=name,index', '--format=csv,noheader'],
-                                           stdout=subprocess.PIPE,
-                                           universal_newlines=True,
-                                           check=True,
-                                           ).stdout
-    except subprocess.CalledProcessError:
-        return
-
+    nvidia_smi_output = subprocess.check_output(('nvidia-smi', '--query-gpu=name,index', '--format=csv,noheader'),
+                                                universal_newlines=True)
     nvidia_gpu_list = nvidia_smi_output.split('\n')[:-1]
-
     nvidia_gpu_info_dict = {}
 
     for gpu_string in nvidia_gpu_list:
-        # Used for determining what the numbers of the GPU's device files in /dev
-        gpu_index = int(gpu_string.split(',')[1])
+        # gpu_index is used for determining what the numbers of the GPU's device files in /dev
+        gpu_model, gpu_index = gpu_string.split(',', 1)
         # Strip all except numbers and add 'nv' in front to distinguish from number of GPUs
         # when specifying type in SLURM.
-        gpu_model_number = 'nv' + re.sub('[^0-9]', '', gpu_string.split(',')[0])
-        nvidia_gpu_info_dict[gpu_index] = gpu_model_number
+        gpu_model_number = 'nv' + strip_non_ints(gpu_model)
+        nvidia_gpu_info_dict[int(gpu_index)] = gpu_model_number
 
     # To convert the dictionary into a Ruby hash, it's easiest to spit it out as a JSON-formatted string,
     # since all custom facts are strings by default. We convert it back into a hash in the SLURM configuration

--- a/modules/ocf_hpc/facts.d/nvidia_gpu_info
+++ b/modules/ocf_hpc/facts.d/nvidia_gpu_info
@@ -30,6 +30,9 @@ def main():
         gpu_model_number = 'nv' + re.sub('[^0-9]', '', gpu_string.split(',')[0])
         nvidia_gpu_info_dict[gpu_index] = gpu_model_number
 
+    # To convert the dictionary into a Ruby hash, it's easiest to spit it out as a JSON-formatted string,
+    # since all custom facts are strings by default. We convert it back into a hash in the SLURM configuration
+    # templates.
     print('nvidia_gpu_info={}'.format(json.dumps(nvidia_gpu_info_dict)))
 
 

--- a/modules/ocf_hpc/facts.d/nvidia_gpu_info
+++ b/modules/ocf_hpc/facts.d/nvidia_gpu_info
@@ -3,6 +3,7 @@ import json
 import re
 import shutil
 import subprocess
+import sys
 
 
 def strip_non_ints(string):
@@ -11,12 +12,11 @@ def strip_non_ints(string):
 
 def main():
     if not shutil.which('nvidia-smi'):
-        print('NVIDIA drivers not installed; machine probably does not have NVIDIA GPUs.')
+        print('NVIDIA drivers not installed; machine probably does not have NVIDIA GPUs.', file=sys.stderr)
         return
 
-    nvidia_smi_output = subprocess.check_output(('nvidia-smi', '--query-gpu=name,index', '--format=csv,noheader'),
-                                                universal_newlines=True)
-    nvidia_gpu_list = nvidia_smi_output.split('\n')[:-1]
+    nvidia_smi_output = subprocess.check_output(('nvidia-smi', '--query-gpu=name,index', '--format=csv,noheader'))
+    nvidia_gpu_list = nvidia_smi_output.decode('utf-8').split('\n')[:-1]
     nvidia_gpu_info_dict = {}
 
     for gpu_string in nvidia_gpu_list:

--- a/modules/ocf_hpc/templates/gres.conf.erb
+++ b/modules/ocf_hpc/templates/gres.conf.erb
@@ -1,6 +1,5 @@
 # These are the gres devices available on this node.
-# Need to edit to dynamically write the gpu type
-# and correct number of devices on nodes that we
-# decide to have generic resources.
-Name=gpu File=/dev/nvidia0
-Name=gpu File=/dev/nvidia1
+
+<% JSON.parse(@nvidia_gpu_info).each do |index, model| -%>
+Name=gpu File=/dev/nvidia<%= index %> Type=<%= model %>
+<% end -%>

--- a/modules/ocf_hpc/templates/gres.conf.erb
+++ b/modules/ocf_hpc/templates/gres.conf.erb
@@ -1,5 +1,6 @@
 # These are the gres devices available on this node.
 
+# Since the nvidia_gpu_info fact comes in as a JSON-formatted string, we have to convert it back into a hash.
 <% JSON.parse(@nvidia_gpu_info).each do |index, model| -%>
 Name=gpu File=/dev/nvidia<%= index %> Type=<%= model %>
 <% end -%>

--- a/modules/ocf_hpc/templates/gres.conf.erb
+++ b/modules/ocf_hpc/templates/gres.conf.erb
@@ -1,6 +1,6 @@
 # These are the gres devices available on this node.
 
-# Since the nvidia_gpu_info fact comes in as a JSON-formatted string, we have to convert it back into a hash.
+<%# Since the nvidia_gpu_info fact comes in as a JSON-formatted string, we have to convert it back into a hash. %>
 <% JSON.parse(@nvidia_gpu_info).each do |index, model| -%>
 Name=gpu File=/dev/nvidia<%= index %> Type=<%= model %>
 <% end -%>

--- a/modules/ocf_hpc/templates/nodes-partitions.erb
+++ b/modules/ocf_hpc/templates/nodes-partitions.erb
@@ -1,6 +1,6 @@
 # Currently there is a 'Gres=...' entry that should be changed to dynamically handle
 # gres resources on selected nodes
 <% @slurm_nodes_facts.each do |facts| -%>
-NodeName=<%= facts["hostname"] %> NodeAddr=<%= facts["ipaddress"] %> CPUs=<%= facts["processorcount"] %> Sockets=<%= facts["physicalprocessorcount"] %> CoresPerSocket=<%= facts["cores_per_socket"] %> ThreadsPerCore=<%= facts["threads_per_core"] %> RealMemory=<%= facts["memorysize_mb"].floor %> Gres=gpu:2 State=UNKNOWN
+NodeName=<%= facts["hostname"] %> NodeAddr=<%= facts["ipaddress"] %> CPUs=<%= facts["processorcount"] %> Sockets=<%= facts["physicalprocessorcount"] %> CoresPerSocket=<%= facts["cores_per_socket"] %> ThreadsPerCore=<%= facts["threads_per_core"] %> RealMemory=<%= facts["memorysize_mb"].floor %> Gres=<% JSON.parse(facts["nvidia_gpu_info"]).each do |_, model| -%>gpu:<%= model %>:1,<% end -%> State=UNKNOWN
 <% end -%>
 PartitionName=ocf-hpc Nodes=ALL Default=YES MaxTime=48:00:00 State=UP

--- a/modules/ocf_hpc/templates/nodes-partitions.erb
+++ b/modules/ocf_hpc/templates/nodes-partitions.erb
@@ -1,5 +1,5 @@
-# Currently there is a 'Gres=...' entry that should be changed to dynamically handle
-# gres resources on selected nodes
+# We do a nested iteration over the nvidia_gpu_info fact to configure GRES.
+# In addition, nvidia_gpu_info comes in as a JSON-formatted string, so we have to convert back into a hash first.
 <% @slurm_nodes_facts.each do |facts| -%>
 NodeName=<%= facts["hostname"] %> NodeAddr=<%= facts["ipaddress"] %> CPUs=<%= facts["processorcount"] %> Sockets=<%= facts["physicalprocessorcount"] %> CoresPerSocket=<%= facts["cores_per_socket"] %> ThreadsPerCore=<%= facts["threads_per_core"] %> RealMemory=<%= facts["memorysize_mb"].floor %> Gres=<% JSON.parse(facts["nvidia_gpu_info"]).each do |_, model| -%>gpu:<%= model %>:1,<% end -%> State=UNKNOWN
 <% end -%>


### PR DESCRIPTION
Produces output in slurm.conf:
```
NodeName=corruption NodeAddr=169.229.226.18 CPUs=40 Sockets=2 CoresPerSocket=10 ThreadsPerCore=2 RealMemory=257855 Gres=gpu:nv1080:1,gpu:nv1080:1,gpu:nv1080:1,gpu:nv1080:1, State=UNKNOWN
```

and in gres.conf:
```
# These are the gres devices available on this node.

Name=gpu File=/dev/nvidia0 Type=nv1080
Name=gpu File=/dev/nvidia1 Type=nv1080
Name=gpu File=/dev/nvidia2 Type=nv1080
Name=gpu File=/dev/nvidia3 Type=nv1080
```

Requesting multiple GPUs in SLURM using `--gres=gpu:4` or `--gres=gpu:nv1080:4` still works; thankfully SLURM is intelligent enough to group GPUs of the same type.

I also assume that the `index` field supplied by `nvidia-smi` corresponds to the number of the GPU's devfile; the docs don't say so hopefully that's so.