### PR TITLE
let lightning access puppet-ca api endpoint

### DIFF
--- a/modules/ocf_puppet/manifests/init.pp
+++ b/modules/ocf_puppet/manifests/init.pp
@@ -3,7 +3,7 @@ class ocf_puppet {
   include ocf_puppet::environments
   include ocf_puppet::firewall_input
   include ocf_puppet::puppetboard
-  include ocf_puppet::puppetmaster
+  include ocf_puppet::puppetserver
 
   file { '/etc/sudoers.d/ocfdeploy-puppet':
     content => "ocfdeploy ALL=NOPASSWD: /opt/puppetlabs/scripts/update-prod\n";

--- a/modules/ocf_puppet/manifests/puppetserver.pp
+++ b/modules/ocf_puppet/manifests/puppetserver.pp
@@ -1,4 +1,4 @@
-class ocf_puppet::puppetmaster {
+class ocf_puppet::puppetserver {
   package {
     ['puppetserver', 'puppet-lint', 'augeas-tools']:;
   }
@@ -30,6 +30,17 @@ class ocf_puppet::puppetmaster {
     match_request_method => ['get', 'post'],
     allow                => suffix($docker_private_hosts, '.ocf.berkeley.edu'),
     sort_order           => 500,
+    path                 => '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+    require              => Package['puppetserver'],
+    notify               => Service['puppetserver'],
+  }
+
+  puppet_authorization::rule { 'allow-puppetserver-cli':
+    match_request_path   => '/puppet-ca/v1/(?:certificate|certificate_status)',
+    match_request_type   => 'regex',
+    match_request_method => ['get', 'post', 'put', 'delete'],
+    allow                => $::fqdn,
+    sort_order           => 998,
     path                 => '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
     require              => Package['puppetserver'],
     notify               => Service['puppetserver'],

--- a/modules/ocf_puppet/manifests/puppetserver.pp
+++ b/modules/ocf_puppet/manifests/puppetserver.pp
@@ -35,6 +35,7 @@ class ocf_puppet::puppetserver {
     notify               => Service['puppetserver'],
   }
 
+  # allow the puppetmaster itself to get/set all certificate information
   puppet_authorization::rule { 'allow-puppetserver-cli':
     match_request_path   => '/puppet-ca/v1/(?:certificate|certificate_status)',
     match_request_type   => 'regex',


### PR DESCRIPTION
after upgrading to puppet 6, this helpful message appeared in the logs
when trying to run `puppetserver ca list`:

```
2018-10-07 18:17:58,784 ERROR [qtp1785629719-71] [p.t.a.rules] Forbidden request: lightning.ocf.berkeley.edu(2607:f140:8801:0:0:0:1:21) access to /puppet-ca/v1/certificate_statuses/any_key (method :get) (authenticated: true) denied by rule 'puppetlabs deny all'.
```

this additional rule should help fix that by adding:

```
{
    "allow": [
        "lightning.ocf.berkeley.edu"
    ],
    "match-request": {
        "method": [
            "get",
            "post",
	    "put",
	    "delete",
        ],
        "path": "^/puppet-ca/v1/(?:certificate|certificate_status)",
        "query-params": {},
        "type": "regex"
    },
    "name": "allow-puppetserver-cli",
    "sort-order": 998
}
```
to `/etc/puppetlabs/puppetserver/conf.d/auth.conf`