### PR TITLE
Puppet MUNGE authentication, needed for SLURM.

### DIFF
--- a/modules/ocf_hpc/manifests/init.pp
+++ b/modules/ocf_hpc/manifests/init.pp
@@ -41,14 +41,14 @@ class ocf_hpc {
 
   # SLURM uses MUNGE for authentication. Each host needs to have
   # the same munge.key, and have synced clocks.
-  package { 'munge': }
-  -> file { '/etc/munge/munge.key':
+  package { 'munge': } ->
+  file { '/etc/munge/munge.key':
     source => 'puppet:///private/munge.key',
     mode   => '0400',
     owner  => 'munge',
     group  => 'munge',
-  }
-  ~> service { 'munge':
+  } ~>
+  service { 'munge':
     ensure     => 'running',
     enable     => true,
     hasrestart => true,

--- a/modules/ocf_hpc/manifests/init.pp
+++ b/modules/ocf_hpc/manifests/init.pp
@@ -38,4 +38,17 @@ class ocf_hpc {
     owner   => 'slurm',
     group   => 'slurm',
   }
+
+  # SLURM uses MUNGE for authentication. Each host needs to have
+  # the same munge.key, and have synced clocks.
+  package { 'munge': } -> file { '/etc/munge/munge.key':
+    source => 'puppet:///private/munge.key',
+    mode   => '0400',
+    owner  => 'munge',
+    group  => 'munge',
+  } ~> service { 'munge':
+    ensure     => 'running',
+    enable     => true,
+    hasrestart => true,
+  }
 }

--- a/modules/ocf_hpc/manifests/init.pp
+++ b/modules/ocf_hpc/manifests/init.pp
@@ -41,12 +41,14 @@ class ocf_hpc {
 
   # SLURM uses MUNGE for authentication. Each host needs to have
   # the same munge.key, and have synced clocks.
-  package { 'munge': } -> file { '/etc/munge/munge.key':
+  package { 'munge': }
+  -> file { '/etc/munge/munge.key':
     source => 'puppet:///private/munge.key',
     mode   => '0400',
     owner  => 'munge',
     group  => 'munge',
-  } ~> service { 'munge':
+  }
+  ~> service { 'munge':
     ensure     => 'running',
     enable     => true,
     hasrestart => true,


### PR DESCRIPTION
I've put munge.key into the private share folders for corruption and segfault.