### PR TITLE
migrate puppetdb to managed postgres server

### DIFF
--- a/modules/ocf_puppetdb/manifests/init.pp
+++ b/modules/ocf_puppetdb/manifests/init.pp
@@ -1,30 +1,18 @@
 class ocf_puppetdb {
-  class { 'puppetdb::database::postgresql':
-    # Only listen locally since puppetdb is the only database client and it is
-    # a local database
-    listen_addresses    => 'localhost',
+  class { 'puppetdb':
+    database_host       => 'postgres',
+    database_username   => 'ocfpuppetdb',
+    database_password   => hiera('puppetdb::postgres_password'),
+    database_name       => 'ocfpuppetdb',
+    jdbc_ssl_properties => '?ssl=true',
 
-    # We can't have postgresql manage the package repo, since it tries to
-    # include the ::apt class that we have already included ourselves with
-    # custom options, which causes duplicate declaration errors. Besides,
-    # we'd rather install from Debian package repos anyway instead of
-    # PostgreSQL upstream repos.
-    manage_package_repo => false,
-
-    # Although 9.6 is the default currently, we want to pin this so that later
-    # version bumps do not change this and we can keep installing whichever
-    # version is available in Debian repos
-    postgres_version    => '9.6',
-  }
-
-  class { 'puppetdb::server':
-    database_host      => 'localhost',
-    java_args          => {
+    java_args           => {
       '-Xmx' => '1g',
       '-Xms' => '256m',
     },
-    manage_firewall    => true,
-    ssl_set_cert_paths => true,
+    manage_firewall     => true,
+    ssl_set_cert_paths  => true,
+    manage_package_repo => false,
   }
 
   # firewall input, allow access to ports 8081, the puppet DB port


### PR DESCRIPTION
my network connection is too tenuous right now for me to actually test this but it was working for a period of time during the original postgres testing run