### PR TITLE
kubernetes: fix etcdctl

### DIFF
--- a/modules/ocf_kubernetes/files/kubeconfig.sh
+++ b/modules/ocf_kubernetes/files/kubeconfig.sh
@@ -1,0 +1,12 @@
+export KUBECONFIG=/etc/kubernetes/admin.conf
+
+# etcd clients require the CA and server cert or it won't trust responses.
+export ETCDCTL_CA_FILE=/etc/kubernetes/pki/etcd/ca.crt
+export ETCDCTL_CERT_FILE=/etc/kubernetes/pki/etcd/server.crt
+# etcd client needs the server key to decrypt responses
+export ETCDCTL_KEY_FILE=/etc/kubernetes/pki/etcd/server.key
+# Node that the endpoint _must_ be the same name for which
+# the etcd certs were generated for with kubetool. If we used
+# the fqdn here, the etcd client would complain that the cert
+# is issued for the hostname only.
+export ETCDCTL_ENDPOINT="https://$(hostname -s):2379"

--- a/modules/ocf_kubernetes/manifests/master.pp
+++ b/modules/ocf_kubernetes/manifests/master.pp
@@ -98,7 +98,8 @@ class ocf_kubernetes::master {
   file {
     '/etc/profile.d/kubeconfig.sh':
       mode    => '0755',
-      content => "export KUBECONFIG=/etc/kubernetes/admin.conf\n";
+      source  => 'puppet:///modules/ocf_kubernetes/kubeconfig.sh',
+      require => Class['kubernetes'],
   }
 
   class { 'ocf_kubernetes::master::ingress::nginx':


### PR DESCRIPTION
etcdctl needs some environment variables to make with it work without
passing a million flags every time we use it. It needs to know the CA
and server certs so the client can authenticate it is talking to a valid
peer. etcd traffic is encrypted so it needs the server key to decrypt
information.

We also need to set the ETCD_ENDPOINT environment variable with the
_same_ endpoint that was passed to kubetool as part of the initial
cluster. This is because kubetool generates the certs for those values.
In our case we just used the hostname.