### PR TITLE
Update to new home page

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -21,7 +21,7 @@ mesos_slaves:
     - riptide
     - dataloss
 
-browser_homepage: https://www.ocf.berkeley.edu/about/lab/vote
+browser_homepage: https://www.ocf.berkeley.edu/about/lab/survey
 
 #special devices
 devices_ipv4_only:


### PR DESCRIPTION
Last day to register to vote in California for this election cycle was 10/22/18. We should no longer remind users to register to vote.