### PR TITLE
Use systemd timers instead of cron for healthchecks

### DIFF
--- a/modules/ocf_mirrors/files/healthcheck
+++ b/modules/ocf_mirrors/files/healthcheck
@@ -10,6 +10,7 @@ mirrors.kernel.org).
 """
 import argparse
 import sys
+import time
 from collections import namedtuple
 from datetime import datetime
 
@@ -115,6 +116,14 @@ def write_prometheus(project, local, upstream):
         registry=registry,
     )
     updated_local.labels(project=project).set(local.timestamp())
+
+    last_run = Gauge(
+        'mirror_healthcheck_last_run',
+        'When the healthcheck last successfully ran',
+        ['project'],
+        registry=registry,
+    )
+    last_run.labels(project=project).set(time.time())
 
     write_to_textfile(
         '/opt/mirrors/prometheus/{}.prom'.format(project),

--- a/modules/ocf_mirrors/manifests/monitoring.pp
+++ b/modules/ocf_mirrors/manifests/monitoring.pp
@@ -27,17 +27,17 @@ define ocf_mirrors::monitoring(
       owner  => mirrors,
       group  => mirrors,
     } ->
-    cron { "${title}-health":
-      command => "${project_path}/health ${title} ${local_url} ${upstream_url} --type=${type}",
-      user    => mirrors,
-      minute  => '*/5',
+    ocf_mirrors::timer { "${title}-health":
+      exec_start => "${project_path}/health ${title} ${local_url} ${upstream_url} --type=${type}",
+      minute     => '0/5',
+      type       => 'monitor',
     }
   } else {
     file { "${project_path}/health":
       ensure => absent;
     }
 
-    cron { "${title}-health":
+    ocf::systemd::timer { "${title}-health":
       ensure => absent,
       user   => mirrors;
     }

--- a/modules/ocf_mirrors/manifests/timer.pp
+++ b/modules/ocf_mirrors/manifests/timer.pp
@@ -4,6 +4,7 @@ define ocf_mirrors::timer(
   $day = '*',
   $month = '*',
   $year = '*',
+  $type = 'sync',
   $exec_user = 'mirrors',
   $exec_start = '',
   $environments = {},

--- a/modules/ocf_mirrors/templates/systemd/sync.timer.erb
+++ b/modules/ocf_mirrors/templates/systemd/sync.timer.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description=Sync timer for <%= @title %>
+Description=<% if @type == "sync" %>Sync<% elsif @type == "monitor" %>Monitoring<% end %> timer for <%= @title %>
 After=network.target
 Wants=network.target
 

--- a/modules/ocf_mirrors/templates/systemd/sync.timer.erb
+++ b/modules/ocf_mirrors/templates/systemd/sync.timer.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description=<% if @type == "sync" %>Sync<% elsif @type == "monitor" %>Monitoring<% end %> timer for <%= @title %>
+Description=<%= @type %> timer for <%= @title %>
 After=network.target
 Wants=network.target
 

--- a/modules/ocf_prometheus/files/rules.d/mirror.rules.yml
+++ b/modules/ocf_prometheus/files/rules.d/mirror.rules.yml
@@ -7,9 +7,18 @@ groups:
       annotations:
         dashboard: https://grafana.ocf.berkeley.edu/d/Jo_bRsyiz/mirrors
         summary: "Mirror {{ $labels.project }} has not been updated in {{ humanizeDuration $value }}"
+        suggestion: "On fallingrocks: read the logs by running `journalctl -eu {{ $labels.project }}` or `journalctl -eu ftpsync-{{ $labels.project }}`."
+
         # We have to re-run the query, once for the upstream and once for local,
         # to generate this annotations. Yes, the template syntax is ugly. If you
         # can think of a better way to write this, submit a PR ;)
         description: |-
           Local mirror: {{ with $labels.project | printf "mirror_updated_local{project=%q}" | query | first }}{{ humanizeTimestamp .Value }}{{end}},
           Upstream mirror: {{ with $labels.project | printf "mirror_updated_upstream{project=%q}" | query | first }}{{ humanizeTimestamp .Value }}{{end}}
+
+    - alert: HealthcheckNotRunning
+      expr: time() - mirror_healthcheck_last_run > 10800 # 3 hours
+      annotations:
+        dashboard: https://grafana.ocf.berkeley.edu/d/Jo_bRsyiz/mirrors
+        summary: "Healthcheck for {{ $labels.project }} has not been run in {{ humanizeDuration $value }}"
+        suggestion: "On fallingrocks: read the logs by running `journalctl -eu {{ $labels.project }}-health`."


### PR DESCRIPTION
We've been getting an increased amount of rootspam recently because we are running the healthcheck at 5m frequency instead of 6 hours. We want to know if a mirror endpoint is down, but we don't need a root@ email if an endpoint is down for a few scrapes.

Since systemd timers log instead of send email alerts, they make sense for this. Now the healthcheck fails "silently" but if it hasn't been updated for 3 hours, we alert. Then we can check the logs to see what the alert is for.