### PR TITLE
Mirroring openbsd and freebsd

### DIFF
--- a/modules/ocf_mirrors/files/project/freebsd/sync-archive
+++ b/modules/ocf_mirrors/files/project/freebsd/sync-archive
@@ -1,3 +1,3 @@
 #!/bin/sh -eu
 /usr/local/bin/rsync-no-vanished -azH --safe-links --delete-after --delay-updates --no-motd \
- rsync://mirrors.mit.edu/freebsd /opt/mirrors/ftp/freebsd
+ rsync://mirrors.rit.edu/FreeBSD /opt/mirrors/ftp/freebsd

--- a/modules/ocf_mirrors/files/project/freebsd/sync-archive
+++ b/modules/ocf_mirrors/files/project/freebsd/sync-archive
@@ -1,0 +1,3 @@
+#!/bin/sh -eu
+/usr/local/bin/rsync-no-vanished -azH --safe-links --delete-after --delay-updates --no-motd \
+ rsync://mirrors.mit.edu/freebsd /opt/mirrors/ftp/freebsd

--- a/modules/ocf_mirrors/files/project/openbsd/sync-archive
+++ b/modules/ocf_mirrors/files/project/openbsd/sync-archive
@@ -1,0 +1,3 @@
+#!/bin/sh -eu
+/usr/local/bin/rsync-no-vanished -azH --safe-links --delete-after --delay-updates --no-motd \
+ rsync://ftp3.usa.openbsd.org/ftp /opt/mirrors/ftp/openbsd

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -15,11 +15,13 @@ class ocf_mirrors {
   include ocf_mirrors::projects::centos_debuginfo
   include ocf_mirrors::projects::debian
   include ocf_mirrors::projects::finnix
+  include ocf_mirrors::projects::freebsd
   include ocf_mirrors::projects::gnu
   include ocf_mirrors::projects::kali
   include ocf_mirrors::projects::kde
   include ocf_mirrors::projects::kde_applicationdata
   include ocf_mirrors::projects::manjaro
+  include ocf_mirrors::projects::openbsd
   include ocf_mirrors::projects::parrot
   include ocf_mirrors::projects::puppetlabs
   include ocf_mirrors::projects::qt

--- a/modules/ocf_mirrors/manifests/projects/freebsd.pp
+++ b/modules/ocf_mirrors/manifests/projects/freebsd.pp
@@ -11,7 +11,7 @@ class ocf_mirrors::projects::freebsd {
 
   ocf_mirrors::monitoring { 'freebsd':
     type          => 'unix_timestamp',
-    upstream_host => 'mirror.math.princeton.edu',
+    upstream_host => 'ftp.freebsd.org',
     upstream_path => '/pub/FreeBSD',
     ts_path       => 'TIMESTAMP';
   }

--- a/modules/ocf_mirrors/manifests/projects/freebsd.pp
+++ b/modules/ocf_mirrors/manifests/projects/freebsd.pp
@@ -11,7 +11,8 @@ class ocf_mirrors::projects::freebsd {
 
   ocf_mirrors::monitoring { 'freebsd':
     type          => 'unix_timestamp',
-    upstream_host => 'mirrors.mit.edu',
+    upstream_host => 'mirror.math.princeton.edu',
+    upstream_path => '/pub/FreeBSD',
     ts_path       => 'TIMESTAMP';
   }
 

--- a/modules/ocf_mirrors/manifests/projects/freebsd.pp
+++ b/modules/ocf_mirrors/manifests/projects/freebsd.pp
@@ -1,0 +1,24 @@
+class ocf_mirrors::projects::freebsd {
+  file {
+    '/opt/mirrors/project/freebsd':
+      ensure  => directory,
+      source  => 'puppet:///modules/ocf_mirrors/project/freebsd',
+      owner   => mirrors,
+      group   => mirrors,
+      mode    => '0755',
+      recurse => true;
+  }
+
+  ocf_mirrors::monitoring { 'freebsd':
+    type          => 'unix_timestamp',
+    upstream_host => 'mirrors.mit.edu',
+    ts_path       => 'TIMESTAMP';
+  }
+
+  ocf_mirrors::timer {
+    'freebsd':
+      exec_start => '/opt/mirrors/project/freebsd/sync-archive',
+      hour       => '0/3',
+      minute     => '35';
+  }
+}

--- a/modules/ocf_mirrors/manifests/projects/openbsd.pp
+++ b/modules/ocf_mirrors/manifests/projects/openbsd.pp
@@ -11,7 +11,7 @@ class ocf_mirrors::projects::openbsd {
 
   ocf_mirrors::monitoring { 'openbsd':
     type          => 'unix_timestamp',
-    upstream_host => 'mirrors.mit.edu',
+    upstream_host => 'ftp.openbsd.org',
     upstream_path => '/pub/OpenBSD',
     ts_path       => 'timestamp';
   }

--- a/modules/ocf_mirrors/manifests/projects/openbsd.pp
+++ b/modules/ocf_mirrors/manifests/projects/openbsd.pp
@@ -1,0 +1,25 @@
+class ocf_mirrors::projects::openbsd {
+  file {
+    '/opt/mirrors/project/openbsd':
+      ensure  => directory,
+      source  => 'puppet:///modules/ocf_mirrors/project/openbsd',
+      owner   => mirrors,
+      group   => mirrors,
+      mode    => '0755',
+      recurse => true;
+  }
+
+  ocf_mirrors::monitoring { 'openbsd':
+    type          => 'unix_timestamp',
+    upstream_host => 'mirrors.mit.edu',
+    upstream_path => '/pub/OpenBSD',
+    ts_path       => 'timestamp';
+  }
+
+  ocf_mirrors::timer {
+    'openbsd':
+      exec_start => '/opt/mirrors/project/openbsd/sync-archive',
+      hour       => '0/3',
+      minute     => '30';
+  }
+}


### PR DESCRIPTION
The title pretty much says everything.

Currently the config is to sync openbsd from `usa.openbsd.org` which is located in Colorado (not very sure if that's a good idea,) and freebsd from MIT mainly because I cannot find a rsync host in the United State on the official list (`www.freebsd.org/doc/handbook/mirrors-ftp.html`) and MIT happens to host freebsd.

(Also, have we considered a template for sync-archive as well?)