### PR TITLE
Temporarily change upstream mirrors.

### DIFF
--- a/modules/ocf_mirrors/manifests/archlinux.pp
+++ b/modules/ocf_mirrors/manifests/archlinux.pp
@@ -11,7 +11,7 @@ class ocf_mirrors::archlinux {
 
   ocf_mirrors::monitoring { 'archlinux':
     type          => 'unix_timestamp',
-    upstream_host => 'mirrors.kernel.org',
+    upstream_host => 'mirrors.mit.edu',
     ts_path       => 'lastsync',
   }
 

--- a/modules/ocf_mirrors/manifests/debian.pp
+++ b/modules/ocf_mirrors/manifests/debian.pp
@@ -1,7 +1,7 @@
 class ocf_mirrors::debian {
   ocf_mirrors::ftpsync {
     'debian':
-      rsync_host  => 'mirrors.kernel.org',
+      rsync_host  => 'ftp.us.debian.org',
       cron_minute => '10';
 
     'debian-security':

--- a/modules/ocf_mirrors/manifests/ubuntu.pp
+++ b/modules/ocf_mirrors/manifests/ubuntu.pp
@@ -1,6 +1,6 @@
 class ocf_mirrors::ubuntu {
   ocf_mirrors::ftpsync { 'ubuntu':
-    rsync_host  => 'mirrors.kernel.org',
+    rsync_host  => 'mirrors.mit.edu',
     cron_minute => '50';
   }
 


### PR DESCRIPTION
It appears that mirrors.kernel.org is not accepting connections.
To prevent our mirrors from going out of date, switch upstream
sources until mirrors.kernel.org recovers.