### PR TITLE
Add kubectl to extrapackages

### DIFF
--- a/modules/ocf/manifests/extrapackages.pp
+++ b/modules/ocf/manifests/extrapackages.pp
@@ -12,11 +12,11 @@
 # without concerns of redeclaring ocf::packages with different parameters.
 class ocf::extrapackages {
   # special snowflake packages that require some config
+  include ocf::packages::kubernetes::apt
   include ocf::packages::matplotlib
   include ocf::packages::mysql
   include ocf::packages::mysql_server
   include ocf::packages::nmap
-  include ocf::packages::kubernetes::apt
 
   # other packages
   package {

--- a/modules/ocf/manifests/extrapackages.pp
+++ b/modules/ocf/manifests/extrapackages.pp
@@ -16,6 +16,7 @@ class ocf::extrapackages {
   include ocf::packages::mysql
   include ocf::packages::mysql_server
   include ocf::packages::nmap
+  include ocf::packages::kubernetes::apt
 
   # other packages
   package {
@@ -70,6 +71,7 @@ class ocf::extrapackages {
     'jupyter-core',
     'jupyter-notebook',
     'keychain',
+    'kubectl',
     'libcrack2-dev',
     'libdbi-perl',
     'libexpect-perl',


### PR DESCRIPTION
This would pull in the kubernetes apt repo on all machines that use extrapackages, but I think it's worth it since kubectl could end up being used a lot (for instance, by staffers on supernova). Thoughts?