### PR TITLE
add class for specifying additional custom apt repositories

### DIFF
--- a/hieradata/nodes/failure.yaml
+++ b/hieradata/nodes/failure.yaml
@@ -1,1 +1,15 @@
+classes:
+  - ocf::packages::docker
+  - ocf::packages::custom::apt
+
+ocf::packages::custom::apt::sources:
+  - name: zerotier
+    keyid: 74A5E9C458E1A431F1DA57A71657198823E52A61
+    location: https://download.zerotier.com/debian/stretch
+  - name: syncthing
+    keyid: 37C84554E7E0A261E4F76E1ED26E6ED000654A3E
+    location: https://apt.syncthing.net
+    release: syncthing
+    repos: stable
+
 owner: cooperc

--- a/modules/ocf/manifests/packages/custom/apt.pp
+++ b/modules/ocf/manifests/packages/custom/apt.pp
@@ -1,0 +1,27 @@
+class ocf::packages::custom::apt ($sources = [], $stage = 'first') {
+  $sources.each |$source| {
+    apt::key { $source['name']:
+      id     => $source['keyid'],
+      server => 'pgp.ocf.berkeley.edu',
+    }
+
+    $real_release = $source['release'] ? {
+      # default to current release name (e.g. stretch)
+      undef   => $::lsbdistcodename,
+      default => $source['release'],
+    }
+    $real_repos = $source['repos'] ? {
+      # default to 'main'
+      undef   => 'main',
+      default => $source['repos'],
+    }
+
+    apt::source { $source['name']:
+      architecture => 'amd64',
+      location     => $source['location'],
+      release      => $real_release,
+      repos        => $real_repos,
+      require      => Apt::Key[$source['name']],
+    }
+  }
+}


### PR DESCRIPTION
This is mostly useful for staffvms, where you might want to add additional repositories that aren't applicable to any other OCF infra. If you add them manually, puppet will delete them every time it runs. This provides a way to specify them in hieradata.

This is probably not the best approach, but I don't know enough about puppet to come up with something better. Reviews greatly appreciated.