### PR TITLE
Remove rt-ops list

### DIFF
--- a/modules/ocf_mail/files/site_ocf/aliases
+++ b/modules/ocf_mail/files/site_ocf/aliases
@@ -2,7 +2,6 @@
 root: root@g.ocf.berkeley.edu
 puppet: puppet@g.ocf.berkeley.edu
 rt: rt@g.ocf.berkeley.edu
-rt-ops: rt-ops@g.ocf.berkeley.edu
 mon: mon@g.ocf.berkeley.edu
 
 postmaster: sm


### PR DESCRIPTION
I'm almost certain this isn't used anywhere, since I've repurposed the `operations` RT queue to automatically email the right people.

After this is merged, I'll also delete this group from Google Admin.