### PR TITLE
Conf builder

### DIFF
--- a/modules/ocf/functions/lookup_wrap.pp
+++ b/modules/ocf/functions/lookup_wrap.pp
@@ -1,8 +1,6 @@
 function ocf::lookup_wrap($item) {
-  if String($item) =~ /^[a-zA-Z_:]*$/ {
-    lookup(String($item))
-  }
-  else {
-    $item
+  $item ? {
+    String  => lookup($item),
+    default => $item,
   }
 }

--- a/modules/ocf/functions/lookup_wrap.pp
+++ b/modules/ocf/functions/lookup_wrap.pp
@@ -1,0 +1,8 @@
+function ocf::lookup_wrap($item) {
+  if $item =~ /^[a-zA-Z_:]*$/ {
+    lookup($item)
+  }
+  else {
+    $item
+  }
+}

--- a/modules/ocf/functions/lookup_wrap.pp
+++ b/modules/ocf/functions/lookup_wrap.pp
@@ -1,6 +1,6 @@
 function ocf::lookup_wrap($item) {
-  if $item =~ /^[a-zA-Z_:]*$/ {
-    lookup($item)
+  if String($item) =~ /^[a-zA-Z_:]*$/ {
+    lookup(String($item))
   }
   else {
     $item

--- a/modules/ocf/manifests/conf.pp
+++ b/modules/ocf/manifests/conf.pp
@@ -3,16 +3,19 @@ define ocf::conf(
   $owner = 'root',
   $group = 'root',
   $mode = '0400',
+  $show_diff = false,
+  $force = true,
 ) {
 
   $builder = $layout.tree_each.map |$h| { [ $h[0], ocf::lookup_wrap($h[1]) ] }
   $config = Hash($builder, 'hash_tree')
 
   file { $title:
-    ensure  => file,
-    content => template('ocf/conf.erb'),
-    mode    => $mode,
-    owner   => $owner,
-    group   => $group,
+    ensure    => file,
+    content   => template('ocf/conf.erb'),
+    mode      => $mode,
+    owner     => $owner,
+    group     => $group,
+    show_diff => $show_diff,
   }
 }

--- a/modules/ocf/manifests/conf.pp
+++ b/modules/ocf/manifests/conf.pp
@@ -1,0 +1,18 @@
+define ocf::conf(
+  $layout = {},
+  $owner = 'root',
+  $group = 'root',
+  $mode = '0400',
+) {
+
+  $builder = $layout.tree_each.map |$h| { [ $h[0], ocf::lookup_wrap($h[1]) ] }
+  $config = Hash($builder, 'hash_tree')
+
+  file { $title:
+    ensure  => file,
+    content => template('ocf/conf.erb'),
+    mode    => $mode,
+    owner   => $owner,
+    group   => $group,
+  }
+}

--- a/modules/ocf/manifests/configbuilder.pp
+++ b/modules/ocf/manifests/configbuilder.pp
@@ -17,5 +17,6 @@ define ocf::configbuilder(
     owner     => $owner,
     group     => $group,
     show_diff => $show_diff,
+    force     => $force,
   }
 }

--- a/modules/ocf/manifests/configbuilder.pp
+++ b/modules/ocf/manifests/configbuilder.pp
@@ -1,4 +1,4 @@
-define ocf::conf(
+define ocf::configbuilder(
   $layout = {},
   $owner = 'root',
   $group = 'root',

--- a/modules/ocf/templates/conf.erb
+++ b/modules/ocf/templates/conf.erb
@@ -3,4 +3,5 @@
 <% passwords.each do |title, value| -%>
 <%= title %>=<%= value %>
 <% end -%>
+
 <% end -%>

--- a/modules/ocf/templates/conf.erb
+++ b/modules/ocf/templates/conf.erb
@@ -1,0 +1,6 @@
+<% @config.each do |section, passwords| -%>
+[<%= section %>]
+<% passwords.each do |title, value| -%>
+<%= title %>=<%= value %>
+<% end -%>
+<% end -%>

--- a/modules/ocf_mesos/manifests/secrets.pp
+++ b/modules/ocf_mesos/manifests/secrets.pp
@@ -33,7 +33,7 @@ class ocf_mesos::secrets {
       show_diff => false;
   }
 
-  ocf::conf { '/opt/share/docker/secrets/slackbridge/slackbridge.conf':
+  ocf::confbuilder { '/opt/share/docker/secrets/slackbridge/slackbridge.conf':
     mode   => '0644',
     layout => {
       'irc'   => {

--- a/modules/ocf_mesos/manifests/secrets.pp
+++ b/modules/ocf_mesos/manifests/secrets.pp
@@ -33,7 +33,7 @@ class ocf_mesos::secrets {
       show_diff => false;
   }
 
-  ocf::confbuilder { '/opt/share/docker/secrets/slackbridge/slackbridge.conf':
+  ocf::configbuilder { '/opt/share/docker/secrets/slackbridge/slackbridge.conf':
     mode   => '0644',
     layout => {
       'irc'   => {

--- a/modules/ocf_mesos/manifests/secrets.pp
+++ b/modules/ocf_mesos/manifests/secrets.pp
@@ -33,6 +33,20 @@ class ocf_mesos::secrets {
       show_diff => false;
   }
 
+  ocf::conf { '/opt/share/docker/secrets/slackbridge/slackbridge.conf':
+    mode   => '0644',
+    layout => {
+      'irc'   => {
+        'nickserv_pass' => 'ocf::slackbridge::nickserv_pass',
+      },
+      'slack' => {
+        'token' => 'ocf::slackbridge::token',
+        'user'  => 'ocf::slackbridge::user',
+      },
+    },
+  }
+
+
   ocf_mesos::slave::attribute { 'secrets':
     value => 'true',  # lint:ignore:quoted_booleans
   }


### PR DESCRIPTION
So basically we have passwords duplicated all over our puppet private share. This is not great when one needs to rotate passwords or add a new host/password. Instead of that, we should have each password once in `private.yaml`, pull that in, and create config files from a template.

This is just one of the possible implementations. The nice thing about this is it creates a config file on the fly and resolves all the passwords in hiera. The downside is that it's constrained only to Windows INI format (good for most our python things) and could become a bit verbose. A positive is that it the `layout` hash is self-describing and will give staffers perusing our code more insight into the infrastructure.

For those not on root staff, I've provided and example using the `slackbridge.conf` that gets put into the slackbridge docker container. It will look like this:

```
[irc]
nickserv_pass=password

[slack]
token=password
user=password
```

If we want to proceed with this, I'll move the other docker secrets here along with the create and ircbot configs. One thing I should mention is that I think we should use this sparingly—only when there is serious password duplication going on.

EDIT: No mesos agents are on my environment, but I've tested this and it does work.