### PR TITLE
Firefox configuration

### DIFF
--- a/modules/ocf/templates/firefox/prefs.js.erb
+++ b/modules/ocf/templates/firefox/prefs.js.erb
@@ -1,15 +1,26 @@
 // Use LANG environment variable to choose locale
 pref("intl.locale.requested", "");
 lockPref("browser.startup.homepage", "<%= @browser_homepage %>");
+pref("browser.aboutHomeSnippets.updateUrl", "");
 pref("browser.cache.disk.capacity", 0);
 pref("browser.download.useDownloadDir", false);
+pref("browser.newtabpage.enabled", false);
+pref("browser.onboarding.enabled", false);
 pref("browser.privatebrowsing.autostart", true);
 pref("browser.search.geoSpecificDefaults", false);
+pref("browser.search.geoip.url", "");
+pref("browser.selfsupport.url", "");
 pref("browser.shell.checkDefaultBrowser", false);
 pref("browser.showQuitWarning", true);
+pref("browser.startup.homepage_override.mstone", "ignore");
+pref("network.captive-portal-service.enabled", false);
+pref("network.dns.disablePrefetch", true);
+pref("network.http.speculative-parallel-limit", 0);
 pref("network.negotiate-auth.trusted-uris", "https://rt.ocf.berkeley.edu");
+pref("network.prefetch-next", false);
 pref("pdfjs.disabled", true);
 pref("signon.rememberSignons", false);
 pref("startup.homepage_welcome_url", "");
 pref("startup.homepage_welcome_url.additional", "");
 pref("security.webauth.u2f", true);
+pref("extensions.getAddons.cache.enabled", false);


### PR DESCRIPTION
`browser.aboutHomeSnippets.updateUrl`, `browser.search.geoip.url`, 
`network.captive-portal-service.enabled`, `network.dns.disablePrefetch`, `network.http.speculative-parallel-limit`, `network.prefetch-next`, and `extensions.getAddons.cache.enabled` are for enchanced privacy.

`browser.newtabpage.enabled`, `browser.onboarding.enabled`, and `browser.startup.homepage_override.mstone` are for quality of life. 

Specifically `browser.newtabpage.enabled` disables the horrifying mess that is the modern firefox newtab (makes it blank instead), and `browser.onboarding.enabled` disables the firefox tour on startup.