### PR TITLE
Add service definition for rpc-statd on nfs server

### DIFF
--- a/modules/ocf_filehost/manifests/init.pp
+++ b/modules/ocf_filehost/manifests/init.pp
@@ -92,5 +92,11 @@ class ocf_filehost(
       subscribe => [Concat['/etc/exports'], Mount['/opt/homes']],
   }
 
+  # This service is required for remote file locking in nfsv3. For some reason it doesn't start automatically with nfs-server
+  service { 'rpc-statd':
+    ensure => 'running',
+    enable => true,
+  }
+
   include ocf::firewall::nfs
 }


### PR DESCRIPTION
For the curious, this is why I couldn't get Kafka working on NFS earlier -- our kubernetes nfs client seems to be using nfsv3 and the service was down (probably from the last time I crashed nfs)