### PR TITLE
[WIP] SKS Keyserver

### DIFF
--- a/hieradata/nodes/pgp.yaml
+++ b/hieradata/nodes/pgp.yaml
@@ -1,0 +1,2 @@
+classes:
+    - ocf_keyserver

--- a/modules/ocf_keyserver/files/membership
+++ b/modules/ocf_keyserver/files/membership
@@ -1,1 +1,2 @@
 pgp.librelabucm.org 11370 # LibreLabUCM <librelab@ucm.es> 0x3607372187BA32BC
+keys.andreas-puls.de 11370 # Andreas Puls <appu@gmx.net> 0x0E37D51DDAC73FA6

--- a/modules/ocf_keyserver/files/membership
+++ b/modules/ocf_keyserver/files/membership
@@ -1,2 +1,3 @@
 pgp.librelabucm.org 11370 # LibreLabUCM <librelab@ucm.es> 0x3607372187BA32BC
 keys.andreas-puls.de 11370 # Andreas Puls <appu@gmx.net> 0x0E37D51DDAC73FA6
+key.bbs4.us 11370  # Jonathan Zhang <jonathan@bbs4.us>

--- a/modules/ocf_keyserver/files/membership
+++ b/modules/ocf_keyserver/files/membership
@@ -1,3 +1,4 @@
 pgp.librelabucm.org 11370 # LibreLabUCM <librelab@ucm.es> 0x3607372187BA32BC
 keys.andreas-puls.de 11370 # Andreas Puls <appu@gmx.net> 0x0E37D51DDAC73FA6
 key.bbs4.us 11370  # Jonathan Zhang <jonathan@bbs4.us>
+sks.daylightpirates.org 11370 # Daniel Roesler <diafygi@gmail.com> 0xE7F6FAD172EFEE3D

--- a/modules/ocf_keyserver/files/membership
+++ b/modules/ocf_keyserver/files/membership
@@ -2,3 +2,4 @@ pgp.librelabucm.org 11370 # LibreLabUCM <librelab@ucm.es> 0x3607372187BA32BC
 keys.andreas-puls.de 11370 # Andreas Puls <appu@gmx.net> 0x0E37D51DDAC73FA6
 key.bbs4.us 11370  # Jonathan Zhang <jonathan@bbs4.us>
 sks.daylightpirates.org 11370 # Daniel Roesler <diafygi@gmail.com> 0xE7F6FAD172EFEE3D
+pgpkeys.urown.net 11370 # <keymaster@urown.net> 0x27A69FC9A1744242

--- a/modules/ocf_keyserver/files/membership
+++ b/modules/ocf_keyserver/files/membership
@@ -1,0 +1,1 @@
+pgp.librelabucm.org 11370 # LibreLabUCM <librelab@ucm.es> 0x3607372187BA32BC

--- a/modules/ocf_keyserver/files/sks-keyserver.service
+++ b/modules/ocf_keyserver/files/sks-keyserver.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=OCF SKS Keyserver Instance
+Requires=network-online.target docker.service
+After=docker.service
+
+[Service]
+User=root
+ExecStart=/usr/bin/docker run --rm \
+    -v /var/lib/sks:/var/lib/sks \
+    -p 127.0.0.1:11370:11370/tcp \
+    -p 127.0.0.1:11371:11371/tcp \
+    --name sks-keyserver \
+    zhusj/sks
+Restart=always
+
+[Install]
+WantedBy=docker.service

--- a/modules/ocf_keyserver/files/sks-keyserver.service
+++ b/modules/ocf_keyserver/files/sks-keyserver.service
@@ -1,10 +1,9 @@
 [Unit]
 Description=OCF SKS Keyserver Instance
 Requires=network-online.target docker.service
-After=docker.service
+After=network-online.target docker.service
 
 [Service]
-User=root
 # we proxy hkp from a different port so nginx can claim 11371
 ExecStart=/usr/bin/docker run --rm \
     -v /var/lib/sks:/var/lib/sks \
@@ -15,4 +14,4 @@ ExecStart=/usr/bin/docker run --rm \
 Restart=always
 
 [Install]
-WantedBy=docker.service
+WantedBy=multi-user.target

--- a/modules/ocf_keyserver/files/sks-keyserver.service
+++ b/modules/ocf_keyserver/files/sks-keyserver.service
@@ -5,10 +5,11 @@ After=docker.service
 
 [Service]
 User=root
+# we proxy hkp from a different port so nginx can claim 11371
 ExecStart=/usr/bin/docker run --rm \
     -v /var/lib/sks:/var/lib/sks \
-    -p 127.0.0.1:11370:11370/tcp \
-    -p 127.0.0.1:11371:11371/tcp \
+    -p 0.0.0.0:11370:11370/tcp \
+    -p 127.0.0.1:11372:11371/tcp \
     --name sks-keyserver \
     zhusj/sks
 Restart=always

--- a/modules/ocf_keyserver/manifests/init.pp
+++ b/modules/ocf_keyserver/manifests/init.pp
@@ -1,6 +1,6 @@
 class ocf_keyserver {
+  require ocf::ssl::default
   include ocf::firewall::allow_web
-  include ocf::ssl::default
   include ocf::packages::docker
 
   file {
@@ -12,7 +12,6 @@ class ocf_keyserver {
 
     '/var/lib/sks/membership':
       source  => 'puppet:///modules/ocf_keyserver/membership';
-
   }
 
   ocf::systemd::service { 'sks-keyserver':

--- a/modules/ocf_keyserver/manifests/init.pp
+++ b/modules/ocf_keyserver/manifests/init.pp
@@ -1,0 +1,40 @@
+class ocf_keyserver {
+  include ocf::firewall::allow_web
+  include ocf::ssl::default
+  include ocf::packages::docker
+
+  file {
+    '/var/lib/sks':
+      ensure  => directory;
+
+    '/var/lib/sks/sksconf':
+      content => template('ocf_keyserver/sksconf.erb');
+
+    '/var/lib/sks/membership':
+      source  => 'puppet:///modules/ocf_keyserver/membership';
+
+  }
+
+  ocf::systemd::service { 'sks-keyserver':
+    source  => 'puppet:///modules/ocf_keyserver/sks-keyserver.service',
+    require => [
+      Package['docker-ce'],
+      File['/var/lib/sks'],
+    ];
+  }
+
+  class { 'nginx':
+    manage_repo  => false,
+    confd_purge  => true,
+    server_purge => true;
+  }
+
+  Class['ocf::ssl::default'] ~> Class['Nginx::Service']
+
+  # not using the nginx resource because I can't figure out
+  # how to recreate this config in 'native' puppet-nginx
+  file {
+    '/etc/nginx/sites-enabled/sks-web-proxy.conf':
+      content => template('ocf_keyserver/sks-web-nginx.erb');
+  }
+}

--- a/modules/ocf_keyserver/manifests/init.pp
+++ b/modules/ocf_keyserver/manifests/init.pp
@@ -12,8 +12,7 @@ class ocf_keyserver {
 
     '/var/lib/sks/membership':
       source  => 'puppet:///modules/ocf_keyserver/membership';
-  }
-
+  } ~>
   ocf::systemd::service { 'sks-keyserver':
     source  => 'puppet:///modules/ocf_keyserver/sks-keyserver.service',
     require => [

--- a/modules/ocf_keyserver/manifests/init.pp
+++ b/modules/ocf_keyserver/manifests/init.pp
@@ -35,6 +35,27 @@ class ocf_keyserver {
   # how to recreate this config in 'native' puppet-nginx
   file {
     '/etc/nginx/sites-enabled/sks-web-proxy.conf':
-      content => template('ocf_keyserver/sks-web-nginx.erb');
+      content => template('ocf_keyserver/sks-web-nginx.erb'),
+      notify  => Class['Nginx::Service'];
+  }
+
+  ocf::firewall::firewall46 {
+    '101 allow sks-recon':
+      opts => {
+        chain  => 'PUPPET-INPUT',
+        proto  => ['tcp'],
+        dport  => 11370,
+        action => 'accept',
+      };
+  }
+
+  ocf::firewall::firewall46 {
+    '101 allow sks-hkp':
+      opts => {
+        chain  => 'PUPPET-INPUT',
+        proto  => ['tcp'],
+        dport  => 11371,
+        action => 'accept',
+      };
   }
 }

--- a/modules/ocf_keyserver/templates/sks-web-nginx.erb
+++ b/modules/ocf_keyserver/templates/sks-web-nginx.erb
@@ -1,41 +1,45 @@
 server {
-        listen 80 default_server;
-        listen [::]:80 default_server;
-        listen 443 default_server ssl;
-        listen [::]:443 default_server ssl;
 
-        ssl_certificate /etc/ssl/private/<%= @fqdn %>.bundle;
-        ssl_certificate_key /etc/ssl/private/<%= @fqdn %>.key;
-        ssl_dhparam /etc/ssl/dhparam.pem;
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    listen 443 default_server ssl;
+    listen [::]:443 default_server ssl;
+    listen 11371;
+    listen [::]:11371;
 
-        server_name <%= @fqdn %>;
-        server_name <%= @hostname %>;
-        server_name *.sks-keyservers.net;
-        server_name *.pool.sks-keyservers.net;
-        server_name pgp.mit.edu;
-        server_name keys.gnupg.net;
+    ssl_certificate /etc/ssl/private/<%= @fqdn %>.bundle;
+    ssl_certificate_key /etc/ssl/private/<%= @fqdn %>.key;
+    ssl_dhparam /etc/ssl/dhparam.pem;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 
-        root /var/www/html;
+    server_name _;
+    server_name <%= @fqdn %>;
+    server_name <%= @hostname %>;
+    server_name *.sks-keyservers.net;
+    server_name *.pool.sks-keyservers.net;
+    server_name pgp.mit.edu;
+    server_name keys.gnupg.net;
 
-        rewrite ^/stats /pks/lookup?op=stats;
-        rewrite ^/s/(.*) /pks/lookup?search=$1;
-        rewrite ^/search/(.*) /pks/lookup?search=$1;
-        rewrite ^/g/(.*) /pks/lookup?op=get&search=$1;
-        rewrite ^/get/(.*) /pks/lookup?op=get&search=$1;
-        rewrite ^/d/(.*) /pks/lookup?op=get&options=mr&search=$1;
-        rewrite ^/download/(.*) /pks/lookup?op=get&options=mr&search=$1;
+    root /var/www/html;
 
-        location /pks {
-            proxy_pass         http://127.0.0.1:11371;
-            proxy_pass_header  Server;
-            add_header         Via "1.1 <%= @fqdn %>:11371 (nginx)";
-            proxy_ignore_client_abort on;
-            client_max_body_size 8m;
-        }
+    rewrite ^/stats /pks/lookup?op=stats;
+    rewrite ^/s/(.*) /pks/lookup?search=$1;
+    rewrite ^/search/(.*) /pks/lookup?search=$1;
+    rewrite ^/g/(.*) /pks/lookup?op=get&search=$1;
+    rewrite ^/get/(.*) /pks/lookup?op=get&search=$1;
+    rewrite ^/d/(.*) /pks/lookup?op=get&options=mr&search=$1;
+    rewrite ^/download/(.*) /pks/lookup?op=get&options=mr&search=$1;
 
-        location ~ (.git|LICENSE|readme.md) {
-            deny all;
-            return 404;
-        }
-   }
+    location /pks {
+        proxy_pass         http://127.0.0.1:11372;
+        proxy_pass_header  Server;
+        add_header         Via "1.1 <%= @fqdn %>:11371 (nginx)";
+        proxy_ignore_client_abort on;
+        client_max_body_size 8m;
+    }
+
+    location ~ (.git|LICENSE|readme.md) {
+        deny all;
+        return 404;
+    }
+}

--- a/modules/ocf_keyserver/templates/sks-web-nginx.erb
+++ b/modules/ocf_keyserver/templates/sks-web-nginx.erb
@@ -1,0 +1,41 @@
+server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+        listen 443 default_server ssl;
+        listen [::]:443 default_server ssl;
+
+        ssl_certificate /etc/ssl/private/<%= @fqdn %>.bundle;
+        ssl_certificate_key /etc/ssl/private/<%= @fqdn %>.key;
+        ssl_dhparam /etc/ssl/dhparam.pem;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+
+        server_name <%= @fqdn %>;
+        server_name <%= @hostname %>;
+        server_name *.sks-keyservers.net;
+        server_name *.pool.sks-keyservers.net;
+        server_name pgp.mit.edu;
+        server_name keys.gnupg.net;
+
+        root /var/www/html;
+
+        rewrite ^/stats /pks/lookup?op=stats;
+        rewrite ^/s/(.*) /pks/lookup?search=$1;
+        rewrite ^/search/(.*) /pks/lookup?search=$1;
+        rewrite ^/g/(.*) /pks/lookup?op=get&search=$1;
+        rewrite ^/get/(.*) /pks/lookup?op=get&search=$1;
+        rewrite ^/d/(.*) /pks/lookup?op=get&options=mr&search=$1;
+        rewrite ^/download/(.*) /pks/lookup?op=get&options=mr&search=$1;
+
+        location /pks {
+            proxy_pass         http://127.0.0.1:11371;
+            proxy_pass_header  Server;
+            add_header         Via "1.1 <%= @fqdn %>:11371 (nginx)";
+            proxy_ignore_client_abort on;
+            client_max_body_size 8m;
+        }
+
+        location ~ (.git|LICENSE|readme.md) {
+            deny all;
+            return 404;
+        }
+   }

--- a/modules/ocf_keyserver/templates/sksconf.erb
+++ b/modules/ocf_keyserver/templates/sksconf.erb
@@ -1,0 +1,12 @@
+# from https://github.com/zhsj/dockerfile/blob/master/sks/files/etc/sks/sksconf
+debuglevel: 1
+hostname: <%= @fqdn %>
+server_contact: 0xE2F6B8BAAE028F9B
+recon_address: 0.0.0.0
+recon_port: 11370
+hkp_address: 0.0.0.0
+hkp_port: 11371
+initial_stat:
+disable_mailsync:
+pagesize:          16
+ptree_pagesize:    16


### PR DESCRIPTION
sks-keyserver is running in a docker container provided by an upstream
maintainer, and nginx on the host reverse proxies 80/443 to 11371 (hkp)
I'll expose 11371 itself on nginx as well as another proxied port, and
then work on configuring nginx to reverse proxy the recon port (11370)
as well. the frontend site is not puppeted and is basically this
https://github.com/mattrude/pgpkeyserver-lite cloned into /var/www/html.