### PR TITLE
Remove centos-debuginfo mirror

### DIFF
--- a/modules/ocf_mirrors/files/project/centos-debuginfo/sync-archive
+++ b/modules/ocf_mirrors/files/project/centos-debuginfo/sync-archive
@@ -1,2 +1,0 @@
-#!/bin/sh -eu
-/usr/local/bin/rsync-no-vanished -aqzH --delete --exclude "4" --exclude "5" debuginfo.centos.org::centos-debuginfo /opt/mirrors/ftp/centos-debuginfo

--- a/modules/ocf_mirrors/files/rsyncd.conf
+++ b/modules/ocf_mirrors/files/rsyncd.conf
@@ -25,10 +25,6 @@ dont compress = *.gz *.tgz *.zip *.z *.rpm *.deb *.iso *.bz2 *.tbz
 	comment = centos altarch mirror
 	path = /opt/mirrors/ftp/centos-altarch
 
-[centos-debuginfo]
-	comment = centos debuginfo mirror
-	path = /opt/mirrors/ftp/centos-debuginfo
-
 [debian]
 	comment = debian package mirror
 	path = /opt/mirrors/ftp/debian

--- a/modules/ocf_mirrors/manifests/centos_debuginfo.pp
+++ b/modules/ocf_mirrors/manifests/centos_debuginfo.pp
@@ -11,15 +11,13 @@ class ocf_mirrors::centos_debuginfo {
   ocf_mirrors::monitoring {
     'centos-debuginfo':
       type          => 'unix_timestamp',
-      upstream_host => 'debuginfo.centos.org',
+      ensure        => absent,
       upstream_path => '/',
+      upstream_host => 'debuginfo.centos.org',
       ts_path       => 'TIME';
   }
 
-  ocf_mirrors::timer {
-    'centos-debuginfo':
-      exec_start => '/opt/mirrors/project/centos-debuginfo/sync-archive',
-      hour       => '0/3',
-      minute     => '56';
+  ocf::systemd::timer { 'centos-debuginfo':
+    ensure => absent;
   }
 }

--- a/modules/ocf_mirrors/manifests/centos_debuginfo.pp
+++ b/modules/ocf_mirrors/manifests/centos_debuginfo.pp
@@ -10,8 +10,8 @@ class ocf_mirrors::centos_debuginfo {
 
   ocf_mirrors::monitoring {
     'centos-debuginfo':
-      type          => 'unix_timestamp',
       ensure        => absent,
+      type          => 'unix_timestamp',
       upstream_path => '/',
       upstream_host => 'debuginfo.centos.org',
       ts_path       => 'TIME';

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -10,6 +10,7 @@ class ocf_mirrors {
   include ocf_mirrors::archlinux
   include ocf_mirrors::centos
   include ocf_mirrors::centos_altarch
+  include ocf_mirrors::centos_debuginfo
   include ocf_mirrors::debian
   include ocf_mirrors::finnix
   include ocf_mirrors::firewall_input

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -10,7 +10,6 @@ class ocf_mirrors {
   include ocf_mirrors::archlinux
   include ocf_mirrors::centos
   include ocf_mirrors::centos_altarch
-  include ocf_mirrors::centos_debuginfo
   include ocf_mirrors::debian
   include ocf_mirrors::finnix
   include ocf_mirrors::firewall_input


### PR DESCRIPTION
This mirror has been "out of date" for weeks now, and apparently it was never supposed to be used, according to https://lists.centos.org/pipermail/centos-mirror/2018-December/011418.html.

I'm pretty sure this PR properly removes the mirror, but please lmk if I missed anything.