### PR TITLE
Add CUPS monitoring and alerting

### DIFF
--- a/modules/ocf_printhost/files/monitor-cups
+++ b/modules/ocf_printhost/files/monitor-cups
@@ -25,6 +25,7 @@ def main():
     conn = cups.Connection()
     for cups_class, printers in conn.getClasses().items():
         for printer in printers:
+            # class is a reserved keyword, so we have to pass it via dictionary
             classes.labels(**{'class': cups_class, 'printer': printer}).set(1)
 
     write_to_textfile(sys.argv[1], registry)

--- a/modules/ocf_printhost/files/monitor-cups
+++ b/modules/ocf_printhost/files/monitor-cups
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+Collects metrics from CUPS and writes them to a text file in the Prometheus
+metrics format.
+"""
+
+import sys
+
+import cups
+from prometheus_client import CollectorRegistry
+from prometheus_client import Gauge
+from prometheus_client import write_to_textfile
+
+
+def main():
+    registry = CollectorRegistry()
+
+    classes = Gauge(
+        'cups_class',
+        'Existence of printer on CUPS class',
+        ['class', 'printer'],
+        registry=registry,
+    )
+
+    conn = cups.Connection()
+    for cups_class, printers in conn.getClasses().items():
+        for printer in printers:
+            classes.labels(**{'class': cups_class, 'printer': printer}).set(1)
+
+    write_to_textfile(sys.argv[1], registry)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/modules/ocf_printhost/manifests/init.pp
+++ b/modules/ocf_printhost/manifests/init.pp
@@ -6,4 +6,5 @@ class ocf_printhost {
   include ocf_printhost::enforcer
   include ocf::firewall::output_printers
   include ocf_printhost::firewall_input
+  include ocf_printhost::monitor
 }

--- a/modules/ocf_printhost/manifests/monitor.pp
+++ b/modules/ocf_printhost/manifests/monitor.pp
@@ -1,0 +1,25 @@
+class ocf_printhost::monitor {
+  package { ['libcups2-dev', 'python3-cups', 'python3-prometheus-client']: }
+
+  file {
+    '/var/local/prometheus':
+      ensure => directory;
+  } ->
+  file {
+    '/usr/local/bin/monitor-cups':
+      source => 'puppet:///modules/ocf_printhost/monitor-cups',
+      mode   => '0755';
+  } ->
+  exec { 'monitor-cups-initial':
+    command => '/usr/local/bin/monitor-cups /var/local/prometheus/cups.prom',
+    creates => '/var/local/prometheus/cups.prom',
+  } ->
+  cron { 'monitor-cups':
+    command => '/usr/local/bin/monitor-cups /var/local/prometheus/cups.prom',
+    # Run every minute
+  }
+
+  class { 'prometheus::node_exporter':
+    extra_options => '--collector.textfile.directory /var/local/prometheus',
+  }
+}

--- a/modules/ocf_prometheus/files/rules.d/cups.rules.yml
+++ b/modules/ocf_prometheus/files/rules.d/cups.rules.yml
@@ -1,0 +1,27 @@
+groups:
+  - name: cups
+    rules:
+    - alert: CUPSClassInconsistent
+      # This expression essentially checks how many times each printer is
+      # specified. It should either be specified 0 times (out of rotation) or
+      # twice (in rotation on both single and double).
+      #
+      # The next alert ensures that single printers are not in the double class,
+      # and vice-versa.
+      expr: sum(label_replace(cups_class, "printername", "$1", "printer", "(.*)-.*")) by (printername, instance) == 1
+      for: 2m
+      annotations:
+        summary: "Printer {{ $labels.printername }} is in rotation on either single or double, but not both"
+        remediation: "https://{{ $labels.instance }}.ocf.berkeley.edu/classes/"
+
+    - alert: SingleClassMismatch
+      expr: cups_class{class="single", printer!~".*-single"}
+      annotations:
+        summary: "Printer {{ $labels.printer }} is in rotation on the single class"
+        remediation: "https://{{ $labels.instance }}.ocf.berkeley.edu/classes/single"
+
+    - alert: DoubleClassMismatch
+      expr: cups_class{class="double", printer!~".*-double"}
+      annotations:
+        summary: "Printer {{ $labels.printer }} is in rotation on the double class"
+        remediation: "https://{{ $labels.instance }}.ocf.berkeley.edu/classes/double"

--- a/modules/ocf_prometheus/files/rules.d/printer.rules.yml
+++ b/modules/ocf_prometheus/files/rules.d/printer.rules.yml
@@ -40,3 +40,28 @@ groups:
       expr: up{job="printer"} == 0
       annotations:
         summary: "Printer {{ $labels.instance }} is down"
+
+    - alert: CUPSClassInconsistent
+      # This expression essentially checks how many times each printer is
+      # specified. It should either be specified 0 times (out of rotation) or
+      # twice (in rotation on both single and double).
+      #
+      # The next alert ensures that single printers are not in the double class,
+      # and vice-versa.
+      expr: sum(label_replace(cups_class, "printername", "$1", "printer", "(.*)-.*")) by (printername, instance) == 1
+      for: 2m
+      annotations:
+        summary: "Printer {{ $labels.printername }} is in rotation on either single or double, but not both"
+        remediation: "https://{{ $labels.instance }}.ocf.berkeley.edu/classes/"
+
+    - alert: SingleClassMismatch
+      expr: cups_class{class="single", printer!~".*-single"}
+      annotations:
+        summary: "Printer {{ $labels.printer }} is in rotation on the single class"
+        remediation: "https://{{ $labels.instance }}.ocf.berkeley.edu/classes/single"
+
+    - alert: DoubleClassMismatch
+      expr: cups_class{class="double", printer!~".*-double"}
+      annotations:
+        summary: "Printer {{ $labels.printer }} is in rotation on the double class"
+        remediation: "https://{{ $labels.instance }}.ocf.berkeley.edu/classes/double"

--- a/modules/ocf_prometheus/files/rules.d/printer.rules.yml
+++ b/modules/ocf_prometheus/files/rules.d/printer.rules.yml
@@ -40,28 +40,3 @@ groups:
       expr: up{job="printer"} == 0
       annotations:
         summary: "Printer {{ $labels.instance }} is down"
-
-    - alert: CUPSClassInconsistent
-      # This expression essentially checks how many times each printer is
-      # specified. It should either be specified 0 times (out of rotation) or
-      # twice (in rotation on both single and double).
-      #
-      # The next alert ensures that single printers are not in the double class,
-      # and vice-versa.
-      expr: sum(label_replace(cups_class, "printername", "$1", "printer", "(.*)-.*")) by (printername, instance) == 1
-      for: 2m
-      annotations:
-        summary: "Printer {{ $labels.printername }} is in rotation on either single or double, but not both"
-        remediation: "https://{{ $labels.instance }}.ocf.berkeley.edu/classes/"
-
-    - alert: SingleClassMismatch
-      expr: cups_class{class="single", printer!~".*-single"}
-      annotations:
-        summary: "Printer {{ $labels.printer }} is in rotation on the single class"
-        remediation: "https://{{ $labels.instance }}.ocf.berkeley.edu/classes/single"
-
-    - alert: DoubleClassMismatch
-      expr: cups_class{class="double", printer!~".*-double"}
-      annotations:
-        summary: "Printer {{ $labels.printer }} is in rotation on the double class"
-        remediation: "https://{{ $labels.instance }}.ocf.berkeley.edu/classes/double"


### PR DESCRIPTION
This lays the groundwork for monitoring CUPS, and adds some important alerts.

It works by periodically writing to a metrics file on whiteout, and including that file in `node_exporter` via the textfile collector.

We alert on inconsistent configurations of CUPS printer rotations. I think I was able to cover all erroneous cases, though it's possible I'm missing something. See the mon@ mailing list for examples of these in action.

You'll notice the cron->creates->file pattern is back. This is at least the third time it appears, so suggestions are welcome on how to cut down this repetition.