### PR TITLE
zshrc: revert to default keybindings instead of vim keybindings

### DIFF
--- a/modules/ocf/files/shell/zshrc
+++ b/modules/ocf/files/shell/zshrc
@@ -50,7 +50,6 @@ autoload run-help
 
 setopt appendhistory extendedglob notify
 unsetopt autocd nomatch
-bindkey -v
 autoload -U colors && colors
 
 autoload -U compinit promptinit


### PR DESCRIPTION
changing this in the global zshrc is likely confusing for users
who expect the default readline keybindings.