### PR TITLE
Add IRC cert reloading cronjob

### DIFF
--- a/modules/ocf_irc/files/reload-ssl.sh
+++ b/modules/ocf_irc/files/reload-ssl.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
+set -euo pipefail
 
 # Log into the IRC server and reload the SSL cert.
 
 # Use a random nick to ensure no collisions with users on the server
-username=$(pwgen --secure --no-numerals 16 1)
+nick=$(pwgen --secure --no-numerals 16 1)
 oper_pass=$(<"$1")
 
 (
-echo NICK $username
-echo USER ocfletsencrypt 0 0 :Lets Encrypt cert reloading script
+echo NICK $nick
+echo USER ocf-cert-reload 0 0 :Lets Encrypt cert reloading script
 sleep 2
-echo OPER ocfletsencrypt "$oper_pass"
+echo OPER ocf-cert-reload "$oper_pass"
 sleep 2
 echo REHASH -ssl
 echo QUIT
-) | telnet 127.0.0.1 6667
+) | nc 127.0.0.1 6667

--- a/modules/ocf_irc/files/reload-ssl.sh
+++ b/modules/ocf_irc/files/reload-ssl.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Log into the IRC server and reload the SSL cert.
+
+# Use a random nick to ensure no collisions with users on the server
+username=$(pwgen --secure --no-numerals 16 1)
+oper_pass=$(<"$1")
+
+(
+echo NICK $username
+echo USER ocfletsencrypt 0 0 :Lets Encrypt cert reloading script
+sleep 2
+echo OPER ocfletsencrypt "$oper_pass"
+sleep 2
+echo REHASH -ssl
+echo QUIT
+) | telnet 127.0.0.1 6667

--- a/modules/ocf_irc/manifests/ircd.pp
+++ b/modules/ocf_irc/manifests/ircd.pp
@@ -8,10 +8,7 @@ class ocf_irc::ircd {
     subscribe => Class['ocf::ssl::default'],
   } ->
   cron { 'reload-irc-cert':
-    # We can't use chronic here to suppress output because telnet will return an
-    # "error" code of 1 if the server disconnects, which it will for this
-    # script.
-    command => '/usr/local/bin/reload-ssl.sh /etc/inspircd/reload_pass > /dev/null',
+    command => 'chronic /usr/local/bin/reload-ssl.sh /etc/inspircd/reload_pass',
     hour    => 0,
     minute  => 0,
     user    => 'irc',

--- a/modules/ocf_irc/manifests/ircd.pp
+++ b/modules/ocf_irc/manifests/ircd.pp
@@ -11,6 +11,7 @@ class ocf_irc::ircd {
     command => 'chronic /usr/local/bin/reload-ssl.sh /etc/inspircd/reload_pass',
     hour    => 0,
     minute  => 0,
+    weekday => 0,
     user    => 'irc',
   }
 

--- a/modules/ocf_irc/manifests/ircd.pp
+++ b/modules/ocf_irc/manifests/ircd.pp
@@ -8,6 +8,9 @@ class ocf_irc::ircd {
     subscribe => Class['ocf::ssl::default'],
   } ->
   cron { 'reload-irc-cert':
+    # We can't use chronic here to suppress output because telnet will return an
+    # "error" code of 1 if the server disconnects, which it will for this
+    # script.
     command => '/usr/local/bin/reload-ssl.sh /etc/inspircd/reload_pass > /dev/null',
     hour    => 0,
     minute  => 0,

--- a/modules/ocf_irc/manifests/ircd.pp
+++ b/modules/ocf_irc/manifests/ircd.pp
@@ -6,6 +6,12 @@ class ocf_irc::ircd {
     enable    => true,
     require   => Package['inspircd'],
     subscribe => Class['ocf::ssl::default'],
+  } ->
+  cron { 'reload-irc-cert':
+    command => '/usr/local/bin/reload-ssl.sh /etc/inspircd/reload_pass > /dev/null',
+    hour    => 0,
+    minute  => 0,
+    user    => 'irc',
   }
 
   $passwords = parsejson(file("/opt/puppet/shares/private/${::hostname}/ircd-passwords"))
@@ -29,5 +35,14 @@ class ocf_irc::ircd {
 
     '/etc/inspircd/inspircd.motd':
       source  => 'puppet:///modules/ocf_irc/ircd.motd';
+
+    '/usr/local/bin/reload-ssl.sh':
+      source => 'puppet:///modules/ocf_irc/reload-ssl.sh',
+      mode   => '0755';
+
+    '/etc/inspircd/reload_pass':
+      content   => $passwords['cert-reload-pass'],
+      mode      => '0640',
+      show_diff => false;
   }
 }

--- a/modules/ocf_irc/templates/inspircd.conf.erb
+++ b/modules/ocf_irc/templates/inspircd.conf.erb
@@ -36,10 +36,12 @@
         keyfile="/etc/ssl/private/<%= @fqdn -%>.key"
         priority="NORMAL:-MD5">
 
-# Allow connections on 6697 (TLS only)
-# Port 25580 is localhost-only for anope services to connect
+# Allow public connections on 6697 (TLS only)
 <bind address="" port="6697" type="clients" ssl="gnutls">
+# Port 25580 is localhost-only for anope services to connect
 <bind address="127.0.0.1" port="25580" type="servers">
+# Port 6667 is localhost-only for automation scripts
+<bind address="127.0.0.1" port="6667">
 
 # Link to the anope server, only allow local connections
 <link name="services.irc.ocf.berkeley.edu"
@@ -100,6 +102,9 @@
       vhost="ocf.gods"
       override="KICK MODEOP MODEDEOP MODEVOICE MODEDEVOICE MODEHALFOP MODEDEHALFOP OTHERMODE">
 
+<type name="ReloadCert" classes="Shutdown">
+
+
 # Store oper credentials in mysql
 <database name="ocfirc"
           user="ocfirc"
@@ -113,6 +118,13 @@
 
 <files motd="/etc/inspircd/inspircd.motd"
        rules="/etc/inspircd/inspircd.rules">
+
+
+# Automated user for reloading certs
+<oper name="ocf-cert-reload"
+      password="<%= @passwords['cert-reload-pass'] -%>"
+      host="*@localhost *@<%= @fqdn -%>"
+      type="ReloadCert">
 
 # Allow both regular users and opers to join up to 200 channels
 <channels users="200" opers="200">


### PR DESCRIPTION
* IRC server now listens on port 6667 for localhost
* Creates a new oper user that has permission to reload certs
* Cronjob script that logs in as this oper and reloads the cert

We need to do the 6667 because cert reloading seems to not work if the operator itself is connected via SSL.