### PR TITLE
Postgres @ OCF

### DIFF
--- a/hieradata/nodes/lethe.yaml
+++ b/hieradata/nodes/lethe.yaml
@@ -1,0 +1,2 @@
+classes:
+  - ocf_postgres

--- a/hieradata/nodes/lethe.yaml
+++ b/hieradata/nodes/lethe.yaml
@@ -1,4 +1,2 @@
 classes:
   - ocf_postgres
-
-ocf::ssl::default::owner: root

--- a/hieradata/nodes/lethe.yaml
+++ b/hieradata/nodes/lethe.yaml
@@ -1,2 +1,4 @@
 classes:
   - ocf_postgres
+
+ocf::ssl::default::owner: root

--- a/modules/ocf/manifests/ssl/bundle.pp
+++ b/modules/ocf/manifests/ssl/bundle.pp
@@ -1,8 +1,8 @@
 define ocf::ssl::bundle(
   Boolean $use_lets_encrypt = true,
   Array[String] $domains = [$title],
-  String $owner = ocfletsencrypt,
-  String $group = ssl-cert,
+  String $owner = 'ocfletsencrypt',
+  String $group = 'ssl-cert',
 ) {
   require ocf::ssl::setup
 
@@ -16,7 +16,6 @@ define ocf::ssl::bundle(
     $intermediate_source = 'puppet:///modules/ocf/ssl/lets-encrypt.crt'
     $cert_path = "/var/lib/lets-encrypt/certs/${title}/cert.pem"
     $key_path = "/var/lib/lets-encrypt/certs/${title}/privkey.pem"
-    $fullchain_path = "/var/lib/lets-encrypt/certs/${title}/fullchain.pem"
     $cert_source = "file://${cert_path}"
     $key_source = "file://${key_path}"
 
@@ -40,12 +39,6 @@ define ocf::ssl::bundle(
         ensure => symlink,
         links  => manage,
         target => $cert_path,
-        mode   => '0644';
-
-      "/etc/ssl/private/${title}.fullchain":
-        ensure => symlink,
-        links  => manage,
-        target => $fullchain_path,
         mode   => '0644';
 
       "/etc/ssl/private/${title}.intermediate":

--- a/modules/ocf/manifests/ssl/bundle.pp
+++ b/modules/ocf/manifests/ssl/bundle.pp
@@ -16,6 +16,7 @@ define ocf::ssl::bundle(
     $intermediate_source = 'puppet:///modules/ocf/ssl/lets-encrypt.crt'
     $cert_path = "/var/lib/lets-encrypt/certs/${title}/cert.pem"
     $key_path = "/var/lib/lets-encrypt/certs/${title}/privkey.pem"
+    $fullchain_path = "/var/lib/lets-encrypt/certs/${title}/fullchain.pem"
     $cert_source = "file://${cert_path}"
     $key_source = "file://${key_path}"
 
@@ -39,6 +40,12 @@ define ocf::ssl::bundle(
         ensure => symlink,
         links  => manage,
         target => $cert_path,
+        mode   => '0644';
+
+      "/etc/ssl/private/${title}.fullchain":
+        ensure => symlink,
+        links  => manage,
+        target => $fullchain_path,
         mode   => '0644';
 
       "/etc/ssl/private/${title}.intermediate":

--- a/modules/ocf/manifests/ssl/bundle.pp
+++ b/modules/ocf/manifests/ssl/bundle.pp
@@ -1,12 +1,16 @@
 define ocf::ssl::bundle(
   Boolean $use_lets_encrypt = true,
   Array[String] $domains = [$title],
+  String $owner = ocfletsencrypt,
+  String $group = ssl-cert,
 ) {
   require ocf::ssl::setup
 
   if $use_lets_encrypt {
     ocf::ssl::lets_encrypt::dns { $title:
       domains => $domains,
+      owner   => $owner,
+      group   => $group,
     }
 
     $intermediate_source = 'puppet:///modules/ocf/ssl/lets-encrypt.crt'
@@ -41,6 +45,7 @@ define ocf::ssl::bundle(
         source => $intermediate_source,
         mode   => '0644';
     }
+
   } else {
     # TODO: Remove this branch once we are confident enough that using Let's
     # Encrypt certs is working well and is sustainable

--- a/modules/ocf/manifests/ssl/default.pp
+++ b/modules/ocf/manifests/ssl/default.pp
@@ -2,9 +2,9 @@
 # /etc/ssl/private/$cert_name.{key,crt,bundle,intermediate}
 
 class ocf::ssl::default(
-  String $owner = ocfletsencrypt,
-  String $group = ssl-cert,
-){
+  String $owner = 'ocfletsencrypt',
+  String $group = 'ssl-cert',
+) {
   # Attempt to collect all domains for a host to include in a SSL certificate.
   # The '@' record needs to be handled in a special case, since
   # "@.ocf.berkeley.edu" and "@.ocf.io" are both not valid domains

--- a/modules/ocf/manifests/ssl/default.pp
+++ b/modules/ocf/manifests/ssl/default.pp
@@ -1,6 +1,10 @@
 # Provides the key, certificate, and Let's Encrypt CA certificate bundle at
 # /etc/ssl/private/$cert_name.{key,crt,bundle,intermediate}
-class ocf::ssl::default {
+
+class ocf::ssl::default(
+  String $owner = ocfletsencrypt,
+  String $group = ssl-cert,
+){
   # Attempt to collect all domains for a host to include in a SSL certificate.
   # The '@' record needs to be handled in a special case, since
   # "@.ocf.berkeley.edu" and "@.ocf.io" are both not valid domains
@@ -12,5 +16,7 @@ class ocf::ssl::default {
 
   ocf::ssl::bundle { $::fqdn:
     domains => ocf::get_host_fqdns() + ocf::get_host_fqdns('ocf.io') + $extra_domains,
+    owner   => $owner,
+    group   => $group,
   }
 }

--- a/modules/ocf/manifests/ssl/lets_encrypt/dns.pp
+++ b/modules/ocf/manifests/ssl/lets_encrypt/dns.pp
@@ -1,7 +1,7 @@
 define ocf::ssl::lets_encrypt::dns(
   Array[String] $domains = [$::fqdn],
-  String $owner = ocfletsencrypt,
-  String $group = ssl-cert,
+  String $owner = 'ocfletsencrypt',
+  String $group = 'ssl-cert',
 ) {
   require ocf::ssl::lets_encrypt::dns_common
 

--- a/modules/ocf/manifests/ssl/lets_encrypt/dns.pp
+++ b/modules/ocf/manifests/ssl/lets_encrypt/dns.pp
@@ -1,5 +1,7 @@
 define ocf::ssl::lets_encrypt::dns(
   Array[String] $domains = [$::fqdn],
+  String $owner = ocfletsencrypt,
+  String $group = ssl-cert,
 ) {
   require ocf::ssl::lets_encrypt::dns_common
 
@@ -23,7 +25,7 @@ define ocf::ssl::lets_encrypt::dns(
     # This exec can be notified to get it to run dehydrated again, even if the
     # cert will not expire soon.
     command     => '/usr/bin/dehydrated --cron --privkey /etc/ssl/lets-encrypt/le-account.key',
-    user        => ocfletsencrypt,
+    user        => $owner,
     refreshonly => true,
     require     => Package['dehydrated-hook-ddns-tsig'],
     subscribe   => [
@@ -40,8 +42,8 @@ define ocf::ssl::lets_encrypt::dns(
     # https://github.com/lukas2511/dehydrated/issues/544
     "/var/lib/lets-encrypt/certs/${title}":
       ensure  => directory,
-      owner   => ocfletsencrypt,
-      group   => ssl-cert,
+      owner   => $owner,
+      group   => $group,
       mode    => '0640',
       recurse => true,
       require => [Package['ssl-cert'], File['/var/lib/lets-encrypt/certs']],

--- a/modules/ocf/manifests/ssl/setup.pp
+++ b/modules/ocf/manifests/ssl/setup.pp
@@ -7,7 +7,8 @@ class ocf::ssl::setup {
   package { 'ssl-cert':; }
 
   user { 'ocfletsencrypt':
-    groups => ['ssl-cert', 'sys'],
+    groups     => ['ssl-cert', 'sys'],
+    forcelocal => false,
   }
 
   file {

--- a/modules/ocf/manifests/ssl/setup.pp
+++ b/modules/ocf/manifests/ssl/setup.pp
@@ -2,8 +2,13 @@
 # To build and deploy private keys, use the `ocf::ssl::bundle` type.
 # (Or include `ocf::ssl::default` if you just want the default one that includes
 # the FQDN and all aliases of a server.)
+
 class ocf::ssl::setup {
   package { 'ssl-cert':; }
+
+  user { 'ocfletsencrypt':
+    groups => ['ssl-cert', 'sys'],
+  }
 
   file {
     default:

--- a/modules/ocf_backups/files/backup-pgsql
+++ b/modules/ocf_backups/files/backup-pgsql
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# Dumps the entire PostgreSQL instance to one .sql file. 
+# Dumps the entire PostgreSQL instance to one .sql file.
 # Requires that a valid ~/.pgpass file be available on the PostgreSQL host
 ssh -K ocfbackups@postgres 'pg_dumpall -U postgres -h localhost | pigz' > pgsql-all-$(date +%F).sql.gz
-
-

--- a/modules/ocf_backups/files/backup-pgsql
+++ b/modules/ocf_backups/files/backup-pgsql
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+# Dumps the entire PostgreSQL instance to one .sql file. 
+# Requires that a valid ~/.pgpass file be available on the PostgreSQL host
+ssh -K ocfbackups@postgres 'pg_dumpall -U postgres -h localhost | pigz' > pgsql-all-$(date +%F).sql.gz
+
+

--- a/modules/ocf_backups/files/rsnapshot.conf
+++ b/modules/ocf_backups/files/rsnapshot.conf
@@ -49,6 +49,7 @@ backup	ocfbackups@filehost:/opt/homes/		nfs/
 # scripts
 backup_script	/opt/share/backups/backup-mysql	mysql/
 backup_script	/opt/share/backups/backup-git	git/
+backup_script	/opt/share/backups/backup-pgsql	pgsql/
 
 # remote servers
 backup	ocfbackups@kerberos:/var/lib/heimdal-kdc/	servers/kerberos/

--- a/modules/ocf_backups/manifests/init.pp
+++ b/modules/ocf_backups/manifests/init.pp
@@ -1,6 +1,7 @@
 class ocf_backups {
   include ocf_backups::git
   include ocf_backups::mysql
+  include ocf_backups::pgsql
   include ocf_backups::offsite
   include ocf_backups::rsnapshot
 

--- a/modules/ocf_backups/manifests/pgsql.pp
+++ b/modules/ocf_backups/manifests/pgsql.pp
@@ -2,11 +2,6 @@ class ocf_backups::pgsql {
   include ocf::packages::postgres
 
   file {
-    '~/.pgpass':
-      source    => 'puppet:///private/backups/.pgpass',
-      mode      => '0600',
-      show_diff => false;
-
     '/opt/share/backups/backup-pgsql':
       source => 'puppet:///modules/ocf_backups/backup-pgsql',
       mode   => '0755';

--- a/modules/ocf_backups/manifests/pgsql.pp
+++ b/modules/ocf_backups/manifests/pgsql.pp
@@ -1,6 +1,4 @@
 class ocf_backups::pgsql {
-  include ocf::packages::postgres
-
   file {
     '/opt/share/backups/backup-pgsql':
       source => 'puppet:///modules/ocf_backups/backup-pgsql',

--- a/modules/ocf_backups/manifests/pgsql.pp
+++ b/modules/ocf_backups/manifests/pgsql.pp
@@ -1,0 +1,14 @@
+class ocf_backups::pgsql {
+  include ocf::packages::postgres
+
+  file {
+    '~/.pgpass':
+      source    => 'puppet:///private/backups/.pgpass',
+      mode      => '0600',
+      show_diff => false;
+
+    '/opt/share/backups/backup-pgsql':
+      source => 'puppet:///modules/ocf_backups/backup-pgsql',
+      mode   => '0755';
+  }
+}

--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -1,14 +1,24 @@
 class ocf_postgres {
+
+  include ocf::ssl::default
+
   class { 'postgresql::server':
-    postgres_password => hiera('postgres::root'),
-    #                      type    db       usr srcaddr   auth
+    postgres_password => hiera('postgres::rootpw'),
+    # https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html
     ipv4acls          => ['hostssl sameuser all 0.0.0.0/0 md5'],
-    ipv6acls          => ['hostssl sameuser all ::/0 md5'];
+    ipv6acls          => ['hostssl sameuser all ::/0 md5'],
   }
 
-  # defaults to localhost
-  postgresql::server::config_entry { 'listen_addresses':
-    value => '*';
+  postgresql::server::config_entry {
+    # defaults to localhost
+    'listen_addresses':
+      value => '*';
+    'ssl':
+      value => 'on';
+    'ssl_cert_file':
+      value => "/etc/ssl/private/${::fqdn}.crt";
+    'ssl_key_file':
+      value => "/etc/ssl/private/${::fqdn}.key";
   }
 
   ocf::firewall::firewall46 {
@@ -20,4 +30,6 @@ class ocf_postgres {
         action => 'accept',
       };
   }
+
+  Class['ocf::ssl::default'] ~> Class['Postgresql::Server']
 }

--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -9,6 +9,15 @@ class ocf_postgres {
     ipv6acls          => ['hostssl sameuser all ::/0 md5'],
   }
 
+  file {
+    # copies proper .pgpass file for ocfbackups to authenticate on backup
+    '/opt/share/.pgpass':
+      source          => 'puppet:///private/backups/.pgpass',
+      mode            => '0600',
+      owner           => 'ocfbackups', 	
+      show_diff       => false;
+  }
+
   postgresql::server::config_entry {
     # defaults to localhost
     'listen_addresses':

--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -12,7 +12,7 @@ class ocf_postgres {
   file {
     # copies proper .pgpass file for ocfbackups to authenticate on backup
     '/opt/share/.pgpass':
-      source    => 'puppet:///private/backups/.pgpass',
+      source    => 'puppet:///private/backups/pgpass',
       mode      => '0600',
       owner     => 'ocfbackups',
       show_diff => false;

--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -31,5 +31,5 @@ class ocf_postgres {
       };
   }
 
-  Class['ocf::ssl::default'] ~> Class['Postgresql::Server']
+  Class['Ocf::Ssl::Default'] ~> Class['Postgresql::Server']
 }

--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -12,10 +12,10 @@ class ocf_postgres {
   file {
     # copies proper .pgpass file for ocfbackups to authenticate on backup
     '/opt/share/.pgpass':
-      source          => 'puppet:///private/backups/.pgpass',
-      mode            => '0600',
-      owner           => 'ocfbackups', 	
-      show_diff       => false;
+      source    => 'puppet:///private/backups/.pgpass',
+      mode      => '0600',
+      owner     => 'ocfbackups',
+      show_diff => false;
   }
 
   postgresql::server::config_entry {

--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -1,9 +1,12 @@
 class ocf_postgres {
   class { 'postgresql::server':
-    postgres_password       => hiera('postgres::root'),
-    ip_mask_allow_all_users => '0.0.0.0/0';
+    postgres_password => hiera('postgres::root'),
+    #                      type    db       usr srcaddr   auth
+    ipv4acls          => ['hostssl sameuser all 0.0.0.0/0 md5'],
+    ipv6acls          => ['hostssl sameuser all ::/0 md5'];
   }
 
+  # defaults to localhost
   postgresql::server::config_entry { 'listen_addresses':
     value => '*';
   }

--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -1,21 +1,13 @@
 class ocf_postgres {
-
-  include ocf::ssl::default
+  class { 'ocf::ssl::default':
+    owner => 'root',
+  }
 
   class { 'postgresql::server':
     postgres_password => hiera('postgres::rootpw'),
     # https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html
     ipv4acls          => ['hostssl sameuser all 0.0.0.0/0 md5'],
     ipv6acls          => ['hostssl sameuser all ::/0 md5'],
-  }
-
-  file {
-    # copies proper .pgpass file for ocfbackups to authenticate on backup
-    '/opt/share/.pgpass':
-      source    => 'puppet:///private/backups/pgpass',
-      mode      => '0600',
-      owner     => 'ocfbackups',
-      show_diff => false;
   }
 
   postgresql::server::config_entry {
@@ -25,7 +17,7 @@ class ocf_postgres {
     'ssl':
       value => 'on';
     'ssl_cert_file':
-      value => "/etc/ssl/private/${::fqdn}.fullchain";
+      value => "/etc/ssl/private/${::fqdn}.bundle";
     'ssl_key_file':
       value => "/etc/ssl/private/${::fqdn}.key";
   }
@@ -41,4 +33,14 @@ class ocf_postgres {
   }
 
   Class['Ocf::Ssl::Default'] ~> Class['Postgresql::Server']
+
+  file {
+    # copies proper .pgpass file for ocfbackups to authenticate on backup
+    '/opt/share/.pgpass':
+      source    => 'puppet:///private/pgpass',
+      mode      => '0600',
+      owner     => 'ocfbackups',
+      show_diff => false;
+  }
+
 }

--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -16,7 +16,7 @@ class ocf_postgres {
     'ssl':
       value => 'on';
     'ssl_cert_file':
-      value => "/etc/ssl/private/${::fqdn}.crt";
+      value => "/etc/ssl/private/${::fqdn}.fullchain";
     'ssl_key_file':
       value => "/etc/ssl/private/${::fqdn}.key";
   }

--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -1,0 +1,20 @@
+class ocf_postgres {
+  class { 'postgresql::server':
+    postgres_password       => hiera('postgres::root'),
+    ip_mask_allow_all_users => '0.0.0.0/0';
+  }
+
+  postgresql::server::config_entry { 'listen_addresses':
+    value => '*';
+  }
+
+  ocf::firewall::firewall46 {
+    '101 allow postgresql':
+      opts => {
+        chain  => 'PUPPET-INPUT',
+        proto  => ['tcp'],
+        dport  => 5432,
+        action => 'accept',
+      };
+  }
+}


### PR DESCRIPTION
This introduces the preliminary Puppet aspect of a Postgres service @ OCF. The provisional host is hozer-72, but I'm going to create a new machine at .66 to serve as the Postgres host. 

I'm planning on doing role and database creation by means of a Celery task like how account creation currently works, rather than by seeding the root password to tsunami like `makemysql` does (and hopefully migrate the mysql method to this create-like service as well). `makepgsql` will then be a wrapper around calling those Celery tasks. Thoughts on this approach? In the meantime, roles and databases can be created manually (for discourse, puppetdb, mastodon, etc. for example).

Also need to add this to the backups, among other things.