### PR TITLE
ocf_kubernetes: Allow ocfroot to use kubectl

### DIFF
--- a/modules/ocf_kubernetes/manifests/master.pp
+++ b/modules/ocf_kubernetes/manifests/master.pp
@@ -95,6 +95,27 @@ class ocf_kubernetes::master {
     },
   }
 
+  # Give ocfroot access to the admin.conf file. This file contains the client
+  # cert for the "kubernetes-admin" role, granting permissions to do anything
+  # in the cluster.
+  file {
+    '/etc/kubernetes/admin.conf':
+      content => undef, # NOTE: kubeadm creates this file
+      owner   => 'root',
+      group   => 'ocfroot',
+      mode    => '0440',
+      require => Class['kubernetes'],
+  } ->
+
+  # Proxy script for ocfroot to run kubectl as a cluster admin.
+  file {
+    '/usr/local/bin/ocf-kubectl':
+      content => "!#/bin/bash\nKUBECONFIG=/etc/kubernetes/admin.conf kubectl \"$@\"\n",
+      owner   => 'root',
+      group   => 'ocfroot',
+      mode    => '0554',
+  }
+
   file {
     '/etc/profile.d/kubeconfig.sh':
       mode    => '0755',


### PR DESCRIPTION
Give ocfroot read access to /etc/kubernetes/admin.conf, which has the
client cert required to authenticate as a "kubernetes-admin". Now
ocfroot can administer the cluster without becoming the root user.

Create a smaller helper script called 'ocf-kubectl' that sets the
KUBECONFIG environment variable and proxies the rest of the arguments to
kubectl.