### PR TITLE
Add python3.7(-dev/-venv) to packages

### DIFF
--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -142,7 +142,7 @@ class ocf::packages {
       backport_on => jessie,
   }
 
-  if $::lsbdistcodename == 'stretch' or $::lsbdistcodename == 'buster' {
+  if $::lsbdistcodename != 'jessie' {
     package {
       [
         'python3.7',

--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -142,6 +142,16 @@ class ocf::packages {
       backport_on => jessie,
   }
 
+  if $::lsbdistcodename == 'stretch' or $::lsbdistcodename == 'buster' {
+    package {
+      [
+        'python3.7',
+        'python3.7-dev',
+        'python3.7-venv',
+      ]:;
+    }
+  }
+
   if $::lsbdistcodename == 'jessie' {
     package {
       # in jessie, install python-pip-whl to avoid problems where a system-wide


### PR DESCRIPTION
This will allow experimenting with moving ocflib and other OCF projects to newer versions of Python which are not only are faster, but also make static typing nicer and easier.