### PR TITLE
Specify Prometheus node exporter version.

### DIFF
--- a/modules/ocf/manifests/init.pp
+++ b/modules/ocf/manifests/init.pp
@@ -21,6 +21,6 @@ class ocf {
   include ocf::walldeny
 
   if $::lsbdistid != 'Raspbian' {
-    include prometheus::node_exporter
+    include ocf::nodeexporter
   }
 }

--- a/modules/ocf/manifests/nodeexporter.pp
+++ b/modules/ocf/manifests/nodeexporter.pp
@@ -1,0 +1,5 @@
+class ocf::nodeexporter {
+  class { 'prometheus::node_exporter':
+    version => '0.17.0',
+  }
+}


### PR DESCRIPTION
We have been running node_exporter 0.15.2; this bumps it up to 0.17.0, which re-enables a whole bunch of collectors.

Thoughts on the manifest file's name? We may add new exporters for all hosts in the future, so perhaps 'prometheusexporters.pp' would be more appropriate.