### PR TITLE
Remove uses of deprecated hiera function

### DIFF
--- a/hieradata/type/staffvm.yaml
+++ b/hieradata/type/staffvm.yaml
@@ -1,6 +1,6 @@
 # owners always get sudo and login
-ocf::auth::ulogin: [["%{hiera('owner')}", 'ALL']]
-ocf::auth::usudo: ["%{hiera('owner')}"]
+ocf::auth::ulogin: [["%{lookup('owner')}", 'ALL']]
+ocf::auth::usudo: ["%{lookup('owner')}"]
 # ocfroot gets nopasswd as well, since we don't want root staffers typing their
 # passwords into staff VMs
 ocf::auth::nopasswd: true

--- a/modules/ocf/manifests/ssl/lets_encrypt/dns_common.pp
+++ b/modules/ocf/manifests/ssl/lets_encrypt/dns_common.pp
@@ -6,7 +6,7 @@ class ocf::ssl::lets_encrypt::dns_common {
     require => Package['dehydrated'],
   }
 
-  $letsencrypt_ddns_key = assert_type(Stdlib::Base64, hiera('letsencrypt::ddns::key'))
+  $letsencrypt_ddns_key = assert_type(Stdlib::Base64, lookup('letsencrypt::ddns::key'))
 
   file {
     '/var/lib/lets-encrypt/certs':

--- a/modules/ocf_admin/manifests/create/redis.pp
+++ b/modules/ocf_admin/manifests/create/redis.pp
@@ -14,7 +14,7 @@ class ocf_admin::create::redis {
     notify  => Service['redis-server'];
   }
 
-  $redis_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], hiera('create::redis::password'))
+  $redis_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], lookup('create::redis::password'))
 
   augeas { '/etc/redis/redis.conf':
     lens      => 'Spacevars.simple_lns',

--- a/modules/ocf_broker/manifests/init.pp
+++ b/modules/ocf_broker/manifests/init.pp
@@ -15,7 +15,7 @@ class ocf_broker {
       notify  => Service['redis-server'];
     }
 
-    $redis_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], hiera('broker::redis::password'))
+    $redis_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], lookup('broker::redis::password'))
 
     augeas { '/etc/redis/redis.conf':
         lens      => 'Spacevars.simple_lns',

--- a/modules/ocf_desktop/manifests/printnotify.pp
+++ b/modules/ocf_desktop/manifests/printnotify.pp
@@ -11,7 +11,7 @@ class ocf_desktop::printnotify {
     require => User['ocfbroker'],
   }
 
-  $redis_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], hiera('broker::redis::password'))
+  $redis_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], lookup('broker::redis::password'))
 
   file {
     '/opt/share/broker':

--- a/modules/ocf_hpc/manifests/controller.pp
+++ b/modules/ocf_hpc/manifests/controller.pp
@@ -1,7 +1,7 @@
 class ocf_hpc::controller {
   require ocf_hpc
 
-  $slurmdbd_mysql_password = hiera('hpc::controller::slurmdbd_mysql_password')
+  $slurmdbd_mysql_password = lookup('hpc::controller::slurmdbd_mysql_password')
 
   package { 'slurmdbd': } -> file { '/etc/slurm-llnl/slurmdbd.conf':
     content   => template('ocf_hpc/slurmdbd.conf.erb'),

--- a/modules/ocf_labstats/manifests/init.pp
+++ b/modules/ocf_labstats/manifests/init.pp
@@ -19,7 +19,7 @@ class ocf_labstats {
       *      => $file_defaults;
 
     '/opt/stats/ocfstats-password':
-      content => hiera('ocfstats::mysql::password'),
+      content => lookup('ocfstats::mysql::password'),
       mode    => '0600',
       require => File['/opt/stats'],
       *       => $file_defaults;

--- a/modules/ocf_mail/manifests/site_vhost.pp
+++ b/modules/ocf_mail/manifests/site_vhost.pp
@@ -9,7 +9,7 @@ class ocf_mail::site_vhost {
     backport_on => jessie,
   }
 
-  $mysql_ro_password = hiera('ocfmail::mysql::ro_password')
+  $mysql_ro_password = lookup('ocfmail::mysql::ro_password')
 
   file {
     '/etc/pam-mysql.conf':

--- a/modules/ocf_mesos/manifests/master.pp
+++ b/modules/ocf_mesos/manifests/master.pp
@@ -15,10 +15,10 @@ class ocf_mesos::master {
   $mesos_hostname = "mesos${my_mesos_id}"
   $marathon_hostname = "marathon${my_mesos_id}"
 
-  $mesos_http_password = hiera('mesos::master::password')
-  $mesos_agent_http_password = hiera('mesos::slave::password')
-  $marathon_http_password = hiera('mesos::marathon::http_password')
-  $zookeeper_password = hiera('mesos::zookeeper::password')
+  $mesos_http_password = lookup('mesos::master::password')
+  $mesos_agent_http_password = lookup('mesos::slave::password')
+  $marathon_http_password = lookup('mesos::marathon::http_password')
+  $zookeeper_password = lookup('mesos::zookeeper::password')
 
   # TODO: can we not duplicate this between slave/master?
   # looks like: mesos0:2181,mesos1:2181,mesos2:2181

--- a/modules/ocf_mesos/manifests/master/load_balancer.pp
+++ b/modules/ocf_mesos/manifests/master/load_balancer.pp
@@ -19,7 +19,7 @@ class ocf_mesos::master::load_balancer($marathon_http_password) {
 
   # keepalived config
   package { 'keepalived':; }
-  $keepalived_secret = hiera('mesos::keepalived::secret')
+  $keepalived_secret = lookup('mesos::keepalived::secret')
 
   # Virtual addresses are owned by all of the mesos masters.
   # At a given time, only one master will actually have the IP, but

--- a/modules/ocf_mesos/manifests/package.pp
+++ b/modules/ocf_mesos/manifests/package.pp
@@ -13,7 +13,7 @@ class ocf_mesos::package {
   # TODO: if we decide that we *won't* have servers which are both masters and
   # agents (we don't currently), we could simplify this
   $is_master = tagged('ocf_mesos::master')
-  $is_slave = tagged('ocf_mesos::slave') and !hiera('ocf_mesos::slave::disabled', false)
+  $is_slave = tagged('ocf_mesos::slave') and !lookup('ocf_mesos::slave::disabled', {default_value => false})
   service {
     'mesos-master':
       ensure  => $is_master,

--- a/modules/ocf_mesos/manifests/slave.pp
+++ b/modules/ocf_mesos/manifests/slave.pp
@@ -4,7 +4,7 @@ class ocf_mesos::slave($attributes = {}) {
   include ocf_mesos::package
 
   $masters = lookup('mesos_masters')
-  $zookeeper_password = hiera('mesos::zookeeper::password')
+  $zookeeper_password = lookup('mesos::zookeeper::password')
 
   # TODO: can we not duplicate this between slave/master?
   # looks like: mesos0:2181,mesos1:2181,mesos2:2181
@@ -29,8 +29,8 @@ class ocf_mesos::slave($attributes = {}) {
   }
 
 
-  $ocf_mesos_master_password = hiera('mesos::master::password')
-  $ocf_mesos_slave_password = hiera('mesos::slave::password')
+  $ocf_mesos_master_password = lookup('mesos::master::password')
+  $ocf_mesos_slave_password = lookup('mesos::slave::password')
 
   file {
     default:

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -39,7 +39,7 @@ class ocf_mirrors {
     password => '*',
   }
 
-  $ocfstats_password = hiera('ocfstats::mysql::password')
+  $ocfstats_password = lookup('ocfstats::mysql::password')
 
   file {
     ['/opt/mirrors', '/opt/mirrors/ftp', '/opt/mirrors/project', '/opt/mirrors/bin']:

--- a/modules/ocf_ns/manifests/init.pp
+++ b/modules/ocf_ns/manifests/init.pp
@@ -4,7 +4,7 @@ class ocf_ns {
     require => Package['bind9'];
   }
 
-  $letsencrypt_ddns_key = assert_type(Stdlib::Base64, hiera('letsencrypt::ddns::key'))
+  $letsencrypt_ddns_key = assert_type(Stdlib::Base64, lookup('letsencrypt::ddns::key'))
 
   file {
     '/etc/bind/named.conf.options':

--- a/modules/ocf_ocfweb/manifests/dev_config.pp
+++ b/modules/ocf_ocfweb/manifests/dev_config.pp
@@ -5,9 +5,9 @@ class ocf_ocfweb::dev_config($group = 'ocfstaff') {
   include ocf::firewall::output_printers
 
   # TODO: stop copy-pasting this password validation everywhere
-  $redis_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], hiera('create::redis::password'))
-  $ocfmail_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], hiera('ocfmail::mysql::dev_password'))
-  $ocfstats_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], hiera('ocfstats::mysql::dev_password'))
+  $redis_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], lookup('create::redis::password'))
+  $ocfmail_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], lookup('ocfmail::mysql::dev_password'))
+  $ocfstats_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], lookup('ocfstats::mysql::dev_password'))
 
   $broker = "redis://:${redis_password}@admin.ocf.berkeley.edu:6378"
   $backend = $broker

--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -4,7 +4,7 @@ class ocf_postgres {
   }
 
   class { 'postgresql::server':
-    postgres_password => hiera('postgres::rootpw'),
+    postgres_password => lookup('postgres::rootpw'),
     # https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html
     ipv4acls          => ['hostssl sameuser all 0.0.0.0/0 md5'],
     ipv6acls          => ['hostssl sameuser all ::/0 md5'],

--- a/modules/ocf_printhost/manifests/enforcer.pp
+++ b/modules/ocf_printhost/manifests/enforcer.pp
@@ -1,8 +1,8 @@
 class ocf_printhost::enforcer {
   package { ['cups-tea4cups', 'mariadb-client']: }
 
-  $mysql_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], hiera('ocfprinting::mysql::password'))
-  $redis_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], hiera('broker::redis::password'))
+  $mysql_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], lookup('ocfprinting::mysql::password'))
+  $redis_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], lookup('broker::redis::password'))
 
   file {
     '/etc/cups/tea4cups.conf':


### PR DESCRIPTION
The `hiera` function is slated to be [removed in Puppet 6](https://puppet.com/docs/puppet/5.2/hiera_use_hiera_functions.html).