### PR TITLE
better check for when the letsencrypt cert needs renewal

### DIFF
--- a/modules/ocf/facts.d/le-cert-info
+++ b/modules/ocf/facts.d/le-cert-info
@@ -1,12 +1,22 @@
 #!/usr/bin/env python3
 import json
 import os
+import sys
 from datetime import datetime
 
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
-
 LETSENCRYPT_CERT_DIR = '/var/lib/lets-encrypt/certs/'
+
+
+def print_info(data):
+    print('le_cert_info=' + json.dumps(data))
+
+
+try:
+    from cryptography import x509
+    from cryptography.hazmat.backends import default_backend
+except ImportError:
+    print_info({})
+    sys.exit()
 
 cert_data = {}
 
@@ -17,7 +27,7 @@ for title in os.listdir(LETSENCRYPT_CERT_DIR):
     except FileNotFoundError:
         continue
     except PermissionError as e:
-        print('try running this command as root or ocfletsencrypt')
+        print('try running this command as root or ocfletsencrypt', file=sys.stderr)
         raise e
 
     cert = x509.load_pem_x509_certificate(pem_data, default_backend())
@@ -27,4 +37,4 @@ for title in os.listdir(LETSENCRYPT_CERT_DIR):
         'days_to_expiration': (cert.not_valid_after - datetime.today()).days,
     }
 
-print('le_cert_info=' + json.dumps(cert_data))
+print_info(cert_data)

--- a/modules/ocf/facts.d/le-cert-info
+++ b/modules/ocf/facts.d/le-cert-info
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import json
+import os
+from datetime import datetime
+
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+
+LETSENCRYPT_CERT_DIR = '/var/lib/lets-encrypt/certs/'
+
+cert_data = {}
+
+for title in os.listdir(LETSENCRYPT_CERT_DIR):
+    try:
+        with open(os.path.join(LETSENCRYPT_CERT_DIR, title, 'cert.pem'), 'rb') as pem_file:
+            pem_data = pem_file.read()
+    except FileNotFoundError:
+        continue
+    except PermissionError as e:
+        print('try running this command as root or ocfletsencrypt')
+        raise e
+
+    cert = x509.load_pem_x509_certificate(pem_data, default_backend())
+    san = cert.extensions.get_extension_for_oid(x509.oid.ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
+    cert_data[title] = {
+        'cert_names': san.value.get_values_for_type(x509.DNSName),
+        'days_to_expiration': (cert.not_valid_after - datetime.today()).days,
+    }
+
+print('le_cert_info=' + json.dumps(cert_data))

--- a/modules/ocf/manifests/ssl/lets_encrypt/dns.pp
+++ b/modules/ocf/manifests/ssl/lets_encrypt/dns.pp
@@ -10,24 +10,30 @@ define ocf::ssl::lets_encrypt::dns(
     content => "${join($domains, ' ')} > ${title}",
   }
 
-  # Only run the dehydrated command to renew the cert if it is old enough (30
-  # days = 2592000 seconds left until it expires). dehydrated does this check
-  # itself, but this should help with puppet error spam a bit (for instance
-  # if Let's Encrypt is down for any reason) and mean that services can
-  # subscribe to this class to reload after new certs are obtained since this
-  # won't refresh unless dehydrated is re-run for some reason.
-  exec { "check ${title} cert expiration":
-    command => '/bin/true',
-    unless  => "openssl x509 -checkend 2592000 -noout -in /var/lib/lets-encrypt/certs/${title}/cert.pem",
-    user    => ocfletsencrypt,
-  } ~>
+  # Only run the dehydrated command to renew the cert if it is old enough, or
+  # missing some domains. dehydrated does the former check itself, but this
+  # should help with puppet error spam a bit (for instance if Let's Encrypt is
+  # down for any reason) and mean that services can subscribe to this class to
+  # reload after new certs are obtained since this won't refresh unless
+  # dehydrated is re-run for some reason.
+
+  $parsed_cert_info = parsejson($::le_cert_info)
+
+  $have_cert_info = $title in $parsed_cert_info
+  if $have_cert_info {
+    $cert_expires_soon = ($parsed_cert_info[$title]['days_to_expiration'] + 0) < 30
+    # we subtract out any domains that are in the cert, and see if any are left
+    $cert_has_all_domains = ($domains - $parsed_cert_info[$title]['cert_names']) =~ Array[String, 0, 0]
+  }
+
   exec { "obtain ${title} cert":
     # This exec can be notified to get it to run dehydrated again, even if the
     # cert will not expire soon.
     command     => '/usr/bin/dehydrated --cron --privkey /etc/ssl/lets-encrypt/le-account.key',
     user        => $owner,
-    refreshonly => true,
     require     => Package['dehydrated-hook-ddns-tsig'],
+    # if the cert's chillin, only exec on notification
+    refreshonly => $have_cert_info and !$cert_expires_soon and $cert_has_all_domains,
     subscribe   => [
       Concat['/var/lib/lets-encrypt/domains.txt'],
       File['/etc/dehydrated/config'],

--- a/modules/ocf/manifests/ssl/lets_encrypt/dns.pp
+++ b/modules/ocf/manifests/ssl/lets_encrypt/dns.pp
@@ -5,6 +5,10 @@ define ocf::ssl::lets_encrypt::dns(
 ) {
   require ocf::ssl::lets_encrypt::dns_common
 
+  # we use this package in the le_cert_info fact, to gather information about
+  # whatever certs are currently present
+  package { 'python3-cryptography':; }
+
   concat::fragment { $title:
     target  => '/var/lib/lets-encrypt/domains.txt',
     content => "${join($domains, ' ')} > ${title}",

--- a/modules/ocf/manifests/ssl/lets_encrypt/dns.pp
+++ b/modules/ocf/manifests/ssl/lets_encrypt/dns.pp
@@ -10,18 +10,16 @@ define ocf::ssl::lets_encrypt::dns(
     content => "${join($domains, ' ')} > ${title}",
   }
 
-  # Only run the dehydrated command to renew the cert if it is old enough, or
-  # missing some domains. dehydrated does the former check itself, but this
-  # should help with puppet error spam a bit (for instance if Let's Encrypt is
-  # down for any reason) and mean that services can subscribe to this class to
-  # reload after new certs are obtained since this won't refresh unless
-  # dehydrated is re-run for some reason.
-
   $parsed_cert_info = parsejson($::le_cert_info)
 
   $have_cert_info = $title in $parsed_cert_info
   if $have_cert_info {
+
+    # if we have info about the current cert, we need to check to make sure that
+    # the cert includes all domains, and that it is not close to expiring
+
     $cert_expires_soon = $parsed_cert_info[$title]['days_to_expiration'] < 30
+
     # we subtract out any domains that are in the cert, and see if any are left
     $cert_has_all_domains = ($domains - $parsed_cert_info[$title]['cert_names']) =~ Array[String, 0, 0]
   }
@@ -32,8 +30,19 @@ define ocf::ssl::lets_encrypt::dns(
     command     => '/usr/bin/dehydrated --cron --privkey /etc/ssl/lets-encrypt/le-account.key',
     user        => $owner,
     require     => Package['dehydrated-hook-ddns-tsig'],
-    # if the cert's chillin, only exec on notification
+
+    # Only run the dehydrated command to renew the cert if it is old enough, or
+    # missing some domains. dehydrated does the former check itself, but this
+    # should help with puppet error spam a bit (for instance if Let's Encrypt is
+    # down for any reason) and mean that services can subscribe to this class to
+    # reload after new certs are obtained since this won't refresh unless
+    # dehydrated is re-run for some reason.
+
     refreshonly => $have_cert_info and !$cert_expires_soon and $cert_has_all_domains,
+
+    # If we have new domains, the dehydrated config changes, or other related
+    # files are updated, we need to re-run dehydrated anyway
+
     subscribe   => [
       Concat['/var/lib/lets-encrypt/domains.txt'],
       File['/etc/dehydrated/config'],

--- a/modules/ocf/manifests/ssl/lets_encrypt/dns.pp
+++ b/modules/ocf/manifests/ssl/lets_encrypt/dns.pp
@@ -21,7 +21,7 @@ define ocf::ssl::lets_encrypt::dns(
 
   $have_cert_info = $title in $parsed_cert_info
   if $have_cert_info {
-    $cert_expires_soon = ($parsed_cert_info[$title]['days_to_expiration'] + 0) < 30
+    $cert_expires_soon = $parsed_cert_info[$title]['days_to_expiration'] < 30
     # we subtract out any domains that are in the cert, and see if any are left
     $cert_has_all_domains = ($domains - $parsed_cert_info[$title]['cert_names']) =~ Array[String, 0, 0]
   }


### PR DESCRIPTION
specifically, make sure to check that the cert that we have will also contain all the requested alternate names

also just make the cert checking code more robust in general imo

resolves #343