### PR TITLE
Switch ubuntu mirror upstream from MIT to Enzu.

### DIFF
--- a/modules/ocf_mirrors/manifests/projects/ubuntu.pp
+++ b/modules/ocf_mirrors/manifests/projects/ubuntu.pp
@@ -1,6 +1,6 @@
 class ocf_mirrors::projects::ubuntu {
   ocf_mirrors::ftpsync { 'ubuntu':
-    rsync_host  => 'mirrors.mit.edu',
+    rsync_host  => 'mirror.enzu.com',
     cron_minute => '50';
   }
 


### PR DESCRIPTION
rsync with MIT's mirror kept failing, so I switched to this one temporarily, and it works fine. It's listed as a 20GBPS mirror too [here](https://launchpad.net/ubuntu/+archivemirrors).