### PR TITLE
keyserver: redirect http to https

### DIFF
--- a/modules/ocf_keyserver/templates/sks-web-nginx.erb
+++ b/modules/ocf_keyserver/templates/sks-web-nginx.erb
@@ -1,7 +1,12 @@
 server {
-
     listen 80 default_server;
     listen [::]:80 default_server;
+
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+
+server {
     listen 443 default_server ssl;
     listen [::]:443 default_server ssl;
     listen 11371;

--- a/modules/ocf_keyserver/templates/sks-web-nginx.erb
+++ b/modules/ocf_keyserver/templates/sks-web-nginx.erb
@@ -7,8 +7,8 @@ server {
 }
 
 server {
-    listen 443 default_server ssl;
-    listen [::]:443 default_server ssl;
+    listen 443 default_server ssl http2;
+    listen [::]:443 default_server ssl http2;
     listen 11371;
     listen [::]:11371;
 
@@ -16,6 +16,13 @@ server {
     ssl_certificate_key /etc/ssl/private/<%= @fqdn %>.key;
     ssl_dhparam /etc/ssl/dhparam.pem;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
+    ssl_prefer_server_ciphers on;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+    ssl_stapling on;
+    ssl_stapling_verify on;
 
     server_name _;
     server_name <%= @fqdn %>;


### PR DESCRIPTION
@keur was right on this, since HKP operates on its own port,
it's ok for the automatic redirect to occur. The web interface
isn't used by clients, so the 80->443 redirect probably won't
break them.