### PR TITLE
remove avahi-daemon from all machines

### DIFF
--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -45,6 +45,9 @@ class ocf::packages {
       # nonfree shareware with "40-day trial"
       'rar',
       'unrar',
+
+      # slows down desktop unsleeps by ~1 minute
+      'avahi-daemon',
     ]:
       ensure => purged;
   }


### PR DESCRIPTION
Speeds up systemctl start networking from ~50 seconds to ~6 seconds
Nothing seems to actually use avahi and I tested it and nothing broke so we should remove it.