### PR TITLE
puppet: change etc volume to only include configs

### DIFF
--- a/modules/ocf_puppet/files/fileserver.conf
+++ b/modules/ocf_puppet/files/fileserver.conf
@@ -12,5 +12,5 @@
   allow *
 
 [etc]
-  path /opt/puppet/shares/etc
+  path /opt/puppet/shares/etc/configs
   allow *


### PR DESCRIPTION
Anyone have thoughts on this? I think it would be nicer.

This would mean, for example, that `hours.yaml` would be located at `/etc/ocf/hours.yaml` instead of `/etc/ocf/configs/hours.yaml`. The other files don't really need to be on every host.