### PR TITLE
Change flags in sync script of Parrot

### DIFF
--- a/modules/ocf_mirrors/files/project/parrot/sync
+++ b/modules/ocf_mirrors/files/project/parrot/sync
@@ -1,3 +1,3 @@
 #!/bin/sh -eu
-/usr/local/bin/rsync-no-vanished -rltpHS --delete-excluded \
+/usr/local/bin/rsync-no-vanished -rltpHS --delete-after --delay-updates\
 	rsync://archive.parrotsec.org/parrot/ /opt/mirrors/ftp/parrot


### PR DESCRIPTION
Parrot have been failing for a while, the reason was something like "cannot open directory `.~tmp~`". After adapting some flags from other projects, the problem seems solved. This also suggest we can consider using a fixed set of flags for all sync scripts (except those `--exclude`).

By the way I have no idea what Parrot is about.