### PR TITLE
Modify enforcer to always read TEACOPIES

### DIFF
--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -130,8 +130,7 @@ def read_config():
 
 def page_count(env):
     path = env['TEADATAFILE']
-    # When printing with single, page number is already multiplied by copy count
-    num_copy = 1 if env['CLASS'] == 'single' else int(env['TEACOPIES'])
+    num_copy = int(env['TEACOPIES'])
     return num_copy * int(subprocess.check_output(('/usr/local/bin/enforcer-pc', path), timeout=30))
 
 


### PR DESCRIPTION
This should fix our current print copy woes (ie the bug where people can print "infinite" pages by increasing the amount of "copies"). Based on my tests, the "page number is already multiplied by copy count" comment is inaccurate.