### PR TITLE
 update brave apt key when it expires

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -12,7 +12,7 @@ mod 'puppet-nginx',                    '0.16.0'
 mod 'puppet-archive',                  '3.2.0' # Dependency of puppet-prometheus
 mod 'puppet-prometheus',               '6.2.0'
 mod 'puppetlabs-apache',               '3.1.0'
-mod 'puppetlabs-apt',                  '4.5.1'
+mod 'puppetlabs-apt',                  '6.3.0'
 mod 'puppetlabs-concat',               '4.2.1'
 mod 'puppetlabs-firewall',             '1.12.0'
 mod 'puppetlabs-hocon',                '1.0.0'

--- a/modules/ocf/manifests/packages/brave/apt.pp
+++ b/modules/ocf/manifests/packages/brave/apt.pp
@@ -1,6 +1,7 @@
 # Include Brave apt repo.
 class ocf::packages::brave::apt {
   apt::key { 'brave':
+    ensure => refreshed,
     id     => 'D8BAD4DE7EE17AF52A834B2D0BB75829C2D4E821',
     server => 'pgp.ocf.berkeley.edu',
   }


### PR DESCRIPTION
Brave's APT signing key has a short expiration date: they updated the key on 2019-04-10 before the key was set to expire on 2019-04-13. This will update the key so that we receive the new expiration dates and we can continue to pull from brave's repos.