### PR TITLE
actually run nss_updatedb

### DIFF
--- a/modules/ocf/manifests/auth.pp
+++ b/modules/ocf/manifests/auth.pp
@@ -47,7 +47,8 @@ class ocf::auth($glogin = [], $ulogin = [[]], $gsudo = [], $usudo = [], $nopassw
   cron {
     'nss-updatedb':
       command => 'nss_updatedb ldap > /dev/null',
-      hour    => '6',
+      # run at a random time between 10am and 4:59pm
+      hour    => 10 + fqdn_rand(7),
       minute  => fqdn_rand(60),
       require => Package['nss-updatedb'],
   }


### PR DESCRIPTION
Currently the desktops never actually run `nss_updatedb` because the are always asleep between 6 and 7 AM. Currently on destruction, this is causing the mesos-slave service to fail because the ocfroot group can't be found before networking is up (so docker can't start). This was also true on cyclone until I manually ran `nss_updatedb ldap`.