### PR TITLE
Check for ValueError in process-mirrors-logs

### DIFF
--- a/modules/ocf_mirrors/files/process-mirrors-logs
+++ b/modules/ocf_mirrors/files/process-mirrors-logs
@@ -23,7 +23,10 @@ def process_log(dists, fn, log_date):
             # line.split()[3][1:12] = 11/Jul/2017
             # we need to dump dates that don't match because
             # logrotate rotates the logs at 6am
-            line_date = datetime.strptime(stats[3][1:12], '%d/%b/%Y')
+            try:
+                line_date = datetime.strptime(stats[3][1:12], '%d/%b/%Y')
+            except ValueError:
+                continue
             if line_date.date() != log_date:
                 continue
 

--- a/modules/ocf_mirrors/files/process-mirrors-logs
+++ b/modules/ocf_mirrors/files/process-mirrors-logs
@@ -4,6 +4,7 @@ import os
 from datetime import date
 from datetime import timedelta
 from datetime import datetime
+import traceback
 
 import pymysql
 
@@ -14,9 +15,7 @@ LOG_NAMES = ['mirrors.ocf.berkeley.edu_access.log', 'mirrors.ocf.berkeley.edu-ss
 
 def process_log(dists, fn, log_date):
     with open(fn, 'r') as f:
-        n = 0
-        for line in f:
-            n += 1
+        for n, line in enumerate(f, 1):
             stats = line.split()
 
             # apache log date format looks like [11/Jul/2017:00:05:16 -0700]
@@ -26,7 +25,9 @@ def process_log(dists, fn, log_date):
             try:
                 line_date = datetime.strptime(stats[3][1:12], '%d/%b/%Y')
             except ValueError:
-                continue
+                print('Error on line {}:\\  {}\\'.format(n, line))
+                traceback.print_exc()
+
             if line_date.date() != log_date:
                 continue
 


### PR DESCRIPTION
Got some rootspam about this last night. Probably a small one-off thing and we don't want the whole script to crash because of it.