### PR TITLE
only check for vms when we actually have libvirtd running

### DIFF
--- a/modules/ocf_kvm/facts.d/vms
+++ b/modules/ocf_kvm/facts.d/vms
@@ -2,6 +2,7 @@
 import json
 import os.path
 import subprocess
+import sys
 
 
 def run_command(command_args):
@@ -11,9 +12,16 @@ def run_command(command_args):
     return list(filter(None, output))
 
 
-if (__name__ == '__main__' and
-    os.path.isfile('/usr/bin/virsh') and
-        subprocess.call(('/bin/systemctl', 'is-active', '--quiet', 'libvirtd')) == 0):
+if __name__ == '__main__':
+    # if virsh is not installed, give up
+    if not os.path.isfile('/usr/bin/virsh'):
+        sys.exit()
+
+    # if libvirtd is not running, virsh will not be able to connect to
+    # the system libvirt daemon
+    if subprocess.call(('/bin/systemctl', 'is-active', '--quiet', 'libvirtd')) != 0:
+        sys.exit()
+
     vms_all = run_command(('/usr/bin/virsh', 'list', '--name', '--all'))
     vms_inactive = run_command(('/usr/bin/virsh', 'list', '--name', '--inactive'))
 

--- a/modules/ocf_kvm/facts.d/vms
+++ b/modules/ocf_kvm/facts.d/vms
@@ -11,7 +11,9 @@ def run_command(command_args):
     return list(filter(None, output))
 
 
-if __name__ == '__main__' and os.path.isfile('/usr/bin/virsh'):
+if (__name__ == '__main__' and
+    os.path.isfile('/usr/bin/virsh') and
+        subprocess.call(('/bin/systemctl', 'is-active', '--quiet', 'libvirtd')) == 0):
     vms_all = run_command(('/usr/bin/virsh', 'list', '--name', '--all'))
     vms_inactive = run_command(('/usr/bin/virsh', 'list', '--name', '--inactive'))
 


### PR DESCRIPTION
Avoids the current puppetspam about vms failing when virsh is installed but the system daemon isn't actually running.

Would be good to test on a machine that has vms and a machine that doesn't.