### PR TITLE
Add prune-old-backups script

### DIFF
--- a/modules/ocf_backups/files/prune-old-backups
+++ b/modules/ocf_backups/files/prune-old-backups
@@ -10,8 +10,9 @@ import textwrap
 
 RETENTION_TIME = datetime.timedelta(days=180) # 6 months
 
-BOX_FTP = 'ftps://ftp.box.com:990'
 BACKUP_PREFIX = 'ocf-backup-'
+BOX_FTP = 'ftps://ftp.box.com:990'
+CREDS_PATH = '/opt/share/backups/box-creds.json'
 
 LFTP_INIT = '''
     set ftps:initial-prot ""
@@ -78,7 +79,7 @@ def is_old_backup(filename):
     return datetime.date.today() - backup_date > RETENTION_TIME
 
 def main(args):
-    with open('/opt/share/backups/box-creds.json') as f:
+    with open(CREDS_PATH) as f:
         creds = json.load(f)
 
     items = set(list_items(creds))
@@ -93,8 +94,8 @@ def main(args):
         print('Items to delete:')
         print(textwrap.indent('\n'.join(sorted(to_delete)), '  '))
 
-    if args.dry_run:
-        return
+    if not args.dry_run:
+        delete_items(to_delete)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Prune old Box.com backups')

--- a/modules/ocf_backups/files/prune-old-backups
+++ b/modules/ocf_backups/files/prune-old-backups
@@ -102,7 +102,7 @@ def main():
 
 
     if not args.dry_run:
-        delete_items(to_delete)
+        delete_items(creds, to_delete, args.quiet)
 
 if __name__ == '__main__':
     main()

--- a/modules/ocf_backups/files/prune-old-backups
+++ b/modules/ocf_backups/files/prune-old-backups
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+import argparse
+import datetime
+import json
+import shlex
+import subprocess
+import sys
+import textwrap
+
+RETENTION_TIME = datetime.timedelta(days=180) # 6 months
+
+BOX_FTP = 'ftps://ftp.box.com:990'
+BACKUP_PREFIX = 'ocf-backup-'
+
+LFTP_INIT = '''
+    set ftps:initial-prot ""
+    set ftp:ssl-force true
+    set ftp:ssl-protect-data true
+    open {box_ftp}
+    user {email} {passwd}
+'''
+
+def parse_date(dtstr):
+    """Converts a 'YYYY-MM-DD' formatted string to a datetime.date object."""
+    if len(dtstr) != 10:
+        raise ValueError
+
+    year = int(dtstr[0:4])
+
+    if dtstr[4] != '-':
+        raise ValueError
+
+    month = int(dtstr[5:7])
+
+    if dtstr[7] != '-':
+        raise ValueError
+
+    day = int(dtstr[8:10])
+
+    return datetime.date(year, month, day)
+
+def list_items(creds):
+    """List all items at the root of the Box.com folder."""
+    lftp_cmd = (LFTP_INIT + 'renlist').format(
+        box_ftp=BOX_FTP,
+        email=creds['email'],
+        passwd=creds['password'],
+    )
+
+    p = subprocess.run(
+        ['lftp', '--norc'],
+        input=lftp_cmd.encode(),
+        stdout=subprocess.PIPE,
+    )
+
+    p.check_returncode()
+
+    return p.stdout.decode().splitlines()
+
+def delete_items(creds, items, quiet):
+    lftp_cmd = (LFTP_INIT + 'rm -r {items}').format(
+        box_ftp=BOX_FTP,
+        email=creds['email'],
+        passwd=creds['password'],
+        items=' '.join(shlex.quote(item) for item in items)
+    )
+
+    if quiet:
+        stdout_pipe = subprocess.DEVNULL
+    else:
+        stdout_pipe = None
+
+    p = subprocess.run(
+        ['lftp', '--norc'],
+        input=lftp_cmd.encode(),
+        stdout=stdout_pipe
+    ).check_returncode()
+
+def is_old_backup(filename):
+    """Returns true if this backup is old enough to be deleted."""
+    start, _, end = filename.partition(BACKUP_PREFIX)
+
+    # Not a backup
+    if start:
+        return False
+
+    try:
+        backup_date = parse_date(end)
+    except ValueError:
+        return False
+
+    return datetime.date.today() - backup_date > RETENTION_TIME
+
+def main(args):
+    with open('/opt/share/backups/box-creds.json') as f:
+        creds = json.load(f)
+
+    items = set(list_items(creds))
+
+    to_delete = {item for item in items if is_old_backup(item)}
+
+    if not args.quiet:
+        print('Items to keep:')
+        print(textwrap.indent('\n'.join(sorted(items - to_delete)), '  '))
+        print()
+
+        print('Items to delete:')
+        print(textwrap.indent('\n'.join(sorted(to_delete)), '  '))
+
+    if args.dry_run:
+        return
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Prune old Box.com backups')
+    parser.add_argument(
+        '-n', '--dry-run',
+        action='store_true',
+        help='Show which backups would be deleted, but do not delete.'
+    )
+    parser.add_argument(
+        '-q', '--quiet',
+        action='store_true',
+        help='do not output progress or information to stdout',
+    )
+
+    args = parser.parse_args()
+    sys.exit(main(args))

--- a/modules/ocf_backups/files/prune-old-backups
+++ b/modules/ocf_backups/files/prune-old-backups
@@ -20,48 +20,41 @@ LFTP_INIT = '''
     set ftp:ssl-protect-data true
     open {box_ftp}
     user {email} {passwd}
+    {command}
 '''
 
 def parse_date(dtstr):
     """Converts a 'YYYY-MM-DD' formatted string to a datetime.date object."""
     return datetime.datetime.strptime(dtstr, "%Y-%m-%d").date()
 
+def lftp_cmd(creds, command, out=subprocess.PIPE):
+    """Runs an lftp command and returns the output as a binary string."""
+    cmd = LFTP_INIT.format(
+        box_ftp=BOX_FTP,
+        email=creds['email'],
+        passwd=creds['password'],
+        command=command,
+    )
+
+    p = subprocess.run(['lftp', '--norc'], input=cmd.encode(), stdout=out)
+    p.check_returncode()
+    return p.stdout
+
 def list_items(creds):
     """List all items at the root of the Box.com folder."""
-    lftp_cmd = (LFTP_INIT + 'renlist').format(
-        box_ftp=BOX_FTP,
-        email=creds['email'],
-        passwd=creds['password'],
-    )
-
-    p = subprocess.run(
-        ['lftp', '--norc'],
-        input=lftp_cmd.encode(),
-        stdout=subprocess.PIPE,
-    )
-
-    p.check_returncode()
-
-    return p.stdout.decode().splitlines()
+    return lftp_cmd(creds, 'renlist').decode().splitlines()
 
 def delete_items(creds, items, quiet):
-    lftp_cmd = (LFTP_INIT + 'rm -r {items}').format(
-        box_ftp=BOX_FTP,
-        email=creds['email'],
-        passwd=creds['password'],
-        items=' '.join(shlex.quote(item) for item in items)
-    )
-
     if quiet:
         stdout_pipe = subprocess.DEVNULL
     else:
         stdout_pipe = None
 
-    p = subprocess.run(
-        ['lftp', '--norc'],
-        input=lftp_cmd.encode(),
-        stdout=stdout_pipe
-    ).check_returncode()
+    lftp_cmd(
+        creds,
+        'rm -r ' + ' '.join(shlex.quote(item) for item in items),
+        out=stdout_pipe,
+    )
 
 def is_old_backup(filename):
     """Returns true if this backup is old enough to be deleted."""
@@ -87,12 +80,13 @@ def main(args):
     to_delete = {item for item in items if is_old_backup(item)}
 
     if not args.quiet:
-        print('Items to keep:')
-        print(textwrap.indent('\n'.join(sorted(items - to_delete)), '  '))
-        print()
-
         print('Items to delete:')
         print(textwrap.indent('\n'.join(sorted(to_delete)), '  '))
+        print()
+
+        print('Items to keep:')
+        print(textwrap.indent('\n'.join(sorted(items - to_delete)), '  '))
+
 
     if not args.dry_run:
         delete_items(to_delete)

--- a/modules/ocf_backups/files/prune-old-backups
+++ b/modules/ocf_backups/files/prune-old-backups
@@ -44,6 +44,11 @@ def list_items(creds):
     return lftp_cmd(creds, 'renlist').decode().splitlines()
 
 def delete_items(creds, items, quiet):
+    if not items:
+        if not quiet:
+            print('Nothing to delete')
+        return
+
     if quiet:
         stdout_pipe = subprocess.DEVNULL
     else:
@@ -99,7 +104,6 @@ def main():
 
         print('Items to keep:')
         print(textwrap.indent('\n'.join(sorted(items - to_delete)), '  '))
-
 
     if not args.dry_run:
         delete_items(creds, to_delete, args.quiet)

--- a/modules/ocf_backups/files/prune-old-backups
+++ b/modules/ocf_backups/files/prune-old-backups
@@ -5,7 +5,6 @@ import datetime
 import json
 import shlex
 import subprocess
-import sys
 import textwrap
 
 RETENTION_TIME = datetime.timedelta(days=180) # 6 months
@@ -106,4 +105,4 @@ def main():
         delete_items(to_delete)
 
 if __name__ == '__main__':
-    sys.exit(main())
+    main()

--- a/modules/ocf_backups/files/prune-old-backups
+++ b/modules/ocf_backups/files/prune-old-backups
@@ -71,7 +71,21 @@ def is_old_backup(filename):
 
     return datetime.date.today() - backup_date > RETENTION_TIME
 
-def main(args):
+def main():
+    parser = argparse.ArgumentParser(description='Prune old Box.com backups')
+    parser.add_argument(
+        '-n', '--dry-run',
+        action='store_true',
+        help='Show which backups would be deleted, but do not delete.'
+    )
+    parser.add_argument(
+        '-q', '--quiet',
+        action='store_true',
+        help='Do not output progress or information to stdout.',
+    )
+
+    args = parser.parse_args()
+
     with open(CREDS_PATH) as f:
         creds = json.load(f)
 
@@ -92,17 +106,4 @@ def main(args):
         delete_items(to_delete)
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Prune old Box.com backups')
-    parser.add_argument(
-        '-n', '--dry-run',
-        action='store_true',
-        help='Show which backups would be deleted, but do not delete.'
-    )
-    parser.add_argument(
-        '-q', '--quiet',
-        action='store_true',
-        help='Do not output progress or information to stdout.',
-    )
-
-    args = parser.parse_args()
-    sys.exit(main(args))
+    sys.exit(main())

--- a/modules/ocf_backups/files/prune-old-backups
+++ b/modules/ocf_backups/files/prune-old-backups
@@ -23,22 +23,7 @@ LFTP_INIT = '''
 
 def parse_date(dtstr):
     """Converts a 'YYYY-MM-DD' formatted string to a datetime.date object."""
-    if len(dtstr) != 10:
-        raise ValueError
-
-    year = int(dtstr[0:4])
-
-    if dtstr[4] != '-':
-        raise ValueError
-
-    month = int(dtstr[5:7])
-
-    if dtstr[7] != '-':
-        raise ValueError
-
-    day = int(dtstr[8:10])
-
-    return datetime.date(year, month, day)
+    return datetime.datetime.strptime(dtstr, "%Y-%m-%d").date()
 
 def list_items(creds):
     """List all items at the root of the Box.com folder."""

--- a/modules/ocf_backups/files/prune-old-backups
+++ b/modules/ocf_backups/files/prune-old-backups
@@ -107,7 +107,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '-q', '--quiet',
         action='store_true',
-        help='do not output progress or information to stdout',
+        help='Do not output progress or information to stdout.',
     )
 
     args = parser.parse_args()

--- a/modules/ocf_backups/manifests/offsite.pp
+++ b/modules/ocf_backups/manifests/offsite.pp
@@ -35,5 +35,11 @@ class ocf_backups::offsite {
       weekday => '6',
       hour    => '12',
       minute  => '0';
+
+    'prune-old-backups':
+      command => 'chronic /opt/share/backups/prune-old-backups',
+      user    => root,
+      hour    => '0',
+      minute  => '0';
   }
 }

--- a/modules/ocf_backups/manifests/offsite.pp
+++ b/modules/ocf_backups/manifests/offsite.pp
@@ -11,6 +11,10 @@ class ocf_backups::offsite {
       source => 'puppet:///modules/ocf_backups/upload-to-box',
       mode   => '0755';
 
+    '/opt/share/backups/prune-old-backups':
+      source => 'puppet:///modules/ocf_backups/prune-old-backups',
+      mode   => '0755';
+
     '/opt/share/backups/keys':
       ensure  => directory,
       source  => 'puppet:///modules/ocf_backups/keys',


### PR DESCRIPTION
This script removes old backups. Going to wait for a lot of approvals and scrutiny before I even add the code to run this on a cronjob, since this is script has potential to be very destructive. 

I haven't fully tested the script, but I can confirm that a dry run works (displays the correct information), and I can confirm that running `prune_old_backups.delete_items(creds, ['ocf-backup-2016-06-09', 'ocf-backup-2016-07-25'], False)` in an interactive shell works.