### PR TITLE
add ocfstaff@lists.berkeley.edu to staff@ alias

### DIFF
--- a/modules/ocf_mail/files/site_ocf/update-aliases
+++ b/modules/ocf_mail/files/site_ocf/update-aliases
@@ -5,7 +5,7 @@ set -o pipefail
 
 staff=$(getent group ocfstaff | cut -d':' -f4)
 
-echo "staff-current: ${staff}" > /etc/aliases-group
+echo "staff-current: ocfstaff@lists.berkeley.edu,${staff}" > /etc/aliases-group
 /usr/sbin/postalias hash:/etc/aliases-group
 
 # update aliases-local

--- a/modules/ocf_mail/files/site_ocf/update-aliases
+++ b/modules/ocf_mail/files/site_ocf/update-aliases
@@ -5,7 +5,7 @@ set -o pipefail
 
 staff=$(getent group ocfstaff | cut -d':' -f4)
 
-echo "staff-current: ocfstaff@lists.berkeley.edu,${staff}" > /etc/aliases-group
+echo "staff-current: ocf@lists.berkeley.edu,${staff}" > /etc/aliases-group
 /usr/sbin/postalias hash:/etc/aliases-group
 
 # update aliases-local


### PR DESCRIPTION
I made ocfstaff@lists.berkeley.edu so we can have a group for people
who are interested in being staff, or receiving staff updates, without
necessarily needing to give those people additional privileges, especially
since only a tiny fraction of the people on cn=ocfstaff use their privs
at any time. Using this group, we can migrate all 'staff' to the mailing list
where they can continue to get updates, and should they want to get privs,
they can sign up for staff hours and get added to the ocfstaff LDAP group.

The group has the additional benefit of archiving all messages sent to staff
which could be useful for documentation purposes down the road.