### PR TITLE
Enable TCP BBR congestion control

### DIFF
--- a/modules/ocf/manifests/networking.pp
+++ b/modules/ocf/manifests/networking.pp
@@ -76,6 +76,14 @@ class ocf::networking(
       require => Package['resolvconf'];
   }
 
+  # Enable TCP BBR congestion control
+  sysctl {
+    'net.core.default_qdisc':
+      value => 'fq';
+    'net.ipv4.tcp_congestion_control':
+      value => 'bbr';
+  }
+
   # Make sure these are absent so predictable network iface names get used
   file {
     [


### PR DESCRIPTION
BBR improves throughput over lossy connections, so it would be
useful at least on user-facing servers like death and tsunami.
Linux 4.9+ supports BBR. Our machines run Linux from stretch or
jessie-backports, so they should all support BBR.