### PR TITLE
kubernetes: add the cert signing script for user auth

### DIFF
--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -138,6 +138,11 @@ class ocf::packages {
     backport_on =>  ['stretch'],
   }
 
+  ocf::repackage { 'python3-cryptography':
+    backport_on => ['stretch'],
+  }
+
+
   # Packages to only install on Debian (not on Raspbian for example)
   if $::lsbdistid == 'Debian' {
     package {

--- a/modules/ocf/manifests/ssl/lets_encrypt/dns_common.pp
+++ b/modules/ocf/manifests/ssl/lets_encrypt/dns_common.pp
@@ -8,7 +8,9 @@ class ocf::ssl::lets_encrypt::dns_common {
 
   # we use this package in the le_cert_info fact, to gather information about
   # whatever certs are currently present
-  package { 'python3-cryptography':; }
+  ocf::repackage { 'python3-cryptography':
+    backport_on => ['stretch'],
+  }
 
   $letsencrypt_ddns_key = assert_type(Stdlib::Base64, lookup('letsencrypt::ddns::key'))
 

--- a/modules/ocf/manifests/ssl/lets_encrypt/dns_common.pp
+++ b/modules/ocf/manifests/ssl/lets_encrypt/dns_common.pp
@@ -6,12 +6,6 @@ class ocf::ssl::lets_encrypt::dns_common {
     require => Package['dehydrated'],
   }
 
-  # we use this package in the le_cert_info fact, to gather information about
-  # whatever certs are currently present
-  ocf::repackage { 'python3-cryptography':
-    backport_on => ['stretch'],
-  }
-
   $letsencrypt_ddns_key = assert_type(Stdlib::Base64, lookup('letsencrypt::ddns::key'))
 
   file {

--- a/modules/ocf_kubernetes/files/certsign
+++ b/modules/ocf_kubernetes/files/certsign
@@ -73,10 +73,10 @@ def main():
 
     # Set the cert's expiration
     builder = builder.not_valid_before(
-        datetime.datetime.today() - datetime.timedelta(minutes=1)
+        datetime.datetime.utcnow() - datetime.timedelta(minutes=1)
     )
     builder = builder.not_valid_after(
-        datetime.datetime.today() + CERT_VALID_FOR,
+        datetime.datetime.utcnow() + CERT_VALID_FOR,
     )
 
     builder = builder.serial_number(x509.random_serial_number())

--- a/modules/ocf_kubernetes/files/certsign
+++ b/modules/ocf_kubernetes/files/certsign
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import datetime
+import grp
+import os
+import pwd
+from socket import getfqdn
+import sys
+
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+from cryptography.x509.oid import NameOID
+
+PRIVATE_KEY_FILE = '/etc/kubernetes/pki/ca.key'
+CA_CERT = '/etc/kubernetes/pki/ca.crt'
+
+# This can be a short duration, since getting new certs is transparent to the
+# end user.
+CERT_VALID_FOR = datetime.timedelta(minutes=2)
+
+
+def user_groups(username):
+    """Returns all the groups a user is in"""
+    gid = pwd.getpwnam(username).pw_gid
+    return (
+        # Secondary groups
+        [g.gr_name for g in grp.getgrall() if username in g.gr_mem]
+        # Primary group
+        + [grp.getgrgid(gid).gr_name]
+    )
+
+
+def main():
+    username = os.environ.get('SUDO_USER')
+
+    if not username:
+        raise RuntimeError('Unable to read SUDO_USER.')
+
+    ca_key = load_pem_private_key(
+        data=open(PRIVATE_KEY_FILE, 'rb').read(),
+        password=None,
+        backend=default_backend(),
+    )
+
+    ca_crt = x509.load_pem_x509_certificate(
+        data=open(CA_CERT, 'rb').read(),
+        backend=default_backend(),
+    )
+
+    pubkey = load_pem_public_key(
+        sys.stdin.buffer.read(),
+        backend=default_backend()
+    )
+
+    builder = x509.CertificateBuilder()
+
+    # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certs
+    # Set the COMMON_NAME of the cert to be the username
+    # and the ORGANIZATION_NAME (specified multiple times) for each group the
+    # user is in
+    builder = builder.subject_name(x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, username),
+    ] + [
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, group)
+        for group in user_groups(username)
+    ]))
+
+    builder = builder.issuer_name(ca_crt.subject)
+
+    # Set the cert's expiration
+    builder = builder.not_valid_before(
+        datetime.datetime.today() - datetime.timedelta(minutes=1)
+    )
+    builder = builder.not_valid_after(
+        datetime.datetime.today() + CERT_VALID_FOR,
+    )
+
+    builder = builder.serial_number(x509.random_serial_number())
+    builder = builder.public_key(pubkey)
+
+    builder = builder.add_extension(
+        x509.KeyUsage(
+            digital_signature=True,
+            content_commitment=False,
+            key_encipherment=True,
+            data_encipherment=False,
+            key_agreement=False,
+            key_cert_sign=False,
+            crl_sign=False,
+            encipher_only=False,
+            decipher_only=False,
+        ),
+        critical=True,
+    )
+
+    builder = builder.add_extension(
+        x509.ExtendedKeyUsage([x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH]),
+        critical=False,
+    )
+
+    # Identify the signing key
+    builder = builder.add_extension(
+        x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(
+            ca_crt.extensions.get_extension_for_class(x509.SubjectKeyIdentifier)
+        ),
+        critical=False,
+    )
+
+    certificate = builder.sign(
+        private_key=ca_key,
+        algorithm=hashes.SHA256(),
+        backend=default_backend(),
+    )
+
+    sys.stdout.buffer.write(certificate.public_bytes(serialization.Encoding.PEM))
+
+
+if __name__ == '__main__':
+    main()

--- a/modules/ocf_kubernetes/manifests/master.pp
+++ b/modules/ocf_kubernetes/manifests/master.pp
@@ -95,6 +95,32 @@ class ocf_kubernetes::master {
     },
   }
 
+  user { 'kubernetes-ca':
+    ensure =>  present,
+    name   =>  'kubernetes-ca',
+    groups =>  [sys],
+    shell  =>  '/bin/false',
+    system =>  true,
+  }
+
+  # Override the Kubernetes configuration directory, created by
+  # the puppetlabs-kubernetes config module, to have owner kubernetes-ca
+  # and not be readable by any user
+  File<|title == '/etc/kubernetes'|> {
+    owner => 'kubernetes-ca',
+    mode  => '0700',
+  }
+
+  # cert signing script
+  file {
+    '/usr/local/bin/certsign':
+      mode   => '0755',
+      source =>'puppet:///modules/ocf_kubernetes/certsign';
+
+    '/etc/sudoers.d/certsign':
+      content =>  "ALL ALL=(kubernetes-ca) NOPASSWD: /usr/local/bin/certsign\n";
+  }
+
   file {
     '/etc/profile.d/kubeconfig.sh':
       mode    => '0755',


### PR DESCRIPTION
This adds a script called `certsign`, which can be used to authenticate OCF staffers to Kubernetes. "Clients" can generate a keypair and send it to this script to get it signed with their username. Then the generated certificate can be used to authenticate with Kubernetes.

The script is protected by `sudo` and `SUDO_USER` (similar to `makemysql`), so users can only get certs signed with their own username.

This is tested and working, but it essentially does nothing since we don't yet grant any permissions to OCF users.