### PR TITLE
Set node_exporter textfile collector directory option in Hiera.

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -87,3 +87,6 @@ kubernetes::master_nodes:
     - coup
     - autocrat
     - deadlock
+
+# Prometheus config
+prometheus::node_exporter::version: 0.17.0

--- a/hieradata/nodes/dev-whiteout.yaml
+++ b/hieradata/nodes/dev-whiteout.yaml
@@ -1,2 +1,4 @@
 classes:
     - ocf_printhost
+
+prometheus::node_exporter::extra_options: "--collector.textfile.directory /var/local/prometheus"

--- a/hieradata/nodes/fallingrocks.yaml
+++ b/hieradata/nodes/fallingrocks.yaml
@@ -1,3 +1,5 @@
 classes:
     - ocf_apt
     - ocf_mirrors
+
+prometheus::node_exporter::extra_options: "--collector.textfile.directory /opt/mirrors/prometheus"

--- a/hieradata/nodes/whiteout.yaml
+++ b/hieradata/nodes/whiteout.yaml
@@ -1,2 +1,4 @@
 classes:
     - ocf_printhost
+
+prometheus::node_exporter::extra_options: "--collector.textfile.directory /var/local/prometheus"

--- a/modules/ocf/manifests/init.pp
+++ b/modules/ocf/manifests/init.pp
@@ -21,6 +21,6 @@ class ocf {
   include ocf::walldeny
 
   if $::lsbdistid != 'Raspbian' {
-    include ocf::nodeexporter
+    include prometheus::node_exporter
   }
 }

--- a/modules/ocf/manifests/nodeexporter.pp
+++ b/modules/ocf/manifests/nodeexporter.pp
@@ -1,5 +1,0 @@
-class ocf::nodeexporter {
-  class { 'prometheus::node_exporter':
-    version => '0.17.0',
-  }
-}

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -196,7 +196,4 @@ class ocf_mirrors {
       owner  => 'mirrors',
       group  => 'mirrors',
   }
-  class { 'prometheus::node_exporter':
-    extra_options =>  '--collector.textfile.directory /opt/mirrors/prometheus',
-  }
 }

--- a/modules/ocf_printhost/manifests/monitor.pp
+++ b/modules/ocf_printhost/manifests/monitor.pp
@@ -18,8 +18,4 @@ class ocf_printhost::monitor {
     command => '/usr/local/bin/monitor-cups /var/local/prometheus/cups.prom',
     # Run every minute
   }
-
-  class { 'prometheus::node_exporter':
-    extra_options => '--collector.textfile.directory /var/local/prometheus',
-  }
 }


### PR DESCRIPTION
Since `prometheus::node_exporter` is [included as a resource delcaration twice](https://sourcegraph.ocf.berkeley.edu/search?q=node_exporter), which isn't allowed by Puppet, it is failing on fallingrocks and *-whiteout.

I opted to move the textfile collector directory option to Hiera, but I could also have moved node_exporter's `version` option to `common.yaml`. Opinions?