### PR TITLE
[HPC] Add Prometheus exporter for SLURM and alert when all nodes are not accepting new jobs

### DIFF
--- a/modules/ocf_hpc/manifests/controller.pp
+++ b/modules/ocf_hpc/manifests/controller.pp
@@ -35,4 +35,13 @@ class ocf_hpc::controller {
     user    => 'slurm',
     minute  => '*/15',
   }
+
+  # Set up a Prometheus exporter for SLURM, running on port 9341.
+  package { 'prometheus-slurm-exporter': } ~>
+  service { 'prometheus-slurm-exporter':
+    ensure     => 'running',
+    enable     => true,
+    hasrestart => true,
+    require    => Service['slurmctld'],
+  }
 }

--- a/modules/ocf_prometheus/files/rules.d/hpc.rules.yaml
+++ b/modules/ocf_prometheus/files/rules.d/hpc.rules.yaml
@@ -1,0 +1,17 @@
+groups:
+  - name: slurm
+    rules:
+      - record: slurm_nodes_healthy
+        expr: >
+          slurm_nodes_alloc + slurm_nodes_comp + slurm_nodes_idle
+          + slurm_nodes_mix + slurm_nodes_resv
+
+      - alert: SlurmNoNodesHealthy
+        expr: slurm_nodes_healthy == 0
+        for: 5m
+        annotations:
+          dashboard: https://grafana.ocf.berkeley.edu/d/N7Sb3nwik/hpc-slurm-dashboard
+          summary: "All HPC compute nodes are currently unhealthy, and not accepting jobs."
+          suggestion: >
+            "On hpcctl, re-up unhealthy nodes by running
+            `scontrol update nodename=[node name] state=resume`."

--- a/modules/ocf_prometheus/files/rules.d/hpc.rules.yaml
+++ b/modules/ocf_prometheus/files/rules.d/hpc.rules.yaml
@@ -8,10 +8,11 @@ groups:
 
       - alert: SlurmNoNodesHealthy
         expr: slurm_nodes_healthy == 0
-        for: 5m
+        for: 30m
         annotations:
           dashboard: https://grafana.ocf.berkeley.edu/d/N7Sb3nwik/hpc-slurm-dashboard
           summary: "All HPC compute nodes are currently unhealthy, and not accepting jobs."
           suggestion: >
-            "On hpcctl, re-up unhealthy nodes by running
+            "If all nodes are down on purpose for maintenance, ignore.
+            If not, on hpcctl, re-up unhealthy nodes by running
             `scontrol update nodename=[node name] state=resume`."

--- a/modules/ocf_prometheus/manifests/server.pp
+++ b/modules/ocf_prometheus/manifests/server.pp
@@ -169,6 +169,13 @@ class ocf_prometheus::server {
           },
         ],
       },
+      {
+        job_name        => 'slurm',
+        scrape_interval => '30s',
+        scrape_timeout  => '30s',
+
+        static_configs  => [{targets => ['hpcctl:9341']}],
+      },
     ]
   }
 }


### PR DESCRIPTION
We've had a few instances where corruption placed itself in an unhealthy state for some reason and we didn't notice until users let us know. This should cut down on that.

dementors and segfault are currently on my puppet env for this.