### PR TITLE
Drop non-HTTPS support for vhosts before cert available

### DIFF
--- a/modules/ocf_www/files/build-vhosts
+++ b/modules/ocf_www/files/build-vhosts
@@ -152,7 +152,6 @@ def build_config(src_vhosts, template, dev_config=False):
     for domain, vhost in src_vhosts.items():
         user = vhost['username']
         ssl = SSL(domain)
-        use_ssl = 'nossl' not in vhost['flags'] and ssl.is_valid
 
         # Exactly one must be true
         assert ('socket' in vhost) != ('docroot' in vhost)
@@ -167,11 +166,16 @@ def build_config(src_vhosts, template, dev_config=False):
             fqdn=domain,
             user=user,
             comment='{} (user {})'.format(domain, user),
-            ssl=ssl if use_ssl else None,
+            ssl=ssl,
             bind_type=bind_type,
             bind_dest=bind_dest,
         )
-        vhosts.add(primary)
+        # Only add the full vhost if SSL is valid (redirects, like HTTP ->
+        # HTTPS are added regardless)
+        #
+        # We used to support non-HTTPS vhosts, but no longer do (rt#5347)
+        if ssl.is_valid:
+            vhosts.add(primary)
 
         # for app vhosts, define a dev vhost as well
         if bind_type == 'socket':
@@ -188,23 +192,22 @@ def build_config(src_vhosts, template, dev_config=False):
             vhosts.add(VirtualHost(
                 fqdn=dev_alias,
                 user=user,
-                comment='{0} (dev alias of {1}, redirect to {0})'.format(dev_alias, domain),
+                comment='{} (dev alias of {}, redirect to HTTPS)'.format(dev_alias, domain),
                 ssl=None,
                 bind_type='redirect',
                 bind_dest='https://' + dev_alias,
             ))
 
-        redirects = set()
-        if use_ssl:
-            # Redirect from http://{domain} to https://{domain}
-            redirects.add((primary.fqdn, None))
+        # Redirect from http://{domain} to https://{domain} for all vhosts
+        redirects = {(primary.fqdn, None)}
 
         for alias in vhost['aliases']:
-            # Redirect from http://{alias} to http(s)://{domain}
+            # Redirect from http://{alias} to https://{domain}
             redirects.add((alias, None))
             ssl = SSL(alias)
+
             if ssl.is_valid:
-                # Redirect from https://{alias} to http(s)://{domain}
+                # Redirect from https://{alias} to https://{domain}
                 redirects.add((alias, ssl))
 
         for fqdn, ssl in redirects:
@@ -312,7 +315,7 @@ def process_app_vhosts():
 
         # Regenerate SSL bundle if older than cert
         for ssl in chain((SSL(domain),), map(SSL, vhost['aliases'])):
-            if 'nossl' not in vhost['flags'] and ssl.is_valid and (
+            if ssl.is_valid and (
                 not os.path.exists(ssl.bundle) or
                 os.path.getmtime(ssl.bundle) < os.path.getmtime(ssl.cert)
             ):


### PR DESCRIPTION
The idea here is that we don't offer HTTP support for vhosts for the short period between when the DNS is acquired from the university and when we acquire a TLS cert for the vhost from Let's Encrypt. This also drops support for the `nossl` flag, since we don't use that any more (`contrib.ocf.berkeley.edu` was the last use of that, and it is dead as of d4fb1bebadd5658fc8be8d7aa968a5de520a9696).

This related to #491 a bit (which is why I took that issue) because if `lets-encrypt-update` isn't working properly, then having this behavior will cause slightly worse issues, since the vhosts will be unavailable entirely since they will give cert errors instead of a plain HTTP page. However, this is what we want really, since acquiring certs should be happening quickly and working. Some discussion about this is in [rt#5347](https://rt.ocf.berkeley.edu/Ticket/Display.html?id=5347).

This is the diff between the current vhost config and what this script generates:

```diff
jvperrin@death:~/tmp$ diff vhosts.out /etc/apache2/ocf-vhost.conf
15801c15801
<         RewriteRule ^(.*)$ https://dev-dev-vhost.ocf.berkeley.edu$1 [L,R=302]
---
>         RewriteRule ^(.*)$ http://dev-dev-vhost.ocf.berkeley.edu$1 [L,R=302]
15814c15814
< # dev-dev-vhost.ocf.berkeley.edu (redirect to dev-dev-vhost.ocf.berkeley.edu)
---
> # dev-dev-vhost.ocf.berkeley.edu (user ggroup)
15822,15826c15822,15836
<         RewriteEngine on
<         RewriteCond %{REQUEST_URI} !^/\.well-known/
<         # 301 redirects are more correct, but get cached forever by dumb browsers.
<         # Doesn't matter too much for vhosts.
<         RewriteRule ^(.*)$ https://dev-dev-vhost.ocf.berkeley.edu$1 [L,R=302]
---
>         DocumentRoot /services/http/users/g/ggroup/
>
>         <Directory /services/http/users/g/ggroup/>
>             Options ExecCGI IncludesNoExec Indexes MultiViews SymLinksIfOwnerMatch
>             AllowOverride All
>             Require all granted
>             DirectoryIndex index.html index.cgi index.pl index.php index.xhtml index.htm index.shtm index.shtml
>         </Directory>
>
>         <FilesMatch "\.(php[3457]?|phtml|fcgi)$">
>             Require all granted
>             SetHandler fcgid-script
>         </FilesMatch>
>
>         SuexecUserGroup ggroup ocf
29345c29355
< # synapse.berkeley.edu (redirect to synapse.berkeley.edu)
---
> # synapse.berkeley.edu (user synapse)
29353,29357c29363,29377
<         RewriteEngine on
<         RewriteCond %{REQUEST_URI} !^/\.well-known/
<         # 301 redirects are more correct, but get cached forever by dumb browsers.
<         # Doesn't matter too much for vhosts.
<         RewriteRule ^(.*)$ https://synapse.berkeley.edu$1 [L,R=302]
---
>         DocumentRoot /services/http/users/s/synapse/
>
>         <Directory /services/http/users/s/synapse/>
>             Options ExecCGI IncludesNoExec Indexes MultiViews SymLinksIfOwnerMatch
>             AllowOverride All
>             Require all granted
>             DirectoryIndex index.html index.cgi index.pl index.php index.xhtml index.htm index.shtm index.shtml
>         </Directory>
>
>         <FilesMatch "\.(php[3457]?|phtml|fcgi)$">
>             Require all granted
>             SetHandler fcgid-script
>         </FilesMatch>
>
>         SuexecUserGroup synapse ocf
32714c32734
< </VirtualHost>
---
> </VirtualHost>
```

We don't have the DNS for `synapse.berkeley.edu`, so that makes sense, and `dev-dev-vhost.ocf.berkeley.edu` is owned by `dev-death`, so it looks like there's no cert for it because `ocfletsencrypt` isn't set up to request certs on `dev-death`. This sorta makes sense, otherwise it might request certs for domains from `death` that it really shouldn't have, although we could probably make it acquire certs for domains that it indeed is hosting and has the proper DNS for I suppose. That might be good since we can't access the dev vhost otherwise now. Thoughts?