### PR TITLE
Add kubernetes jenkins auth

### DIFF
--- a/modules/ocf_kubernetes/files/abac.jsonl
+++ b/modules/ocf_kubernetes/files/abac.jsonl
@@ -1,0 +1,1 @@
+{"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"group":"ocfdeploy",     "namespace": "*",              "resource": "*",         "apiGroup": "*"                   }}

--- a/modules/ocf_kubernetes/templates/static-tokens.csv.erb
+++ b/modules/ocf_kubernetes/templates/static-tokens.csv.erb
@@ -1,0 +1,1 @@
+<%= @ocf_jenkins_deploy_token %>,jenkins-deploy,jenkins-deploy,"ocfdeploy"


### PR DESCRIPTION
* We add an authentication file (`static-tokens.csv.erb`) which contains the Jenkins token password
* We add an authorization file (`abac.jsonl`) which allows Jenkins to do anything
* We mount these in the apiserver Docker container, and configure the apiserver to use them
* As a bonus, we make the cert valid for `kubernetes.ocf.berkeley.edu`.