### PR TITLE
mirrors: sync archlinux iso, others, sources

### DIFF
--- a/modules/ocf_mirrors/files/project/archlinux/sync-archive
+++ b/modules/ocf_mirrors/files/project/archlinux/sync-archive
@@ -38,8 +38,5 @@ fi
 
 rsync_cmd \
     --exclude='*.links.tar.gz*' \
-    --exclude='/other' \
-    --exclude='/sources' \
-    --exclude='/iso' \
     "${source_url}" \
     "${target}"


### PR DESCRIPTION
We were syncing these before, but the recommended script disables them by default. See [the docs](https://wiki.archlinux.org/index.php/DeveloperWiki:NewMirrors#Mirror_size) for more info.