### PR TITLE
fix `apt update` error in puppetlabs repo

### DIFF
--- a/modules/ocf/manifests/apt.pp
+++ b/modules/ocf/manifests/apt.pp
@@ -108,9 +108,6 @@ class ocf::apt($stage = 'first') {
         location => 'http://mirrors/puppetlabs/apt/',
         release  => $::lsbdistcodename,
         repos    => $puppetlabs_repo,
-        include  => {
-          src => true
-        };
     }
 
     # Add the puppetlabs apt repo key


### PR DESCRIPTION
```bash
abizer@nyx ~
❯ sudo apt update
...
E: Failed to fetch http://mirrors/puppetlabs/apt/dists/stretch/InRelease  Unable to find expected entry 'puppet/source/Sources' in Release file (Wrong sources.list entry or malformed file)
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

becomes

```bash
abizer@nyx ~
❯ sudo apt update
...
Reading package lists... Done
Building dependency tree
Reading state information... Done
1 package can be upgraded. Run 'apt list --upgradable' to see it.
```