### PR TITLE
mirrors: reorganize projects into their own directory

### DIFF
--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -1,32 +1,32 @@
 class ocf_mirrors {
-  include ocf::ssl::default
+  require ocf::ssl::default
   require ocf::packages::rsync
 
   include ocf_mirrors::ftp
   include ocf_mirrors::rsync
+  include ocf_mirrors::firewall_input
 
   # projects
-  include ocf_mirrors::apache
-  include ocf_mirrors::archlinux
-  include ocf_mirrors::centos
-  include ocf_mirrors::centos_altarch
-  include ocf_mirrors::centos_debuginfo
-  include ocf_mirrors::debian
-  include ocf_mirrors::finnix
-  include ocf_mirrors::firewall_input
-  include ocf_mirrors::gnu
-  include ocf_mirrors::kali
-  include ocf_mirrors::kde
-  include ocf_mirrors::kde_applicationdata
-  include ocf_mirrors::manjaro
-  include ocf_mirrors::parrot
-  include ocf_mirrors::puppetlabs
-  include ocf_mirrors::qt
-  include ocf_mirrors::raspbian
-  include ocf_mirrors::tails
-  include ocf_mirrors::tanglu
-  include ocf_mirrors::trisquel
-  include ocf_mirrors::ubuntu
+  include ocf_mirrors::projects::apache
+  include ocf_mirrors::projects::archlinux
+  include ocf_mirrors::projects::centos
+  include ocf_mirrors::projects::centos_altarch
+  include ocf_mirrors::projects::centos_debuginfo
+  include ocf_mirrors::projects::debian
+  include ocf_mirrors::projects::finnix
+  include ocf_mirrors::projects::gnu
+  include ocf_mirrors::projects::kali
+  include ocf_mirrors::projects::kde
+  include ocf_mirrors::projects::kde_applicationdata
+  include ocf_mirrors::projects::manjaro
+  include ocf_mirrors::projects::parrot
+  include ocf_mirrors::projects::puppetlabs
+  include ocf_mirrors::projects::qt
+  include ocf_mirrors::projects::raspbian
+  include ocf_mirrors::projects::tails
+  include ocf_mirrors::projects::tanglu
+  include ocf_mirrors::projects::trisquel
+  include ocf_mirrors::projects::ubuntu
 
   user { 'mirrors':
     comment  => 'OCF Mirroring',

--- a/modules/ocf_mirrors/manifests/projects/apache.pp
+++ b/modules/ocf_mirrors/manifests/projects/apache.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::apache {
+class ocf_mirrors::projects::apache {
   file {
     '/opt/mirrors/project/apache':
       ensure  => directory,

--- a/modules/ocf_mirrors/manifests/projects/archlinux.pp
+++ b/modules/ocf_mirrors/manifests/projects/archlinux.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::archlinux {
+class ocf_mirrors::projects::archlinux {
   file {
     '/opt/mirrors/project/archlinux':
       ensure  => directory,

--- a/modules/ocf_mirrors/manifests/projects/centos.pp
+++ b/modules/ocf_mirrors/manifests/projects/centos.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::centos {
+class ocf_mirrors::projects::centos {
   file { '/opt/mirrors/project/centos':
     ensure  => directory,
     source  => 'puppet:///modules/ocf_mirrors/project/centos/',

--- a/modules/ocf_mirrors/manifests/projects/centos_altarch.pp
+++ b/modules/ocf_mirrors/manifests/projects/centos_altarch.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::centos_altarch {
+class ocf_mirrors::projects::centos_altarch {
   file { '/opt/mirrors/project/centos-altarch':
     ensure  => directory,
     source  => 'puppet:///modules/ocf_mirrors/project/centos-altarch/',

--- a/modules/ocf_mirrors/manifests/projects/centos_debuginfo.pp
+++ b/modules/ocf_mirrors/manifests/projects/centos_debuginfo.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::centos_debuginfo {
+class ocf_mirrors::projects::centos_debuginfo {
   file { '/opt/mirrors/project/centos-debuginfo':
     ensure  => directory,
     source  => 'puppet:///modules/ocf_mirrors/project/centos-debuginfo/',

--- a/modules/ocf_mirrors/manifests/projects/debian.pp
+++ b/modules/ocf_mirrors/manifests/projects/debian.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::debian {
+class ocf_mirrors::projects::debian {
   ocf_mirrors::ftpsync {
     'debian':
       rsync_host  => 'mirrors.mit.edu',

--- a/modules/ocf_mirrors/manifests/projects/finnix.pp
+++ b/modules/ocf_mirrors/manifests/projects/finnix.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::finnix {
+class ocf_mirrors::projects::finnix {
   file {
     default:
       owner => mirrors,

--- a/modules/ocf_mirrors/manifests/projects/gnu.pp
+++ b/modules/ocf_mirrors/manifests/projects/gnu.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::gnu {
+class ocf_mirrors::projects::gnu {
   file {
     '/opt/mirrors/project/gnu':
       ensure  => directory,

--- a/modules/ocf_mirrors/manifests/projects/kali.pp
+++ b/modules/ocf_mirrors/manifests/projects/kali.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::kali {
+class ocf_mirrors::projects::kali {
   ocf_mirrors::ftpsync {
     'kali':
       rsync_host  => 'archive.kali.org',

--- a/modules/ocf_mirrors/manifests/projects/kde.pp
+++ b/modules/ocf_mirrors/manifests/projects/kde.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::kde {
+class ocf_mirrors::projects::kde {
   file {
     '/opt/mirrors/project/kde':
       ensure  => directory,

--- a/modules/ocf_mirrors/manifests/projects/kde_applicationdata.pp
+++ b/modules/ocf_mirrors/manifests/projects/kde_applicationdata.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::kde_applicationdata {
+class ocf_mirrors::projects::kde_applicationdata {
   file {
     '/opt/mirrors/project/kde-applicationdata':
       ensure  => directory,

--- a/modules/ocf_mirrors/manifests/projects/manjaro.pp
+++ b/modules/ocf_mirrors/manifests/projects/manjaro.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::manjaro {
+class ocf_mirrors::projects::manjaro {
   file {
     '/opt/mirrors/project/manjaro':
       ensure  => directory,

--- a/modules/ocf_mirrors/manifests/projects/parrot.pp
+++ b/modules/ocf_mirrors/manifests/projects/parrot.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::parrot {
+class ocf_mirrors::projects::parrot {
   file {
     '/opt/mirrors/project/parrot':
       ensure  => directory,

--- a/modules/ocf_mirrors/manifests/projects/puppetlabs.pp
+++ b/modules/ocf_mirrors/manifests/projects/puppetlabs.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::puppetlabs {
+class ocf_mirrors::projects::puppetlabs {
   ocf_mirrors::ftpsync { 'puppetlabs':
     rsync_host  => 'rsync.puppet.com',
     rsync_path  => 'packages/apt',

--- a/modules/ocf_mirrors/manifests/projects/qt.pp
+++ b/modules/ocf_mirrors/manifests/projects/qt.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::qt {
+class ocf_mirrors::projects::qt {
   file {
     '/opt/mirrors/project/qt':
       ensure  => directory,

--- a/modules/ocf_mirrors/manifests/projects/raspbian.pp
+++ b/modules/ocf_mirrors/manifests/projects/raspbian.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::raspbian {
+class ocf_mirrors::projects::raspbian {
   ocf_mirrors::ftpsync { 'raspbian':
     rsync_host  => 'archive.raspbian.org',
     rsync_path  => 'archive',

--- a/modules/ocf_mirrors/manifests/projects/tails.pp
+++ b/modules/ocf_mirrors/manifests/projects/tails.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::tails {
+class ocf_mirrors::projects::tails {
   file {
     '/opt/mirrors/project/tails':
       ensure  => directory,

--- a/modules/ocf_mirrors/manifests/projects/tanglu.pp
+++ b/modules/ocf_mirrors/manifests/projects/tanglu.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::tanglu {
+class ocf_mirrors::projects::tanglu {
   ocf_mirrors::ftpsync { 'tanglu':
     rsync_host  => 'archive.tanglu.org',
     cron_minute => '40',

--- a/modules/ocf_mirrors/manifests/projects/trisquel.pp
+++ b/modules/ocf_mirrors/manifests/projects/trisquel.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::trisquel {
+class ocf_mirrors::projects::trisquel {
   ocf_mirrors::ftpsync {
     'trisquel':
       rsync_host  => 'rsync.trisquel.info',

--- a/modules/ocf_mirrors/manifests/projects/ubuntu.pp
+++ b/modules/ocf_mirrors/manifests/projects/ubuntu.pp
@@ -1,4 +1,4 @@
-class ocf_mirrors::ubuntu {
+class ocf_mirrors::projects::ubuntu {
   ocf_mirrors::ftpsync { 'ubuntu':
     rsync_host  => 'mirrors.mit.edu',
     cron_minute => '50';


### PR DESCRIPTION
this is a no-op change that just moves the project manifests into their own directory for organizational purposes