### PR TITLE
add reptyr

### DIFF
--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -116,6 +116,7 @@ class ocf::packages {
     'python3-requests',
     'python3-tabulate',
     'quota',
+    'reptyr',
     'screen',
     'systemd-sysv',
     'tcpdump',


### PR DESCRIPTION
Reasoning for this:

sleep 1000 ; [Ctrl+Z] ; bg ; disown ; tmux ; reptyr $(pidof sleep) 

Since Debian has /proc/sys/kernel/yama/ptrace_scope set to 0
by default, no further configuration is necessary.