### PR TITLE
fix archlinuxcn-health script

### DIFF
--- a/modules/ocf_mirrors/manifests/projects/archlinuxcn.pp
+++ b/modules/ocf_mirrors/manifests/projects/archlinuxcn.pp
@@ -21,7 +21,6 @@ class ocf_mirrors::projects::archlinuxcn {
   ocf_mirrors::monitoring { 'archlinuxcn':
     type          => 'unix_timestamp',
     upstream_host => 'mirrors.tuna.tsinghua.edu.cn',
-    upstream_path => 'archlinuxcn',
     ts_path       => 'lastupdate',
   }
 


### PR DESCRIPTION
The `upstream_path` should start with a '/'. The default in `ocf_mirrors:monitoring` is `/${title}`, which should work fine if we just delete this line.