### PR TITLE
add the etc puppet share and put it on all hosts

### DIFF
--- a/modules/ocf/manifests/etc.pp
+++ b/modules/ocf/manifests/etc.pp
@@ -1,0 +1,11 @@
+class ocf::etc {
+  file { '/etc/ocf':
+    ensure  => directory,
+    source  => 'puppet:///etc',
+    owner   => root,
+    group   => root,
+    mode    => '0755',
+    purge   => true,
+    recurse => true,
+  }
+}

--- a/modules/ocf/manifests/init.pp
+++ b/modules/ocf/manifests/init.pp
@@ -2,6 +2,7 @@ class ocf {
   include ocf::apt
   include ocf::auth
   include ocf::autologout
+  include ocf::etc
   include ocf::firewall
   include ocf::groups
   include ocf::kerberos

--- a/modules/ocf_puppet/files/fileserver.conf
+++ b/modules/ocf_puppet/files/fileserver.conf
@@ -10,3 +10,7 @@
 [kubernetes-secrets]
   path /opt/puppet/shares/private/kubernetes/secrets
   allow *
+
+[etc]
+  path /opt/puppet/shares/etc
+  allow *

--- a/modules/ocf_puppet/manifests/puppetserver.pp
+++ b/modules/ocf_puppet/manifests/puppetserver.pp
@@ -127,4 +127,14 @@ class ocf_puppet::puppetserver {
       target  => '/opt/puppetlabs/shares',
       require => Package['puppetserver'];
   }
+
+  vcsrepo { '/opt/puppetlabs/shares/etc':
+    ensure   => latest,
+    provider => git,
+    revision => 'master',
+    source   => 'https://github.com/ocf/etc.git',
+    owner    => puppet,
+    group    => puppet,
+    require  => File['/opt/puppetlabs/shares'];
+  }
 }


### PR DESCRIPTION
Here's my first candidate for this, based on recent discussion in IRC.

I realize there are other ways of doing this-- most notably, we could have Jenkins populate `/opt/shares/etc` instead of making it a `vscrepo`, but my worry with such a solution is that it means a newly provisioned Puppetserver would have an empty `etc` share, which is very bad.  This makes sure we always have something valid being put on all hosts.

However I'm still not sure if I like this solution. It doesn't seem so far off from just putting the `vcsrepo` on every host, and this PR adds another (albeit minor) layer of complexity to that.

Thoughts?