### PR TITLE
purge remmina from desktops

### DIFF
--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -15,8 +15,8 @@ class ocf_desktop::packages {
     ['arandr', 'atom', 'claws-mail', 'eog', 'evince-gtk', 'filezilla',
       'florence', 'freeplane', 'geany', 'gimp', 'gnome-calculator', 'gparted',
       'hexchat', 'imagej', 'inkscape', 'lyx', 'mssh', 'mumble', 'numlockx',
-      'remmina', 'simple-scan', 'ssh-askpass-gnome', 'texmaker', 'texstudio',
-      'vlc', 'xarchiver', 'xcape', 'xterm', 'zenmap']:;
+      'simple-scan', 'ssh-askpass-gnome', 'texmaker', 'texstudio', 'vlc',
+      'xarchiver', 'xcape', 'xterm', 'zenmap']:;
     # desktop
     ['desktop-base', 'anacron', 'accountsservice', 'desktop-file-utils',
       'gnome-icon-theme', 'redshift', 'xfce4-whiskermenu-plugin']:;
@@ -55,6 +55,9 @@ class ocf_desktop::packages {
   package {
     # causes the fcitx menu to vanish
     'ayatana-indicator-application':
+      ensure => purged;
+    # dependencies conflict with backports
+    'remmina':
       ensure => purged;
     # causes gid conflicts
     'sane-utils':


### PR DESCRIPTION
this package is being pulled from stretch-backports and requires a
version of libssh-4 from backports. creates a broken package and
new systems cant be provisioned.