### PR TITLE
Add saslauthd

### DIFF
--- a/modules/ocf_ldap/files/sasl2-slapd
+++ b/modules/ocf_ldap/files/sasl2-slapd
@@ -1,2 +1,2 @@
-mech_list:      GSSAPI plain
+mech_list:      GSSAPI
 pwcheck_method: saslauthd

--- a/modules/ocf_ldap/files/sasl2-slapd
+++ b/modules/ocf_ldap/files/sasl2-slapd
@@ -1,2 +1,2 @@
-mech_list:      GSSAPI
+mech_list:      GSSAPI plain
 pwcheck_method: saslauthd

--- a/modules/ocf_ldap/manifests/init.pp
+++ b/modules/ocf_ldap/manifests/init.pp
@@ -120,4 +120,17 @@ class ocf_ldap {
         action => 'accept',
       };
   }
+
+  package { ['sasl2-bin']:; }
+  augeas { '/etc/default/saslauthd':
+    context => '/files/etc/default/saslauthd',
+    changes => [
+      'set MECHANISMS \'"kerberos5"\'',
+      'set START \'"yes"\'',
+    ],
+    require => Package['sasl2-bin'],
+  }
+  service { 'saslauthd':
+    ensure => running,
+  }
 }

--- a/modules/ocf_ldap/manifests/init.pp
+++ b/modules/ocf_ldap/manifests/init.pp
@@ -130,7 +130,4 @@ class ocf_ldap {
     ],
     require => Package['sasl2-bin'],
   }
-  service { 'saslauthd':
-    ensure => running,
-  }
 }


### PR DESCRIPTION
This PR adds saslauth and enables the plain authentication mechanism. It follows the instructions in https://security.stackexchange.com/a/69031 and lays the groundwork for LDAP authentication integrations in services like Grafana, Discourse, and potentially many others.

This lets LDAP auth pass passwords to Kerberos.