### PR TITLE
Redirect any SSL aliases too in nginx_proxy

### DIFF
--- a/modules/ocf/manifests/nginx_proxy.pp
+++ b/modules/ocf/manifests/nginx_proxy.pp
@@ -42,7 +42,6 @@ define ocf::nginx_proxy(
           # HSTS header
           'Strict-Transport-Security' => 'max-age=31536000',
         }, $headers),
-
         *                => $nginx_options;
 
       "${title}-redirect":
@@ -51,8 +50,6 @@ define ocf::nginx_proxy(
           'return' => "301 https://${server_name}\$request_uri"
         },
 
-        # We have to specify www_root even though we always redirect/proxy
-        www_root          => '/var/www',
         add_header        => $headers,
         *                 => $nginx_options;
     }
@@ -76,8 +73,6 @@ define ocf::nginx_proxy(
             'Strict-Transport-Security' => 'max-age=31536000',
           }, $headers),
 
-          # We have to specify www_root even though we always redirect/proxy
-          www_root          => '/var/www',
           *                 => $nginx_options;
       }
     }

--- a/modules/ocf/manifests/nginx_proxy.pp
+++ b/modules/ocf/manifests/nginx_proxy.pp
@@ -46,18 +46,40 @@ define ocf::nginx_proxy(
         *                => $nginx_options;
 
       "${title}-redirect":
-        # We have to specify www_root even though we always redirect/proxy
-        www_root          => '/var/www',
-
         server_name       => concat([$server_name], $server_aliases),
-
         server_cfg_append => {
           'return' => "301 https://${server_name}\$request_uri"
         },
 
+        # We have to specify www_root even though we always redirect/proxy
+        www_root          => '/var/www',
         add_header        => $headers,
-
         *                 => $nginx_options;
+    }
+
+    if size($server_aliases) > 0 {
+      nginx::resource::server {
+        "${title}-aliases-redirect":
+          server_name       => $server_aliases,
+          server_cfg_append => {
+            'return' => "301 https://${server_name}\$request_uri"
+          },
+
+          listen_port       => 443,
+          ssl               => true,
+          ssl_cert          => $ssl_cert,
+          ssl_key           => $ssl_key,
+          ssl_dhparam       => $ssl_dhparam,
+
+          add_header        => merge({
+            # HSTS header
+            'Strict-Transport-Security' => 'max-age=31536000',
+          }, $headers),
+
+          # We have to specify www_root even though we always redirect/proxy
+          www_root          => '/var/www',
+          *                 => $nginx_options;
+      }
     }
   } else {
     nginx::resource::server { $title:

--- a/modules/ocf_mesos/manifests/master/load_balancer.pp
+++ b/modules/ocf_mesos/manifests/master/load_balancer.pp
@@ -71,7 +71,7 @@ class ocf_mesos::master::load_balancer($marathon_http_password) {
 
   ocf_mesos::master::load_balancer::http_vhost { 'rt':
     server_name    => 'rt.ocf.berkeley.edu',
-    server_aliases => ['rt'],
+    server_aliases => ['rt', 'rt.ocf.io'],
     service_port   => 10001,
   }
 

--- a/modules/ocf_mesos/manifests/master/webui.pp
+++ b/modules/ocf_mesos/manifests/master/webui.pp
@@ -147,9 +147,6 @@ class ocf_mesos::master::webui(
       require             => File['/etc/pam.d/mesos_master_webui'];
 
     'mesos-http-redirect':
-      # we have to specify www_root even though we always redirect/proxy
-      www_root          => '/var/www',
-
       server_name       => [$::hostname, $::fqdn, 'mesos', 'mesos.ocf.berkeley.edu'],
       server_cfg_append => {
         'return' => '301 https://mesos.ocf.berkeley.edu$request_uri',
@@ -180,9 +177,6 @@ class ocf_mesos::master::webui(
       require          => File['/etc/pam.d/mesos_master_webui'];
 
     'marathon-http-redirect':
-      # we have to specify www_root even though we always redirect/proxy
-      www_root          => '/var/www',
-
       server_name       => ['marathon', 'marathon.ocf.berkeley.edu'],
       server_cfg_append => {
         'return' => '301 https://marathon.ocf.berkeley.edu$request_uri',
@@ -228,9 +222,6 @@ class ocf_mesos::master::webui(
         ];
 
       "${slave}-agent-http-redirect":
-        # we have to specify www_root even though we always redirect/proxy
-        www_root          => '/var/www',
-
         server_name       => [$host],
         server_cfg_append => {
           'return' => "301 https://${host}\$request_uri",


### PR DESCRIPTION
This just makes sure that if we're making a proxy with SSL that we also listen on SSL for any aliases and redirect them to the canonical domain. This enables domains like http://sg.ocf.io, http://templates.ocf.io, http://grafana.ocf.io, etc. which otherwise wouldn't redirect properly because we have HSTS on for `*.ocf.io`, so the redirect to HTTPS comes before our server is actually contacted.

One assumption made here is that we have a "bundled" certificate for the domain that also contains all aliases within it, which might not be a proper assumption for all proxies.

Funny enough, other servers using nginx_proxy already (sorta) work, for instance https://irc.ocf.io, https://puppet.ocf.io, and https://jenkins.ocf.io work perfectly fine, but only because they fall back to the default vhost in nginx, which happens to be the one listening for SSL and with the correct cert already. However, it doesn't redirect to the canonical domain properly yet, so that would be nice to have.

Closes #464 (for real this time)