### PR TITLE
do not backport nviida drivers

### DIFF
--- a/modules/ocf_desktop/manifests/drivers.pp
+++ b/modules/ocf_desktop/manifests/drivers.pp
@@ -3,12 +3,10 @@ class ocf_desktop::drivers {
 
   # install proprietary nvidia drivers
   if $::gfx_brand == 'nvidia' {
-    # Install nvidia-driver from backports so that it loads properly
-    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=903770
-    ocf::repackage { ['nvidia-driver', 'libgl1-nvidia-glx:i386', 'nvidia-cuda-toolkit']:
-      backport_on => 'stretch';
+    package {
+      ['nvidia-driver', 'libgl1-nvidia-glx:i386', 'nvidia-cuda-toolkit',
+        'xserver-xorg-video-nvidia', 'nvidia-settings', 'nvidia-cuda-mps']:;
     }
-    package { ['xserver-xorg-video-nvidia', 'nvidia-settings', 'nvidia-cuda-mps']:; }
 
     file { '/etc/X11/xorg.conf':
       source => 'puppet:///modules/ocf_desktop/drivers/nvidia/xorg.conf';


### PR DESCRIPTION
Since the versions in stretch are newer than the versions in stretch-backports, this was causing problems on up-to-date systems.