### PR TITLE
Add noreply to examine-mail exceptions

### DIFF
--- a/modules/ocf_mail/files/spam/logging/examine-mail-log
+++ b/modules/ocf_mail/files/spam/logging/examine-mail-log
@@ -16,7 +16,7 @@ REGEX_EXTRACT_DOMAIN = re.compile('^.*@(.*)$')
 REGEX_EXTRACT_USER = re.compile('^(.*)@.*$')
 
 # users that others are allowed to send mail as
-USER_EXCEPTIONS = {'root', 'apache', 'wordpress', 'decal'}
+USER_EXCEPTIONS = {'root', 'apache', 'wordpress', 'decal', 'noreply'}
 
 # users that are allowed to send infinite mail and impersonate others
 SYSTEM_USERS = {'ocfweb'}


### PR DESCRIPTION
This is following some discussion on a message on the root@ mailing list. This seems to fit in the list of "not real" email addresses that users might send mail from.