### PR TITLE
Google doc error

### DIFF
--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -118,12 +118,12 @@ NOTIFY_JOB_ERROR = dedent("""\
 """)
 
 NOTIFY_PROBLEMATIC_FILE_SOURCE = dedent("""\
-        Unfortunately we don't support printing {file_source}.
-        Please download your file as a PDF, then try again.\
+        Unfortunately, printing from {file_source} results in formatting issues.
+        Please download your file as a PDF and print from desktop instead of web browser.\
 """)
 
 PROBLEMATIC_FILE_SOURCE = [
-    ('Google Doc', lambda job: job.doc_name.endswith(' - Google Docs'))
+    ('Google Docs', lambda job: job.doc_name.endswith(' - Google Docs'))
 ]
 
 

--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -164,6 +164,12 @@ def send_printer_mail(message, job, quo):
 
 def prehook(c, r, job):
     quo = quota.get_quota(c, job.user)
+    import inspect
+    _, _, _, argvals = inspect.getargvalues(inspect.currentframe())
+    with open('~/enforcer_debug.txt', 'w+') as f:
+        for argname in argvals:
+            f.write(argname + ': ' + argvals[argname] + '\n')
+
     if job.pages > quo.daily:
         send_printer_mail(INSUFFICIENT_QUOTA_MESSAGE, job, quo)
         msg = NOTIFY_QUOTA_MESSAGE.format(

--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -181,7 +181,7 @@ def prehook(c, r, job):
                 file_source=file_source,
             )
             r.publish(job.user, msg)
-            sys.exit(1)
+            sys.exit(255)
 
     if job.pages > quo.daily:
         send_printer_mail(INSUFFICIENT_QUOTA_MESSAGE, job, quo)
@@ -190,7 +190,7 @@ def prehook(c, r, job):
             quota=quo.daily,
         )
         r.publish(job.user, msg)
-        sys.exit(1)
+        sys.exit(255)
 
 
 def posthook(c, r, job, success):

--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -181,7 +181,7 @@ def prehook(c, r, job):
                 file_source=file_source,
             )
             r.publish(job.user, msg)
-            sys.exit(253)
+            sys.exit(1)
 
     if job.pages > quo.daily:
         send_printer_mail(INSUFFICIENT_QUOTA_MESSAGE, job, quo)
@@ -190,7 +190,7 @@ def prehook(c, r, job):
             quota=quo.daily,
         )
         r.publish(job.user, msg)
-        sys.exit(254)
+        sys.exit(1)
 
 
 def posthook(c, r, job, success):
@@ -258,7 +258,7 @@ def main(argv):
             except Exception:
                 pass
         # Don't retry; it's not going to print the second time.
-        sys.exit(254)
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -117,6 +117,16 @@ NOTIFY_JOB_ERROR = dedent("""\
         Please contact a staff member for assistance.\
 """)
 
+NOTIFY_PROHIBITED_FILE_TYPE = dedent("""\
+        I'm afraid I can't let you do that.
+        Please download your file as a PDF before downloading.
+        {file_type} files disagree with my software.\
+""")
+
+PROHIBITED_FILE_TYPES = [
+    ('Google Doc', lambda job: job.doc_name[-14:] == ' - Google Docs')
+]
+
 
 def read_config():
     conf = ConfigParser()
@@ -164,11 +174,15 @@ def send_printer_mail(message, job, quo):
 
 def prehook(c, r, job):
     quo = quota.get_quota(c, job.user)
-    import inspect
-    _, _, _, argvals = inspect.getargvalues(inspect.currentframe())
-    with open('/~/enforcer_debug.txt', 'w+') as f:
-        for argname in argvals:
-            f.write(argname + ': ' + argvals[argname] + '\n')
+
+    # A stop gap until we figure out why some file types aren't printing correctly
+    for file_type, prohibited in PROHIBITED_FILE_TYPES:
+        if prohibited(job):
+            msg = NOTIFY_PROHIBITED_FILE_TYPE.format(
+                file_type=file_type,
+            )
+            r.publish(job.user, msg)
+            sys.exit(255)
 
     if job.pages > quo.daily:
         send_printer_mail(INSUFFICIENT_QUOTA_MESSAGE, job, quo)

--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -117,12 +117,12 @@ NOTIFY_JOB_ERROR = dedent("""\
         Please contact a staff member for assistance.\
 """)
 
-NOTIFY_PROHIBITED_FILE_TYPE = dedent("""\
-        Unfortunately we don't support printing {file_type}.
-        Please download your file as PDF, then try again.\
+NOTIFY_PROBLEMATIC_FILE_SOURCE = dedent("""\
+        Unfortunately we don't support printing {file_source}.
+        Please download your file as a PDF, then try again.\
 """)
 
-PROHIBITED_FILE_TYPES = [
+PROBLEMATIC_FILE_SOURCE = [
     ('Google Doc', lambda job: job.doc_name.endswith(' - Google Docs'))
 ]
 
@@ -175,10 +175,10 @@ def prehook(c, r, job):
     quo = quota.get_quota(c, job.user)
 
     # A stop gap until we figure out why some file types aren't printing correctly
-    for file_type, prohibited in PROHIBITED_FILE_TYPES:
-        if prohibited(job):
-            msg = NOTIFY_PROHIBITED_FILE_TYPE.format(
-                file_type=file_type,
+    for file_source, problematic in PROBLEMATIC_FILE_SOURCE:
+        if problematic(job):
+            msg = NOTIFY_PROBLEMATIC_FILE_SOURCE.format(
+                file_source=file_source,
             )
             r.publish(job.user, msg)
             sys.exit(255)

--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -181,7 +181,7 @@ def prehook(c, r, job):
                 file_source=file_source,
             )
             r.publish(job.user, msg)
-            sys.exit(255)
+            sys.exit(253)
 
     if job.pages > quo.daily:
         send_printer_mail(INSUFFICIENT_QUOTA_MESSAGE, job, quo)
@@ -190,7 +190,7 @@ def prehook(c, r, job):
             quota=quo.daily,
         )
         r.publish(job.user, msg)
-        sys.exit(255)
+        sys.exit(254)
 
 
 def posthook(c, r, job, success):
@@ -258,7 +258,7 @@ def main(argv):
             except Exception:
                 pass
         # Don't retry; it's not going to print the second time.
-        sys.exit(255)
+        sys.exit(254)
 
 
 if __name__ == '__main__':

--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -166,7 +166,7 @@ def prehook(c, r, job):
     quo = quota.get_quota(c, job.user)
     import inspect
     _, _, _, argvals = inspect.getargvalues(inspect.currentframe())
-    with open('~/enforcer_debug.txt', 'w+') as f:
+    with open('/~/enforcer_debug.txt', 'w+') as f:
         for argname in argvals:
             f.write(argname + ': ' + argvals[argname] + '\n')
 

--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -118,13 +118,12 @@ NOTIFY_JOB_ERROR = dedent("""\
 """)
 
 NOTIFY_PROHIBITED_FILE_TYPE = dedent("""\
-        I'm afraid I can't let you do that.
-        Please download your file as a PDF before downloading.
-        {file_type} files disagree with my software.\
+        Unfortunately we don't support printing {file_type}.
+        Please download your file as PDF, then try again.\
 """)
 
 PROHIBITED_FILE_TYPES = [
-    ('Google Doc', lambda job: job.doc_name[-14:] == ' - Google Docs')
+    ('Google Doc', lambda job: job.doc_name.endswith(' - Google Docs'))
 ]
 
 


### PR DESCRIPTION
A stop gap measure to prevent people from printing from Google Docs until the reason for the formatting errors can be found.

Not sure if there's a better way to tell if a file is a Google Doc than inspecting the title.