### PR TITLE
Remove printer off error

### DIFF
--- a/modules/ocf_labstats/files/bin/update-printer-stats
+++ b/modules/ocf_labstats/files/bin/update-printer-stats
@@ -13,12 +13,6 @@ def update_printer_stats(ocfstats_pass, printer):
         current_toner, max_toner = get_toner(printer)
         lifetime_pages = get_lifetime_pages(printer)
     except OSError as ex:
-        print(
-            '{}\nError reading data from {}, check that it is on'.format(
-                ex, printer,
-            ),
-            file=sys.stderr
-        )
         return
 
     with get_connection(user='ocfstats', password=ocfstats_pass) as c:


### PR DESCRIPTION
We don't really need this anymore, since Prometheus will monitor printers being down. Though perhaps we could keep this error and modify the cron invokation to ignore stderr? Thoughts?