### PR TITLE
Change upload-to-box from dav to ftps

### DIFF
--- a/modules/ocf_backups/files/upload-to-box
+++ b/modules/ocf_backups/files/upload-to-box
@@ -105,24 +105,34 @@ def get_access_token(creds):
         return response['access_token']
 
 
-def upload_to_box(creds):
+def upload_to_box(creds, quiet):
     """Uploads the archive to box at the configured location"""
     lftp_cmd = '''
         set ftps:initial-prot ""
         set ftp:ssl-force true
         set ftp:ssl-protect-data true
         open {box_ftp}
-        user ocf@berkeley.edu {passwd}
+        user {email} {passwd}
         mirror -R --parallel={concurr} {archive} {folder}
     '''.format(
         box_ftp=BOX_FTP,
+        email=creds['email'],
         passwd=creds['password'],
         concurr=MAX_CONCURR_UPLOADS,
         archive=ARCHIVE,
         folder=FOLDER,
     )
 
-    subprocess.run(['lftp', '--norc'], input=lftp_cmd.encode()).check_output()
+    if quiet:
+        stdout_pipe = subprocess.DEVNULL
+    else:
+        stdout_pipe = None
+
+    subprocess.run(
+        ['lftp', '--norc'],
+        input=lftp_cmd.encode(),
+        stdout=stdout_pipe,
+    ).check_returncode()
 
 
 def get_folder_id(access_token, folder_name):
@@ -189,12 +199,13 @@ def main(args):
     with open('/opt/share/backups/box-creds.json') as f:
         creds = json.load(f)
 
+    # Used for statistics, shown at the end of the run.
     start_time = time.time()
     file_bytes = sum(os.path.getsize(ARCHIVE + '/' + f) for f in files)
     if not args.quiet:
         print('Uploading {}...'.format(humanize_bytes(file_bytes)))
 
-    upload_to_box(creds)
+    upload_to_box(creds, args.quiet)
 
     # Get a shared link from Box.com's API and share it with certain emails
     access_token = get_access_token(creds)
@@ -202,6 +213,7 @@ def main(args):
     add_collaborators(access_token, folder_id, BOX_EMAILS)
     link = get_shared_link(access_token, folder_id)
 
+    # Print statistics about the backup time, size, and speed
     total_time = time.time() - start_time
     transfer_rate = file_bytes / (1000000 * total_time)
     print('Box.com upload complete!')

--- a/modules/ocf_backups/files/upload-to-box
+++ b/modules/ocf_backups/files/upload-to-box
@@ -4,19 +4,14 @@ import json
 import os
 import subprocess
 import sys
-import threading
 import time
-from collections import defaultdict
-from collections import deque
 from io import BytesIO
-from shutil import get_terminal_size
 
 import pycurl
 import pymysql
 from ocflib.lab.stats import humanize_bytes
 
 ARCHIVE = '/opt/backups/scratch/archive'
-BOX_DAV = 'https://dav.box.com/dav/'
 BOX_EMAILS = [
     'abizer@berkeley.edu',
     'benjamin.zhang@berkeley.edu',
@@ -25,6 +20,7 @@ BOX_EMAILS = [
     'jvperrin@ocf.berkeley.edu',
     'kpeng3.4@berkeley.edu',
 ]
+BOX_FTP = 'ftps://ftp.box.com:990'
 FOLDER = 'ocf-backup-' + time.strftime('%Y-%m-%d')
 MAX_CONCURR_UPLOADS = 10
 
@@ -49,61 +45,6 @@ MAX_CONCURR_UPLOADS = 10
 # new one is returned (when the old one is used). Access tokens only last for
 # around an hour before expiring, so they are only stored in this program's
 # memory and are generated using the refresh token.
-
-
-class BoxUpload:
-
-    def __init__(self, filename, curl_auth):
-        self.filename = filename
-        self.auth = curl_auth
-        self.percentage = 0.0
-        self.bytes_uploaded = 0
-
-    def start(self, conn):
-        """Set curl params for the file to upload"""
-        file_path = ARCHIVE + '/' + self.filename
-        conn.upload = self
-
-        # PROGRESSFUNCTION is deprecated in pycurl >= 7.32.0, so this
-        # should be changed to conn.XFERINFOFUNCTION when we upgrade to stretch
-        conn.setopt(conn.PROGRESSFUNCTION, self.store_progress)
-        conn.setopt(conn.NOPROGRESS, False)
-
-        conn.file_bytes = os.path.getsize(file_path)
-        conn.fp = open(file_path, 'rb')
-
-        conn.setopt(conn.INFILESIZE, conn.file_bytes)
-        conn.setopt(conn.READFUNCTION, conn.fp.read)
-        conn.setopt(conn.UPLOAD, True)
-        conn.setopt(conn.URL, '{}{}/{}'.format(BOX_DAV, FOLDER, self.filename))
-        conn.setopt(conn.USERPWD, self.auth)
-
-    def store_progress(self, download_t, download_d, upload_t, upload_d):
-        """Store the upload progress percentage for periodic printing.
-
-        Passed to pycurl as a progress function for each upload
-        """
-        self.bytes_uploaded = upload_d
-        if upload_t > 0:
-            self.percentage = 100 * (upload_d / upload_t)
-
-    def get_progress(self, terminal_width):
-        """Get a nice progress bar including the file and percent complete
-
-        The progress bar has a dynamic width, so it must be constructed by
-        figuring out the correct width based on other data shown
-        """
-        first_half = '{} ['.format(self.filename)
-        second_half = '] {:.2f}%'.format(self.percentage)
-        width = terminal_width - len(first_half) - len(second_half)
-        filled = int(width * self.percentage / 100)
-
-        return '{}{}{}{}'.format(
-            first_half,
-            filled * '#',
-            (width - filled) * ' ',
-            second_half
-        )
 
 
 def box_api_call(url, data='', headers=[], method=''):
@@ -164,6 +105,26 @@ def get_access_token(creds):
         return response['access_token']
 
 
+def upload_to_box(creds):
+    """Uploads the archive to box at the configured location"""
+    lftp_cmd = '''
+        set ftps:initial-prot ""
+        set ftp:ssl-force true
+        set ftp:ssl-protect-data true
+        open {box_ftp}
+        user ocf@berkeley.edu {passwd}
+        mirror -R --parallel={concurr} {archive} {folder}
+    '''.format(
+        box_ftp=BOX_FTP,
+        passwd=creds['password'],
+        concurr=MAX_CONCURR_UPLOADS,
+        archive=ARCHIVE,
+        folder=FOLDER,
+    )
+
+    subprocess.run(['lftp', '--norc'], input=lftp_cmd.encode()).check_output()
+
+
 def get_folder_id(access_token, folder_name):
     """Get the ID for a folder with a specific name in the root folder"""
     response = box_api_call('https://api.box.com/2.0/folders/0/items?limit=1000',
@@ -205,83 +166,6 @@ def get_shared_link(access_token, folder_id):
     return response['shared_link']['url']
 
 
-def make_box_folder(folder, auth):
-    """Make a folder on Box.com using the MKCOL HTTP request method"""
-    conn = pycurl.Curl()
-
-    conn.setopt(conn.CUSTOMREQUEST, 'MKCOL')
-    conn.setopt(conn.USERPWD, auth)
-    conn.setopt(conn.URL, BOX_DAV + folder)
-    conn.perform()
-
-    http_status = conn.getinfo(pycurl.HTTP_CODE)
-    conn.close()
-
-    if http_status == 405:
-        print('Could not create a folder, it already exists, continuing...')
-    elif http_status == 401:
-        print('401 error trying to create a folder, check your authentication!')
-        sys.exit(2)
-    elif http_status != 201:
-        print('Error creating folder, HTTP ' + str(http_status))
-        sys.exit(3)
-
-
-def print_progress(multi, stats):
-    """Show an updating progress bar for all ongoing uploads"""
-    subprocess.call(['clear'])
-    prev_total = 0
-    while stats['num_finished'] < stats['num_total']:
-        width = get_terminal_size((80, 20)).columns  # Default size as a fallback
-
-        # Move cursor to the top left using ANSI magic to overwrite previous lines
-        sys.stdout.write('\033[1;1H')
-
-        bytes_partial = 0
-        for conn in multi.handles:
-            if conn.upload:
-                print(conn.upload.get_progress(width))
-                bytes_partial += conn.upload.bytes_uploaded
-
-        bytes_total = stats['bytes_uploaded'] + bytes_partial
-
-        # Print statistics on upload time and current speed
-        time_stats = 'Time so far: {}  Speed: {:.0f} Mb/s'.format(
-            friendly_time(time.time() - stats['start_time']),
-            (bytes_total - prev_total) * 0.000008
-        )
-        print(time_stats + (width - len(time_stats)) * ' ')
-
-        # Print more stats, this time on amount uploaded
-        upload_stats = 'Uploaded {}/{} files and {}/{} ({:.2f}%) in total'.format(
-            stats['num_finished'],
-            stats['num_total'],
-            humanize_bytes(bytes_total),
-            humanize_bytes(stats['bytes_total']),
-            100 * bytes_total / stats['bytes_total']
-        )
-        print(upload_stats + (width - len(upload_stats)) * ' ')
-
-        # If there are less progress bars now, add blank rows to overwrite the
-        # bottom rows as necessary (to get rid of lines with outdated information)
-        blank_rows = len(multi.free)
-        for row in range(blank_rows):
-            print(' ' * width)
-
-        prev_total = bytes_total
-        time.sleep(1)
-
-
-def reset_connection(multi, conn):
-    """Resets a pycurl connection object to be used again"""
-    conn.fp.close()
-    multi.remove_handle(conn)
-    conn.upload = None
-    conn.fp = None
-    conn.file_bytes = 0
-    multi.free.append(conn)
-
-
 def friendly_time(seconds):
     """Show seconds in terms of larger units for easier reading"""
     times = [('seconds', 60), ('minutes', 60), ('hours', 24), ('days', 365)]
@@ -305,119 +189,12 @@ def main(args):
     with open('/opt/share/backups/box-creds.json') as f:
         creds = json.load(f)
 
-    auth = creds['email'] + ':' + creds['password']
-
-    # Make a new folder for the backup
-    if not args.quiet:
-        print('Creating folder ' + FOLDER + ' on Box.com...')
-
-    make_box_folder(FOLDER, auth)
-
-    # Start timer for upload speed and get total upload size
+    start_time = time.time()
     file_bytes = sum(os.path.getsize(ARCHIVE + '/' + f) for f in files)
     if not args.quiet:
         print('Uploading {}...'.format(humanize_bytes(file_bytes)))
-        time.sleep(3)
 
-    start_time = time.time()
-
-    multi = pycurl.CurlMulti()
-    multi.handles = []
-    multi.free = []
-    stats = {
-        'num_finished': 0,
-        'num_total': len(files),
-        'bytes_uploaded': 0,
-        'bytes_total': file_bytes,
-        'start_time': start_time,
-    }
-
-    # Create free connection handlers that can be reused
-    for i in range(MAX_CONCURR_UPLOADS):
-        conn = pycurl.Curl()
-        conn.fp = None
-        conn.upload = None
-        conn.file_bytes = 0
-        multi.handles.append(conn)
-        multi.free.append(conn)
-
-    # Make a queue of all files to be uploaded
-    queue = deque(files)
-
-    # Error dictionary for number of errored uploads per file
-    num_errors = defaultdict(int)
-
-    # Clear the screen and start printing the progress bar every second
-    if not args.quiet:
-        progress_thread = threading.Thread(target=print_progress, args=(multi, stats), daemon=True)
-        progress_thread.start()
-
-    while stats['num_finished'] < len(files):
-        # Add uploads if there are connections free to use
-        while queue and multi.free:
-            filename = queue.popleft()
-            conn = multi.free.pop()
-            upload = BoxUpload(filename, auth)
-            upload.start(conn)
-            multi.add_handle(conn)
-
-        # Run curl's internal state machine
-        while True:
-            ret, num_handles = multi.perform()
-            if ret != pycurl.E_CALL_MULTI_PERFORM:
-                break
-
-        # Check for successful or failed curl connections and free them again
-        while True:
-            num_queued, ok_list, err_list = multi.info_read()
-
-            # Free up connections from files that have finished
-            for conn in ok_list:
-                stats['bytes_uploaded'] += conn.file_bytes
-                reset_connection(multi, conn)
-
-            # Retry files that have errored in some way
-            for conn, errno, errmsg in err_list:
-                filename = conn.upload.filename
-
-                if not args.quiet:
-                    print('Error uploading {}: Curl error #{} {}'.format(
-                        filename,
-                        errno,
-                        errmsg
-                    ))
-
-                # Allow exits by SIGINT
-                if (errno == pycurl.E_ABORTED_BY_CALLBACK):
-                    sys.exit(4)
-
-                # Retry this file if it hasn't errored too many times
-                if num_errors[filename] < 5:
-                    num_errors[filename] += 1
-                    if not args.quiet:
-                        print('Retrying {}'.format(filename))
-                    queue.appendleft(filename)
-                else:
-                    print('Could not upload {}, errored too many times'.format(filename))
-                    stats['num_finished'] += 1
-
-                reset_connection(multi, conn)
-
-            stats['num_finished'] += len(ok_list)
-
-            # Move on if no more connections need freeing
-            if num_queued == 0:
-                break
-
-        # Wait for more data to be available
-        multi.select(1.0)
-
-    # Clean up any open files and connections
-    for conn in multi.handles:
-        if conn.fp:
-            conn.fp.close()
-        conn.close()
-    multi.close()
+    upload_to_box(creds)
 
     # Get a shared link from Box.com's API and share it with certain emails
     access_token = get_access_token(creds)
@@ -425,17 +202,12 @@ def main(args):
     add_collaborators(access_token, folder_id, BOX_EMAILS)
     link = get_shared_link(access_token, folder_id)
 
-    # Print statistics about the backup time, size, and speed
-    if not args.quiet:
-        progress_thread.join()
-        subprocess.call(['clear'])
-
     total_time = time.time() - start_time
     transfer_rate = file_bytes / (1000000 * total_time)
     print('Box.com upload complete!')
     print('Took {} to transfer {} files with combined size {}'.format(
         friendly_time(total_time),
-        stats['num_total'],
+        len(files),
         humanize_bytes(file_bytes)
     ))
     print('Average rate of {:.2f} Mb/s ({:.2f} MB/s)'.format(

--- a/modules/ocf_backups/manifests/offsite.pp
+++ b/modules/ocf_backups/manifests/offsite.pp
@@ -1,6 +1,6 @@
 # Things for helping with offsite backups.
 class ocf_backups::offsite {
-  package { 'python3-pycurl':; }
+  package { ['lftp', 'python3-pycurl']:; }
 
   file {
     '/opt/share/backups/create-encrypted-backup':


### PR DESCRIPTION
Resolves #367 and #398. The script now uses the `lftp` binary to upload files to Box, which lets us get rid of a lot of custom upload code. I also got rid of code related to the progress bar, since `lftp` has its own mechanism for showing progress.

This has been semi-tested with a small folder I made on `hal` (`/opt/backups/scratch/dkessler`). It's accessible at https://berkeley.box.com/s/9nw4saovck21j75xhf1z1nddgmj78scf for those who have access to backups.