### PR TITLE
add redeclipse to desktop packages

### DIFF
--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -29,7 +29,8 @@ class ocf_desktop::packages {
     # FUSE
     ['fuse', 'exfat-fuse']:;
     # games
-    ['armagetronad', 'gl-117', 'gnome-games', 'minecraft-launcher', 'wesnoth', 'wesnoth-music']:;
+    ['armagetronad', 'gl-117', 'gnome-games', 'minecraft-launcher', 'redeclipse',
+      'wesnoth', 'wesnoth-music']:;
     # graphics/plotting
     ['r-cran-rgl', 'jupyter-qtconsole', 'rstudio']:;
     # input method editors


### PR DESCRIPTION
I've wanted to do this for a while, since Red Eclipse is in the Debian repos, but unfortunately there was a key repeat bug that made it pretty much unplayable. I finally got the the bottom of it. It turns out there was a bug in SDL2 2.0.5 that caused this. The fix is https://hg.libsdl.org/SDL/rev/b48d8a98e261. I rebuilt libsdl2-2.0-0 with this patch applied and pushed it to the internal OCF apt repo as version 2.0.5+dfsg1-2. This means redeclipse will be buggy until someone runs apt-dater. Alternatively, if you notice the bug when playing, just run `sudo apt install libsdl2-2.0-0` to fix.