### PR TITLE
Add puppet certs to ocfweb dev config

### DIFF
--- a/modules/ocf_ocfweb/manifests/dev_config.pp
+++ b/modules/ocf_ocfweb/manifests/dev_config.pp
@@ -29,5 +29,12 @@ class ocf_ocfweb::dev_config($group = 'ocfstaff') {
       group     => $group,
       mode      => '0640',
       show_diff => false;
+
+    '/etc/ocfweb/puppet-certs':
+      ensure    => 'directory',
+      source    => 'puppet:///private-docker/ocfweb/puppet-certs',
+      recurse   => true,
+      purge     => true,
+      show_diff => false;
   }
 }

--- a/modules/ocf_puppet/manifests/puppetserver.pp
+++ b/modules/ocf_puppet/manifests/puppetserver.pp
@@ -51,6 +51,18 @@ class ocf_puppet::puppetserver {
     notify               => Service['puppetserver'],
   }
 
+  # let anyone get the ocfweb certs
+  puppet_authorization::rule { 'ocfweb-cert':
+    match_request_path   => '^/puppet/v3/file_(content|metadata)s?/private-docker/ocfweb/puppet-certs$',
+    match_request_type   => 'regex',
+    match_request_method => ['get', 'post'],
+    allow                => '*.ocf.berkeley.edu',
+    sort_order           => 500,
+    path                 => '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+    require              => Package['puppetserver'],
+    notify               => Service['puppetserver'],
+  }
+
   file {
     '/etc/puppetlabs/puppet/fileserver.conf':
       source  => 'puppet:///modules/ocf_puppet/fileserver.conf',


### PR DESCRIPTION
This commit lets all machines get access to the ocfweb puppet cert, and makes it part of the ocfweb dev config, so users testing on supernova (or staffvms) can use them.