### PR TITLE
Add sourcegraph service

### DIFF
--- a/modules/ocf_mesos/manifests/master/load_balancer.pp
+++ b/modules/ocf_mesos/manifests/master/load_balancer.pp
@@ -116,7 +116,12 @@ class ocf_mesos::master::load_balancer($marathon_http_password) {
     service_port   => 10011,
   }
 
-  # Ports 10013-10019 are reserved for code intelligence servers for sourcegraph
+  ocf_mesos::master::load_balancer::http_vhost { 'sourcegraph':
+    server_name    => 'sourcegraph.ocf.berkeley.edu',
+    server_aliases => ['sourcegraph'],
+    service_port   => 10012,
+  }
 
+  # Ports 10013-10019 are reserved for code intelligence servers for sourcegraph
   # Port 10020 is used by snmp_exporter, it is contacted directly by Prometheus
 }

--- a/modules/ocf_mesos/manifests/secrets.pp
+++ b/modules/ocf_mesos/manifests/secrets.pp
@@ -31,6 +31,16 @@ class ocf_mesos::secrets {
       purge     => true,
       force     => true,
       show_diff => false;
+
+    # Create a couple scratch directories for sourcegraph to use for temporary
+    # data storage
+    #
+    # This isn't great, but I think it's better than creating a whole new repo
+    # for sourcegraph and this temporary directory only stores session
+    # information and cloned repos anyway
+    ['/opt/share/docker/sourcegraph', '/opt/share/docker/sourcegraph/redis']:
+      ensure => directory,
+      mode   => '0700';
   }
 
   ocf_mesos::slave::attribute { 'secrets':


### PR DESCRIPTION
I'm currently running `jaws` and `monsoon` on my puppet env to get sourcegraph working (and sourcegraph is pinned to `jaws`), but once this is merged I should be able to unpin that and have it run anywhere with the correct directory for temporary data.

I also think we should set up the python code intelligence server as another service on port 10013: https://about.sourcegraph.com/docs/code-intelligence/install-manual#python