### PR TITLE
Add automatic docker image removal and cleanup to ocf_docker.

### DIFF
--- a/modules/ocf_docker/files/garbage-collect
+++ b/modules/ocf_docker/files/garbage-collect
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# Delete all images older than 2 months.
+deckschrubber -repos 9999 -month 2
+
+systemctl stop docker-registry
+docker run --rm \
+    -v /var/lib/registry:/var/lib/registry \
+    registry:2 \
+    registry garbage-collect /etc/docker/registry/config.yml
+
+# Always make sure the registry is started, no matter what fails.
+trap 'systemctl start docker-registry' EXIT

--- a/modules/ocf_docker/manifests/deckschrubber.pp
+++ b/modules/ocf_docker/manifests/deckschrubber.pp
@@ -1,0 +1,20 @@
+class ocf_docker::deckschrubber {
+  package { 'deckschrubber': }
+
+  file { ['/opt/docker', '/opt/docker/registry']:
+    ensure => directory,
+    mode   => '0755',
+  } ->
+  file { '/opt/docker/registry/garbage-collect':
+    source  => 'puppet:///modules/ocf_docker/garbage-collect',
+    mode    => '0755',
+    require => Package['deckschrubber'],
+  } ->
+  cron { 'registry-gc':
+    command  => '/opt/docker/registry/garbage-collect',
+    user     => 'root',
+    monthday => 1,
+    hour     => 7,
+    minute   => 0,
+  }
+}

--- a/modules/ocf_docker/manifests/init.pp
+++ b/modules/ocf_docker/manifests/init.pp
@@ -3,6 +3,8 @@ class ocf_docker {
   include ocf::packages::docker
   require ocf::ssl::default
 
+  include ocf_docker::deckschrubber
+
   class { 'nginx':
     manage_repo  => false,
     confd_purge  => true,


### PR DESCRIPTION
This stops the Docker registry while garbage collection is happening, as if an image is being uploaded as GC is happening, GC could delete one if its layers. If the registry goes down as a push happens, or if Puppet restarts the registry while GC is happening, that might be bad, but hopefully that is rare enough to not happen (too often).

Script has been tested with dry run flags, and output looks good.