### PR TITLE
Use the vendored apt module for kube package pinning

### DIFF
--- a/modules/ocf/manifests/packages/kubernetes/apt.pp
+++ b/modules/ocf/manifests/packages/kubernetes/apt.pp
@@ -16,10 +16,13 @@ class ocf::packages::kubernetes::apt {
   # which unfortunately is not exposed.
   $kube_packages = ['kubelet', 'kubectl', 'kubeadm']
   $kube_package_version = lookup('kubernetes::kubernetes_package_version')
-  # Pins each package in $kube_packages to the hiera-specified version,
-  # so it won't get upgraded automatically by apt.
-  file { '/etc/apt/preferences.d/kubernetes.pref':
-    ensure  => file,
-    content => template('ocf/apt/kubernetes-pin.pref.erb'),
+
+  # Pin each package in $kube_packages to the hiera-specified version,
+  # so they won't get upgraded automatically by apt-dater.
+  apt::pin { 'kubernetes':
+    packages    => $kube_packages,
+    version     => $kube_package_version,
+    priority    => 1001,
+    explanation => "Pin kubernetes packages to the hiera-specified version so they won't get upgraded automatically by apt-dater",
   }
 }

--- a/modules/ocf/templates/apt/kubernetes-pin.pref.erb
+++ b/modules/ocf/templates/apt/kubernetes-pin.pref.erb
@@ -1,9 +1,0 @@
-# This file is managed by Puppet. DO NOT EDIT.
-# Pins each package in $kube_packages to the hiera-specified version,
-# so it won't get upgraded automatically by apt.
-<% @kube_packages.each do |pkg| -%>
-Package: <%= pkg %>
-Pin: version <%= @kube_package_version %>
-Pin-Priority: 1001
-
-<% end -%>


### PR DESCRIPTION
This is the same as #567 but this just uses the (already) vendored apt module to pin the package. When puppet runs, it spits out a diff like so:

```diff
Notice: /Stage[first]/Ocf::Packages::Kubernetes::Apt/Apt::Pin[kubernetes]/Apt::Setting[pref-kubernetes]/File[/etc/apt/preferences.d/kubernetes.pref]/content:
--- /etc/apt/preferences.d/kubernetes.pref      2019-04-04 18:42:47.111541196 -0700
+++ /tmp/puppet-file20190404-16771-1fqfcx       2019-04-04 18:48:10.721641940 -0700
@@ -1,15 +1,5 @@
 # This file is managed by Puppet. DO NOT EDIT.
-# Pins each package in $kube_packages to the hiera-specified version,
-# so it won't get upgraded automatically by apt.
-Package: kubelet
+Explanation: Pin kubernetes packages to the hiera-specified version so they won't get upgraded automatically by apt-dater
+Package: kubelet kubectl kubeadm
 Pin: version 1.12.7-00
 Pin-Priority: 1001
-
-Package: kubectl
-Pin: version 1.12.7-00
-Pin-Priority: 1001
-
-Package: kubeadm
-Pin: version 1.12.7-00
-Pin-Priority: 1001
-
```

The resulting file looks like this:

`/etc/apt/preferences.d/kubernetes.pref`:

```
# This file is managed by Puppet. DO NOT EDIT.
Explanation: Pin kubernetes packages to the hiera-specified version so they won't get upgraded automatically by apt-dater
Package: kubelet kubectl kubeadm
Pin: version 1.12.7-00
Pin-Priority: 1001
```

I also checked that the priority with `apt-cache policy kubelet` for instance is set to 1001 for the version it's supposed to be pinned at (`1.12.7-00`).

Apparently you can have multiple packages on one line and that's fine? Pretty cool anyway. For a bit more information, this uses [this template](https://github.com/puppetlabs/puppetlabs-apt/blob/master/templates/pin.pref.epp) and [this manifest](https://github.com/puppetlabs/puppetlabs-apt/blob/master/manifests/pin.pp) to work.