### PR TITLE
Hide ocfweb metrics with external apache

### DIFF
--- a/modules/ocf_www/manifests/site/www.pp
+++ b/modules/ocf_www/manifests/site/www.pp
@@ -47,6 +47,8 @@ class ocf_www::site::www {
           '%{REQUEST_URI} !^/~',
           # ...and not if it's a special Apache thing (e.g. autoindex icons)
           '%{REQUEST_URI} !^/icons/',
+          # ...hide ocfweb metrics
+          '%{REQUEST_URI} !^/metrics',
         ],
         rewrite_rule => '^/(.*)$ http://lb.ocf.berkeley.edu:10002/$1 [P]',
       }


### PR DESCRIPTION
This helps [ocfweb#434](https://github.com/ocf/ocfweb/pull/434), by disallowing viewing the metrics endpoint from the public internet. However, users on tsunami can get around this by talking to the loadbalancer directly. Perhaps we should disallow the DMZ from accessing lb ports entirely?