### PR TITLE
fix-displays daisy chaining support

### DIFF
--- a/modules/ocf_desktop/files/xsession/fix-displays
+++ b/modules/ocf_desktop/files/xsession/fix-displays
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # Tile multiple monitors side-by-side
-import re
 import socket
 import subprocess
 import time
@@ -36,21 +35,3 @@ if __name__ == '__main__':
         if prev:
             subprocess.check_call(['xrandr', '--output', monitor, '--right-of', prev])
         prev = monitor
-
-    # special case for eruption: middle monitor is rotated left 90 degrees
-    if len(monitors) == 3 and hostname == 'eruption':
-        # left/right monitors are moved down a bit; move middle up to compensate
-        middle_offset = -305
-        right_offset = 320
-
-        # need to get the current x position of this monitor first
-        line = next(filter(lambda line: monitors[1] in line,
-                           subprocess.check_output(['xrandr']).decode('utf8').splitlines()))
-        x_pos = re.search('\\b\\d+x\\d+\\+(\\d+)\\+', line).group(1)
-
-        subprocess.check_call(['xrandr', '--output', monitors[1],
-                               '--rotate', 'left', '--pos', '{}x{}'.format(x_pos, middle_offset)])
-
-        x_pos = str(int(x_pos) + 1200)
-        subprocess.check_call(['xrandr', '--output', monitors[2],
-                               '--pos', '{}x{}'.format(x_pos, right_offset)])

--- a/modules/ocf_desktop/files/xsession/fix-displays
+++ b/modules/ocf_desktop/files/xsession/fix-displays
@@ -30,8 +30,19 @@ if __name__ == '__main__':
     # |    \------+ \-------/    \------+    \------+  |
     # +------------------------------------------------+
 
+    is_daisy_chaining = any(monitor.endswith('.8') for monitor in monitors)
+    if is_daisy_chaining:
+        sorted_monitors = list(sorted(monitors, reverse=True))
+    else:
+        sorted_monitors = list(sorted(monitors))
+
     prev = None
-    for monitor in sorted(monitors):
+    for monitor in sorted_monitors:
         if prev:
             subprocess.check_call(['xrandr', '--output', monitor, '--right-of', prev])
         prev = monitor
+
+    if is_daisy_chaining:
+        # Disable power saving, this is necessary for some reason
+        subprocess.check_call(['xset', 'dpms', 'force', 'off'])
+        subprocess.check_call(['xset', 'dpms', 'force', 'on'])


### PR DESCRIPTION
This lets us daisy-chain displays together, which is nice because it makes it easier for staffers to connect lab monitors to their personal machines. We need to do a strange thing where we turn of the monitors (`xset dpms force off`) and turn them back on for this to work, otherwise chained monitors won't turn on.

This PR also includes a commit to disable the triple-monitor special case on eruption, which isn't needed anymore.