### PR TITLE
Add ocf::systemuser resource

### DIFF
--- a/modules/ocf/manifests/systemuser.pp
+++ b/modules/ocf/manifests/systemuser.pp
@@ -1,19 +1,20 @@
 define ocf::systemuser(
   $ensure = present,
   $opts = {},
-  $groups = [],
 ){
 
-  $groups_real = $groups ? {
-    Array   => $groups + ['sys'],
-    String  => [$groups, 'sys'],
+  $groups_real = $opts['groups'] ? {
+    Array   => $opts['groups'] + ['sys'],
+    String  => [$opts['groups'], 'sys'],
     default => ['sys'],
   }
+  $updated = { 'groups' =>  $groups_real }
+  # Rightmost hash takes precedence on merge
+  $updated_opts = $opts + $updated
 
   user { $title:
     ensure => $ensure,
     system => true,
-    groups => $groups_real,
     *      => $opts,
   }
 }

--- a/modules/ocf/manifests/systemuser.pp
+++ b/modules/ocf/manifests/systemuser.pp
@@ -1,0 +1,19 @@
+define ocf::systemuser(
+  $ensure = present,
+  $opts = {},
+  $groups = [],
+){
+
+  $groups_real = $groups ? {
+    Array   => $groups + ['sys'],
+    String  => [$groups, 'sys'],
+    default => ['sys'],
+  }
+
+  user { $title:
+    ensure => $ensure,
+    system => true,
+    groups => $groups_real,
+    *      => $opts,
+  }
+}

--- a/modules/ocf_apt/manifests/init.pp
+++ b/modules/ocf_apt/manifests/init.pp
@@ -2,12 +2,12 @@ class ocf_apt {
   include ocf::firewall::allow_web
   include ocf::ssl::default
 
-  user { 'ocfapt':
-    comment => 'OCF Apt',
-    home    => '/opt/apt',
-    groups  => ['sys'],
-    shell   => '/bin/false',
-    system  => true,
+  ocf::systemuser { 'ocfapt':
+    opts => {
+      comment => 'OCF Apt',
+      home    => '/opt/apt',
+      shell   => '/bin/false',
+    },
   }
 
   ocf::repackage { 'reprepro':

--- a/modules/ocf_decal/manifests/init.pp
+++ b/modules/ocf_decal/manifests/init.pp
@@ -3,11 +3,11 @@ class ocf_decal {
   include ocf_decal::website
 
   ocf::systemuser { 'ocfdecal':
-    groups => ['www-data'],
     opts   => {
       comment => 'DeCal management account',
       home    => '/opt/ocfdecal',
       shell   => '/bin/bash',
+      groups  => ['www-data'],
     },
   }
 

--- a/modules/ocf_decal/manifests/init.pp
+++ b/modules/ocf_decal/manifests/init.pp
@@ -2,12 +2,13 @@ class ocf_decal {
   include apache
   include ocf_decal::website
 
-  user { 'ocfdecal':
-    comment => 'DeCal management account',
-    home    => '/opt/ocfdecal',
-    shell   => '/bin/bash',
-    groups  => 'www-data',
-    system  => true,
+  ocf::systemuser { 'ocfdecal':
+    groups => ['www-data'],
+    opts   => {
+      comment => 'DeCal management account',
+      home    => '/opt/ocfdecal',
+      shell   => '/bin/bash',
+    },
   }
 
   file {

--- a/modules/ocf_desktop/manifests/printnotify.pp
+++ b/modules/ocf_desktop/manifests/printnotify.pp
@@ -1,8 +1,9 @@
 class ocf_desktop::printnotify {
-  user { 'ocfbroker':
+  ocf::systemuser { 'ocfbroker':
     ensure => present,
-    shell  => '/bin/false',
-    system =>  true,
+    opts   =>  {
+      shell  => '/bin/false',
+    }
   }
 
   # enable regular users to run notification script as ocfbroker

--- a/modules/ocf_desktop/manifests/stats.pp
+++ b/modules/ocf_desktop/manifests/stats.pp
@@ -1,10 +1,9 @@
 class ocf_desktop::stats {
-  user {
-    'ocfstats':
+  ocf::systemuser { 'ocfstats':
+    opts    => {
       comment => 'OCF Desktop Stats',
       home    => '/opt/stats',
-      system  => true,
-      groups  => 'sys';
+    },
   }
 
   file {

--- a/modules/ocf_irc/manifests/znc.pp
+++ b/modules/ocf_irc/manifests/znc.pp
@@ -3,12 +3,13 @@
 class ocf_irc::znc {
   package { 'znc': }
 
-  user { 'ocfznc':
-    comment => 'IRC Bouncer Server',
-    groups  => [ssl-cert],
-    home    => '/var/lib/znc',
-    shell   => '/bin/false',
-    system  => true,
+  ocf::systemuser { 'ocfznc':
+    groups  => ['ssl-cert'],
+    opts    => {
+      comment => 'IRC Bouncer Server',
+      home    => '/var/lib/znc',
+      shell   => '/bin/false',
+    },
     require => Package['ssl-cert'],
   }
 

--- a/modules/ocf_irc/manifests/znc.pp
+++ b/modules/ocf_irc/manifests/znc.pp
@@ -4,11 +4,11 @@ class ocf_irc::znc {
   package { 'znc': }
 
   ocf::systemuser { 'ocfznc':
-    groups  => ['ssl-cert'],
     opts    => {
       comment => 'IRC Bouncer Server',
       home    => '/var/lib/znc',
       shell   => '/bin/false',
+      groups  => ['ssl-cert'],
     },
     require => Package['ssl-cert'],
   }

--- a/modules/ocf_jenkins/manifests/init.pp
+++ b/modules/ocf_jenkins/manifests/init.pp
@@ -121,17 +121,18 @@ class ocf_jenkins {
   ocf::systemuser {
     default:
       shell   => '/bin/bash',
-      groups  => ['docker'],
       require => Package['docker-ce'];
 
     'jenkins-slave':
       opts => {
+        groups  => ['docker'],
         comment => 'OCF Jenkins Slave',
         home    => '/opt/jenkins/slave/',
       };
 
     'jenkins-deploy':
       opts => {
+        groups  => ['docker'],
         comment => 'OCF Jenkins Deploy',
         home    => '/opt/jenkins/deploy/',
       };

--- a/modules/ocf_jenkins/manifests/init.pp
+++ b/modules/ocf_jenkins/manifests/init.pp
@@ -118,22 +118,23 @@ class ocf_jenkins {
       group   => root;
   }
 
-  user {
-    'jenkins-slave':
-      comment => 'OCF Jenkins Slave',
-      home    => '/opt/jenkins/slave/',
-      groups  => ['sys', 'docker'],
+  ocf::systemuser {
+    default:
       shell   => '/bin/bash',
-      system  => true,
+      groups  => ['docker'],
       require => Package['docker-ce'];
 
+    'jenkins-slave':
+      opts => {
+        comment => 'OCF Jenkins Slave',
+        home    => '/opt/jenkins/slave/',
+      };
+
     'jenkins-deploy':
-      comment => 'OCF Jenkins Deploy',
-      home    => '/opt/jenkins/deploy/',
-      groups  => ['sys', 'docker'],
-      shell   => '/bin/bash',
-      system  => true,
-      require => Package['docker-ce'];
+      opts => {
+        comment => 'OCF Jenkins Deploy',
+        home    => '/opt/jenkins/deploy/',
+      };
   }
 
   # mount jenkins slave workspace as tmpfs for speed

--- a/modules/ocf_labstats/manifests/init.pp
+++ b/modules/ocf_labstats/manifests/init.pp
@@ -1,12 +1,11 @@
 class ocf_labstats {
   include ocf::firewall::output_printers
 
-  user {
-    'ocfstats':
-      comment => 'OCF Lab Stats',
-      home    => '/opt/stats',
-      system  => true,
-      groups  => 'sys';
+  ocf::systemuser { 'ocfstats':
+      opts    => {
+        comment => 'OCF Lab Stats',
+        home    => '/opt/stats',
+      },
   }
 
   $file_defaults = {

--- a/modules/ocf_mail/manifests/init.pp
+++ b/modules/ocf_mail/manifests/init.pp
@@ -12,15 +12,15 @@ class ocf_mail {
     subscribe => Class['ocf::ssl::default'],
   }
 
-  user { 'ocfmail':
+  ocf::systemuser { 'ocfmail':
     ensure  => present,
-    name    => ocfmail,
-    gid     => ocfmail,
-    groups  => [sys],
-    home    => '/var/mail',
-    shell   => '/bin/false',
-    system  => true,
     require => Group['ocfmail'],
+    opts    => {
+      name  => ocfmail,
+      gid   => ocfmail,
+      home  => '/var/mail',
+      shell => '/bin/false',
+    },
   }
 
   group { 'ocfmail':

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -28,15 +28,15 @@ class ocf_mirrors {
   include ocf_mirrors::trisquel
   include ocf_mirrors::ubuntu
 
-  user { 'mirrors':
-    comment  => 'OCF Mirroring',
-    home     => '/opt/mirrors',
-    groups   => ['sys'],
-    shell    => '/bin/bash',
-    system   => true,
+  ocf::systemuser { 'mirrors':
+    opts => {
+      comment  => 'OCF Mirroring',
+      home     => '/opt/mirrors',
+      shell    => '/bin/bash',
 
-    # Set to have no password, only allow key-based login
-    password => '*',
+      # Set to have no password, only allow key-based login
+      password => '*',
+    },
   }
 
   $ocfstats_password = lookup('ocfstats::mysql::password')


### PR DESCRIPTION
Setting system => true is something we have shown time and time again
that we are not able to remember, creating annoying ldap conflicts.
Having a custom resource for this will make it much more apparent. The
resource is simple. It proxies all the arguments passed to opts to the
system resource, but ensures that system is set to true and that the
user is in the group 'sys'.