### PR TITLE
Revert "Remove chronic from lets-encrypt-update temporarily, run dail…

### DIFF
--- a/modules/ocf_www/manifests/lets_encrypt.pp
+++ b/modules/ocf_www/manifests/lets_encrypt.pp
@@ -16,10 +16,10 @@ class ocf_www::lets_encrypt {
 
   if $::host_env == 'prod' {
     cron { 'lets-encrypt-update':
-      command     => '/usr/local/bin/lets-encrypt-update -v web',
+      command     => 'chronic /usr/local/bin/lets-encrypt-update -v web',
       user        => ocfletsencrypt,
       environment => ['MAILTO=root', 'PATH=/bin:/usr/bin:/usr/local/bin'],
-      special     => daily,
+      special     => hourly,
       require     => File['/usr/local/bin/lets-encrypt-update',
                           '/etc/ssl/lets-encrypt/le-vhost.key'],
     }


### PR DESCRIPTION
…y (#491)"

This reverts commit 172763aeee65977be20eff4fc70a2101084314a7.

This hasn't been giving us problems so I assume we don't need it anymore, unless I'm missing something?