### PR TITLE
rename ocfdev to ocfapphost

### DIFF
--- a/hieradata/nodes/vampires.yaml
+++ b/hieradata/nodes/vampires.yaml
@@ -1,6 +1,6 @@
 classes:
     - ocf_apphost
 
-ocf::auth::glogin: [[ocfdev, ALL]]
+ocf::auth::glogin: [[ocfapphost, ALL]]
 
 staff_only: false

--- a/modules/ocf_apphost/facts.d/ocf-dev
+++ b/modules/ocf_apphost/facts.d/ocf-dev
@@ -1,2 +1,2 @@
 #!/bin/bash -eu
-echo "ocf_dev=$(getent group ocfdev | cut -d: -f4)"
+echo "ocf_apphost=$(getent group ocfapphost | cut -d: -f4)"

--- a/modules/ocf_apphost/manifests/init.pp
+++ b/modules/ocf_apphost/manifests/init.pp
@@ -17,10 +17,10 @@ class ocf_apphost {
     recurse => true,
     purge   => true;
   }
-  if $::ocf_dev {
-    $devs = split($::ocf_dev, ',')
+  if $::ocf_apphost {
+    $devs = split($::ocf_apphost, ',')
   } else {
-    # ocf_dev is empty on the first run which causes a runtime error above
+    # ocf_apphost is empty on the first run which causes a runtime error above
     $devs = []
   }
   $devs.each |$user| {

--- a/modules/ocf_www/files/build-vhosts
+++ b/modules/ocf_www/files/build-vhosts
@@ -288,7 +288,7 @@ def test_and_overwrite_config(config_path, new_config, target):
 def process_app_vhosts():
     """Perform extra tasks specific to app vhosts.
 
-    This includes checking for membership in the ocfdev group and fixing
+    This includes checking for membership in the ocfapphost group and fixing
     socket permissions. Returns true if nginx should reload."""
     def groups_for_user(user):
         return (g.gr_name for g in grp.getgrall() if user in g.gr_mem)
@@ -297,10 +297,10 @@ def process_app_vhosts():
     for domain, vhost in get_app_vhosts().items():
         user = vhost['username']
 
-        # Warn about ocfdev group
-        if 'ocfdev' not in groups_for_user(user):
+        # Warn about ocfapphost group
+        if 'ocfapphost' not in groups_for_user(user):
             report(
-                "Warning: user '{}' not in group ocfdev but has app vhost '{}'"
+                "Warning: user '{}' not in group ocfapphost but has app vhost '{}'"
                 .format(user, domain)
             )
 


### PR DESCRIPTION
"ocfdev" is kind of a bad name for this group, it implies it's some kind of development thing when in reality it's an enrollment mechanism for apphosting. So, we should rename the group. If this gets merged I'll rename the cn/dn in LDAP as well.