### PR TITLE
Enable http firewall rule on kubernetes masters

### DIFF
--- a/modules/ocf_kubernetes/manifests/master/loadbalancer.pp
+++ b/modules/ocf_kubernetes/manifests/master/loadbalancer.pp
@@ -1,6 +1,8 @@
 class ocf_kubernetes::master::loadbalancer {
   include ::haproxy
 
+  include ocf::firewall::allow_web
+
   $kubernetes_worker_nodes = lookup('kubernetes::worker_nodes')
   $kubernetes_workers_ipv4 = $kubernetes_worker_nodes.map |$worker| { ldap_attr($worker, 'ipHostNumber') }
   $haproxy_ssl = "/etc/ssl/private/${::fqdn}.pem"


### PR DESCRIPTION
This should finally end our woes related to Kubernetes firewall issues. This is tested (all masters are currently on my environment) and it appears to work.