### PR TITLE
etc: add force and nobackup options

### DIFF
--- a/modules/ocf/manifests/etc.pp
+++ b/modules/ocf/manifests/etc.pp
@@ -7,5 +7,7 @@ class ocf::etc {
     mode    => '0755',
     purge   => true,
     recurse => true,
+    backup  => false,
+    force   => true,
   }
 }


### PR DESCRIPTION
`backup` is definitely required, but `force` is required too since we need to remove residual directories from the old state of the `etc` folder on hosts.

Should `force => true` stay on as an option though? Seems like it should, I can't really think of how it could harm us, though I'd like to exercise caution here since the word "force" is scary...