### PR TITLE
Add kubectl default config

### DIFF
--- a/modules/ocf/files/shell/bash.bashrc
+++ b/modules/ocf/files/shell/bash.bashrc
@@ -5,6 +5,7 @@
 export PATH=/opt/share/utils/bin:/opt/share/utils/sbin:/usr/local/bin:\
 /usr/local/sbin:/opt/puppetlabs/bin:/bin:/usr/bin:/usr/sbin:/usr/lib:/sbin:\
 /usr/games
+export KUBECONFIG=/etc/kubectl.conf
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 

--- a/modules/ocf/files/shell/config.fish
+++ b/modules/ocf/files/shell/config.fish
@@ -14,6 +14,7 @@ set -x PATH /opt/share/utils/bin \
     /usr/lib \
     /sbin \
     /usr/games
+set -x KUBECONFIG /etc/kubectl.conf
 
 if test -e /opt/puppetlabs/bin
     set -x PATH $PATH /opt/puppetlabs/bin

--- a/modules/ocf/files/shell/config.fish
+++ b/modules/ocf/files/shell/config.fish
@@ -14,6 +14,7 @@ set -x PATH /opt/share/utils/bin \
     /usr/lib \
     /sbin \
     /usr/games
+
 set -x KUBECONFIG /etc/kubectl.conf
 
 if test -e /opt/puppetlabs/bin

--- a/modules/ocf/files/shell/csh.cshrc
+++ b/modules/ocf/files/shell/csh.cshrc
@@ -2,6 +2,7 @@
 if(! $?prompt) exit
 
 setenv PATH /opt/share/utils/bin:/opt/share/utils/sbin:/usr/local/bin:/usr/local/sbin:/opt/puppetlabs/bin:/bin:/usr/bin:/usr/sbin:/usr/lib:/sbin:/usr/games
+setenv KUBECONFIG /etc/kubectl.conf
 setenv LANG en_US.UTF-8
 setenv LC_ALL en_US.UTF-8
 setenv MAIL /var/mail/$USER

--- a/modules/ocf/files/shell/zshenv
+++ b/modules/ocf/files/shell/zshenv
@@ -17,4 +17,6 @@ export PATH=/opt/share/utils/bin:/opt/share/utils/sbin:/usr/local/bin:\
 /usr/local/sbin:/opt/puppetlabs/bin:/bin:/usr/bin:/usr/sbin:/usr/lib:/sbin:\
 /usr/games
 
+export KUBECONFIG=/etc/kubectl.conf
+
 zsh-newuser-install () {}

--- a/modules/ocf/manifests/extrapackages.pp
+++ b/modules/ocf/manifests/extrapackages.pp
@@ -13,7 +13,7 @@
 class ocf::extrapackages {
   # special snowflake packages that require some config
   include ocf::packages::emacs
-  include ocf::packages::kubernetes
+  include ocf::packages::kubectl
   include ocf::packages::matplotlib
   include ocf::packages::mysql
   include ocf::packages::mysql_server
@@ -72,7 +72,6 @@ class ocf::extrapackages {
     'jupyter-core',
     'jupyter-notebook',
     'keychain',
-    'kubectl',
     'libcrack2-dev',
     'libdbi-perl',
     'libexpect-perl',

--- a/modules/ocf/manifests/packages/kubectl.pp
+++ b/modules/ocf/manifests/packages/kubectl.pp
@@ -1,0 +1,12 @@
+class ocf::packages::kubectl {
+  include ocf::packages::kubernetes
+
+  package { 'kubectl':; }
+
+  $cluster_cert_base64 = base64('encode', lookup('kubernetes::kubernetes_ca_crt'))
+  file {
+    '/etc/kubectl.conf':
+      content => template('ocf/kubectl/kubectl.conf.erb'),
+      mode    => '0644',
+  }
+}

--- a/modules/ocf/manifests/packages/kubectl.pp
+++ b/modules/ocf/manifests/packages/kubectl.pp
@@ -4,6 +4,7 @@ class ocf::packages::kubectl {
   package { 'kubectl':; }
 
   $cluster_cert_base64 = base64('encode', lookup('kubernetes::kubernetes_ca_crt'))
+
   file {
     '/etc/kubectl.conf':
       content => template('ocf/kubectl/kubectl.conf.erb'),

--- a/modules/ocf/templates/kubectl/kubectl.conf.erb
+++ b/modules/ocf/templates/kubectl/kubectl.conf.erb
@@ -1,5 +1,5 @@
 users:
-- name: ocfstaffer
+- name: kerberos-staff-login
   user:
     exec:
       command: "/opt/share/utils/sbin/gen-kubernetes-cert"
@@ -8,13 +8,13 @@ users:
 clusters:
 - name: prod
   cluster:
-    certificate-authority-data: <%= @cluster_cert_base64.gsub(/\n/, "") %>
+    certificate-authority-data: <%= @cluster_cert_base64.delete("\n") %>
     server: https://kubernetes:6443
 
 contexts:
 - name: prod
   context:
     cluster: prod
-    user: ocfstaffer
+    user: kerberos-staff-login
 
 current-context: prod

--- a/modules/ocf/templates/kubectl/kubectl.conf.erb
+++ b/modules/ocf/templates/kubectl/kubectl.conf.erb
@@ -1,0 +1,20 @@
+users:
+- name: ocfstaffer
+  user:
+    exec:
+      command: "/opt/share/utils/sbin/gen-kubernetes-cert"
+      apiVersion: "client.authentication.k8s.io/v1beta1"
+
+clusters:
+- name: prod
+  cluster:
+    certificate-authority-data: <%= @cluster_cert_base64.gsub(/\n/, "") %>
+    server: https://kubernetes:6443
+
+contexts:
+- name: prod
+  context:
+    cluster: prod
+    user: ocfstaffer
+
+current-context: prod


### PR DESCRIPTION
This adds a default, working, `KUBECONFIG` file that uses the cert generation script. Now staffers can use `kubectl` on supernova!