### PR TITLE
Mount secrets on kubernetes workers

### DIFF
--- a/modules/ocf_kubernetes/manifests/secrets.pp
+++ b/modules/ocf_kubernetes/manifests/secrets.pp
@@ -1,0 +1,45 @@
+class ocf_kubernetes::secrets {
+  # The way we manage secrets in Kubernetes is that we put them in the Puppet
+  # private share under "docker", which is made available to the Kubernetes
+  # workers via a special file share, "private-docker".
+  #
+  # We then mount individual directories (e.g. for the RT service, we might
+  # mount /opt/share/docker/secrets/rt into the container).
+  #
+  # Since inside the container, our processes typically run as "nobody" (or
+  # another unprivileged user), these secrets need to be world-readable.
+  # That's fine inside Docker, but outside Docker, we don't want random users
+  # on the host to be able to access them. So we make one directory,
+  # `/opt/share/docker`, which has strict permissions, and then put the secrets
+  # in `/opt/share/docker/secrets` underneath it.
+  #
+  # The extra directory is theoretically unnecessary, but in practice Puppet
+  # makes it hard to set "0700" on a directory, while recursively setting
+  # 0644/0755 on children. Oh well.
+  #
+  # Only some Kubernetes workers have this class. Some (e.g. desktops) don't,
+  # and so won't run jobs that require secrets.
+  file {
+    '/opt/share/docker':
+      ensure => directory,
+      mode   => '0700';
+
+    '/opt/share/docker/secrets':
+      mode      => '0644',
+      source    => 'puppet:///private-docker/',
+      recurse   => true,
+      purge     => true,
+      force     => true,
+      show_diff => false;
+
+    # Create a couple scratch directories for sourcegraph to use for temporary
+    # data storage
+    #
+    # This isn't great, but I think it's better than creating a whole new repo
+    # for sourcegraph and this temporary directory only stores session
+    # information and cloned repos anyway
+    ['/opt/share/docker/sourcegraph', '/opt/share/docker/sourcegraph/redis']:
+      ensure => directory,
+      mode   => '0700';
+  }
+}

--- a/modules/ocf_kubernetes/manifests/worker.pp
+++ b/modules/ocf_kubernetes/manifests/worker.pp
@@ -9,7 +9,7 @@
 class ocf_kubernetes::worker {
   include ocf::packages::docker_kubernetes
   include ocf::packages::kubernetes
-  include ocf_kubernetes::secrets
+  include ocf_kubernetes::worker::secrets
 
   class { 'kubernetes':
     worker        => true,

--- a/modules/ocf_kubernetes/manifests/worker.pp
+++ b/modules/ocf_kubernetes/manifests/worker.pp
@@ -9,6 +9,7 @@
 class ocf_kubernetes::worker {
   include ocf::packages::docker_kubernetes
   include ocf::packages::kubernetes
+  include ocf_kubernetes::secrets
 
   class { 'kubernetes':
     worker        => true,

--- a/modules/ocf_kubernetes/manifests/worker/secrets.pp
+++ b/modules/ocf_kubernetes/manifests/worker/secrets.pp
@@ -24,7 +24,7 @@ class ocf_kubernetes::worker::secrets {
       ensure => directory,
       mode   => '0700';
 
-    '/opt/share/docker/secrets':
+    '/opt/share/kubernetes/secrets':
       mode      => '0644',
       source    => 'puppet:///private-docker/',
       recurse   => true,

--- a/modules/ocf_kubernetes/manifests/worker/secrets.pp
+++ b/modules/ocf_kubernetes/manifests/worker/secrets.pp
@@ -1,4 +1,4 @@
-class ocf_kubernetes::secrets {
+class ocf_kubernetes::worker::secrets {
   # The way we manage secrets in Kubernetes is that we put them in the Puppet
   # private share under "docker", which is made available to the Kubernetes
   # workers via a special file share, "private-docker".

--- a/modules/ocf_puppet/manifests/puppetserver.pp
+++ b/modules/ocf_puppet/manifests/puppetserver.pp
@@ -21,7 +21,11 @@ class ocf_puppet::puppetserver {
     notify  => Service['puppetserver'],
   }
 
-  $docker_private_hosts = union(keys(lookup('mesos_masters')), lookup('mesos_slaves'))
+  $docker_private_hosts = union(
+    keys(lookup('mesos_masters')),
+    lookup('mesos_slaves'),
+    lookup('kubernetes::worker_nodes'),
+  )
 
   # Allow Mesos agents and masters to access docker secrets
   puppet_authorization::rule { 'private-docker':


### PR DESCRIPTION
This basically copies the Marathon secrets file into Kubernetes.

One departure from how this is handled in Marathon: in Marathon, we labeled certain slaves as "holding secrets" because some we didn't want some slaves (desktops) to mount them. I'm not including that here, since I don't expect us to use the desktops as Kubernetes workers. If we do end up deciding to do that, we can make a separate PR for labeling workers.