### PR TITLE
 kubernetes: add haproxy config for proxied hosts

### DIFF
--- a/modules/ocf_kubernetes/manifests/master/loadbalancer.pp
+++ b/modules/ocf_kubernetes/manifests/master/loadbalancer.pp
@@ -45,7 +45,7 @@ class ocf_kubernetes::master::loadbalancer {
     # When accessing domains from within the OCF subnet, going to the hostname
     # (e.g. typing "labmap/" into the web browser) should also redirect.
     prefix(['.ocf.io', ''], $domain).map |$fqdn| {
-      {'redirect' => "prefix https://${domain}.ocf.berkeley.edu code 301 if { hdr(host) -i ${fqdn} }"}
+      {'redirect' => "prefix https://${domain}.ocf.berkeley.edu%[capture.req.uri] code 301 if { hdr(host) -i ${fqdn} }"}
     }
   })
 


### PR DESCRIPTION
Some dockerized services, like www (ocfweb), irc (thelounge), puppet (puppetboard), don't have DNS entries that point directly to the load balancer, but instead get proxied.

This PR allows haproxy to still redirect these sites. It creates an "insecure" frontend that these services can reverse proxy to.

This is tested to not fail, however since we haven't yet migrated any Kubernetes services that need this, it isn't fully tested. The first application I'll test for this is Puppetboard. If that works, thelounge will probably be next.