### PR TITLE
show firefox quit confirmation dialog

### DIFF
--- a/modules/ocf/templates/firefox/prefs.js.erb
+++ b/modules/ocf/templates/firefox/prefs.js.erb
@@ -4,6 +4,7 @@ pref("browser.download.useDownloadDir", false);
 pref("browser.privatebrowsing.autostart", true);
 pref("browser.search.geoSpecificDefaults", false);
 pref("browser.shell.checkDefaultBrowser", false);
+pref("browser.showQuitWarning", true);
 pref("network.negotiate-auth.trusted-uris", "https://rt.ocf.berkeley.edu");
 pref("pdfjs.disabled", true);
 pref("signon.rememberSignons", false);


### PR DESCRIPTION
~Note: this is untested since I don't have root and can't run puppet-trigger. If anyone wants to test you can switch to my env (cooperc).~