### PR TITLE
remove hal from mesos agents

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -16,7 +16,6 @@ mesos_masters:
 
 mesos_slaves:
     - jaws
-    - hal
     - pandemic
     - riptide
     - dataloss

--- a/hieradata/nodes/hal.yaml
+++ b/hieradata/nodes/hal.yaml
@@ -1,8 +1,6 @@
 classes:
     - ocf_backups
     - ocf_kvm
-    - ocf_mesos::slave
-    - ocf_mesos::secrets
 
 ocf::networking::bridge: true
 ocf::networking::bond: true


### PR DESCRIPTION
hal is really slow and marathon seems to time out rather often
trying to start containers on it. this causes the entire deploy to fail.
we have enough other agents for removing hal to not be an issue.

we'll also need to manually remove the configs/secrets that cause hal to register as an agent so I'll do that manually if this gets approved