### PR TITLE
Migrate jaws from marathon slave to kubernetes worker

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -81,6 +81,7 @@ kubernetes::install_dashboard: false
 kubernetes::controller_address: 169.229.226.75:6443
 kubernetes::nginx_version: '0.21.0'
 kubernetes::worker_nodes:
+    - jaws
     - hozer-73
     - hozer-74
 kubernetes::master_nodes:

--- a/hieradata/nodes/jaws.yaml
+++ b/hieradata/nodes/jaws.yaml
@@ -1,7 +1,6 @@
 classes:
     - ocf_kvm
-    - ocf_mesos::slave
-    - ocf_mesos::secrets
+    - ocf_kubernetes::worker
 
 ocf::networking::bridge: true
 ocf::networking::bond: true


### PR DESCRIPTION
This is tested and working in prod! Mostly just making a PR for this in case there's anything I missed in this transition. I had to manually stop `mesos-slave` on jaws.