### PR TITLE
make ocfbroker a system group

### DIFF
--- a/modules/ocf_desktop/manifests/printnotify.pp
+++ b/modules/ocf_desktop/manifests/printnotify.pp
@@ -2,6 +2,7 @@ class ocf_desktop::printnotify {
   user { 'ocfbroker':
     ensure => present,
     shell  => '/bin/false',
+    system =>  true,
   }
 
   # enable regular users to run notification script as ocfbroker


### PR DESCRIPTION
clashed with the `ocf` gid on some desktops... thus overriding it and every user became part of `ocfbroker`. since `ocfbroker` has no home dir, i think pam didnt bother mounting the remote from tsunami. pretty hilarious.