### PR TITLE
Include project name in ftpsync config file.

### DIFF
--- a/modules/ocf_mirrors/manifests/ftpsync.pp
+++ b/modules/ocf_mirrors/manifests/ftpsync.pp
@@ -31,7 +31,7 @@ define ocf_mirrors::ftpsync(
       ensure => link,
       target => "${project_path}/distrib/etc/common";
 
-    "${project_path}/etc/ftpsync.conf":
+    "${project_path}/etc/ftpsync-${title}.conf":
       content => template('ocf_mirrors/ftpsync.conf.erb'),
       mode    => '0644';
   }
@@ -49,7 +49,7 @@ define ocf_mirrors::ftpsync(
       environments => { 'BASEDIR' => $project_path },
       hour         => $cron_hour,
       minute       => $cron_minute,
-      require      => File["${project_path}/bin", "${project_path}/etc/ftpsync.conf"],
+      require      => File["${project_path}/bin", "${project_path}/etc/ftpsync-${title}.conf"],
     }
   } else {
     cron { "ftpsync-${title}":
@@ -57,7 +57,7 @@ define ocf_mirrors::ftpsync(
       user    => 'mirrors',
       minute  => $cron_minute,
       hour    => $cron_hour,
-      require => File["${project_path}/bin", "${project_path}/etc/ftpsync.conf"];
+      require => File["${project_path}/bin", "${project_path}/etc/ftpsync-${title}.conf"];
     }
   }
 }


### PR DESCRIPTION
The ftpsync script expects the config file to be in this format in certain circumstances. It seems to have broken the Kali push sync, see rt#7886.

I believe this will fix the issue, but someone please correct me if I'm wrong. `fallingrocks` is currently on my env, and has this change. If this is merged I will manually remove the files with the old name.