### PR TITLE
printhost: give opstaff admin permissions

### DIFF
--- a/modules/ocf_printhost/files/cups-files.conf
+++ b/modules/ocf_printhost/files/cups-files.conf
@@ -1,5 +1,5 @@
 # Administrative group
-SystemGroup ocfstaff
+SystemGroup ocfstaff opstaff
 
 # SSL
 ServerKeychain /etc/ssl/private


### PR DESCRIPTION
This lets opstaff take printers in/out of rotation