### PR TITLE
Daisy chaining support for multi-monitor setup

### DIFF
--- a/modules/ocf_desktop/files/suspend/fix-daisy
+++ b/modules/ocf_desktop/files/suspend/fix-daisy
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-case "$1" in
-    resume)
-        xset dpms force off
-        xset dpms force on
-esac
+xset dpms force off
+xset dpms force on

--- a/modules/ocf_desktop/files/suspend/fix-daisy
+++ b/modules/ocf_desktop/files/suspend/fix-daisy
@@ -1,4 +1,10 @@
 #!/bin/bash
 
+# when using daisy chaining on nvidia graphics card on debian,
+# primary monitor is on but the rest of the daisy chained
+# monitors are asleep, and does not wake up.
+#
+# below code forces the monitors to wake up
+
 xset dpms force off
 xset dpms force on

--- a/modules/ocf_desktop/files/suspend/fix-daisy
+++ b/modules/ocf_desktop/files/suspend/fix-daisy
@@ -1,4 +1,7 @@
 #!/bin/bash
 
-xset dpms force off
-xset dpms force on
+case "$1" in
+    resume)
+        xset dpms force off
+        xset dpms force on
+esac

--- a/modules/ocf_desktop/files/suspend/fix-daisy
+++ b/modules/ocf_desktop/files/suspend/fix-daisy
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+xset dpms force off
+xset dpms force on

--- a/modules/ocf_desktop/files/suspend/fix-daisy
+++ b/modules/ocf_desktop/files/suspend/fix-daisy
@@ -7,4 +7,3 @@
 # below code forces the monitors to wake up
 
 xset dpms force off
-xset dpms force on

--- a/modules/ocf_desktop/files/suspend/fix-daisy
+++ b/modules/ocf_desktop/files/suspend/fix-daisy
@@ -7,3 +7,5 @@
 # below code forces the monitors to wake up
 
 xset dpms force off
+xset dpms force on
+xset dpms 0 0 0

--- a/modules/ocf_desktop/files/xsession/fix-displays
+++ b/modules/ocf_desktop/files/xsession/fix-displays
@@ -11,6 +11,9 @@ def get_monitors():
 
 
 def is_daisy_chaining(monitors):
+    # DisplayPort "daisy chaining" utilizes Multi-Stream-Transport feature
+    # that enables several video streams to be carried over single DP port
+    #
     # Check if using daisy chain, if a monitor is daisy chained, the numbering
     # of monitors follows this format (empirically observed, may break if nvidia
     # changes something in the future).

--- a/modules/ocf_desktop/files/xsession/fix-displays
+++ b/modules/ocf_desktop/files/xsession/fix-displays
@@ -58,6 +58,4 @@ if __name__ == '__main__':
         prev = monitor
 
     if daisy_chained:
-        # Disable power saving, this is necessary for some reason
-        subprocess.check_call(['xset', 'dpms', 'force', 'off'])
-        subprocess.check_call(['xset', 'dpms', 'force', 'on'])
+        subprocess.check_call(['fix-daisy'])

--- a/modules/ocf_desktop/files/xsession/fix-displays
+++ b/modules/ocf_desktop/files/xsession/fix-displays
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # Tile multiple monitors side-by-side
-import re
 import socket
 import subprocess
 import time
@@ -9,6 +8,20 @@ import time
 def get_monitors():
     lines = subprocess.check_output(['xrandr']).decode('utf8').splitlines()
     return [line.split()[0] for line in lines if ' connected' in line]
+
+
+def is_daisy_chaining(monitors):
+    # Check if using daisy chain, if a monitor is daisy chained, the numbering
+    # of monitors follows this format (empirically observed, may break if nvidia
+    # changes something in the future).
+    #
+    # ['DP-0.8', 'DP-0.1.8', 'DP-0.1.1.8']
+    # The leading digit stays the same for the daisy chained devices
+    #
+    # In other cases, the leading digits differ.
+    prefix = monitors[0][:4] if len(monitors) > 0 else ''
+
+    return all(monitor.startswith(prefix) for monitor in monitors)
 
 
 if __name__ == '__main__':
@@ -31,26 +44,20 @@ if __name__ == '__main__':
     # |    \------+ \-------/    \------+    \------+  |
     # +------------------------------------------------+
 
+    daisy_chained = is_daisy_chaining(monitors)
+
+    if daisy_chained:
+        sorted_monitors = list(sorted(monitors, reverse=True))
+    else:
+        sorted_monitors = list(sorted(monitors))
+
     prev = None
-    for monitor in sorted(monitors):
+    for monitor in sorted_monitors:
         if prev:
             subprocess.check_call(['xrandr', '--output', monitor, '--right-of', prev])
         prev = monitor
 
-    # special case for eruption: middle monitor is rotated left 90 degrees
-    if len(monitors) == 3 and hostname == 'eruption':
-        # left/right monitors are moved down a bit; move middle up to compensate
-        middle_offset = -305
-        right_offset = 320
-
-        # need to get the current x position of this monitor first
-        line = next(filter(lambda line: monitors[1] in line,
-                           subprocess.check_output(['xrandr']).decode('utf8').splitlines()))
-        x_pos = re.search('\\b\\d+x\\d+\\+(\\d+)\\+', line).group(1)
-
-        subprocess.check_call(['xrandr', '--output', monitors[1],
-                               '--rotate', 'left', '--pos', '{}x{}'.format(x_pos, middle_offset)])
-
-        x_pos = str(int(x_pos) + 1200)
-        subprocess.check_call(['xrandr', '--output', monitors[2],
-                               '--pos', '{}x{}'.format(x_pos, right_offset)])
+    if daisy_chained:
+        # Disable power saving, this is necessary for some reason
+        subprocess.check_call(['xset', 'dpms', 'force', 'off'])
+        subprocess.check_call(['xset', 'dpms', 'force', 'on'])

--- a/modules/ocf_desktop/manifests/suspend.pp
+++ b/modules/ocf_desktop/manifests/suspend.pp
@@ -10,7 +10,18 @@ class ocf_desktop::suspend {
     '/etc/acpi/events/powerbtn-acpi-support':
       source  => 'puppet:///modules/ocf_desktop/suspend/powerbtn-acpi-support',
       require => Package['acpi-support-base'];
+
+    # place files to handle daisy chain sleep issue
+    '/usr/lib/pm-utils/sleep.d/999fix-daisy':
+      mode   => '0755',
+      source => 'puppet:///modules/ocf_desktop/suspend/fix-daisy';
+
+    # place files to handle daisy chain sleep issue
+    '/usr/lib/pm-utils/power.d/fix-daisy':
+      mode   => '0755',
+      source => 'puppet:///modules/ocf_desktop/suspend/fix-daisy';
   }
+
 
   package {
     # ACPI support

--- a/modules/ocf_desktop/manifests/suspend.pp
+++ b/modules/ocf_desktop/manifests/suspend.pp
@@ -11,16 +11,18 @@ class ocf_desktop::suspend {
       source  => 'puppet:///modules/ocf_desktop/suspend/powerbtn-acpi-support',
       require => Package['acpi-support-base'];
 
-    # place files to handle daisy chain sleep issue:
-    # when using daisy chaining on nvidia graphics card on debian,
-    # primary monitor is on but the rest of the daisy chained
-    # monitors are asleep, and does not wake up.
+    # script to handle daisy chained monitors not waking up
     '/usr/lib/pm-utils/sleep.d/999fix-daisy':
       mode   => '0755',
       source => 'puppet:///modules/ocf_desktop/suspend/fix-daisy';
 
-    # place files to handle daisy chain sleep issue as described above
+    # script to handle daisy chained monitors not waking up
     '/usr/lib/pm-utils/power.d/fix-daisy':
+      mode   => '0755',
+      source => 'puppet:///modules/ocf_desktop/suspend/fix-daisy';
+
+    # script to handle daisy chained monitors not waking up
+    '/usr/local/bin/fix-daisy':
       mode   => '0755',
       source => 'puppet:///modules/ocf_desktop/suspend/fix-daisy';
   }

--- a/modules/ocf_desktop/manifests/suspend.pp
+++ b/modules/ocf_desktop/manifests/suspend.pp
@@ -11,12 +11,15 @@ class ocf_desktop::suspend {
       source  => 'puppet:///modules/ocf_desktop/suspend/powerbtn-acpi-support',
       require => Package['acpi-support-base'];
 
-    # place files to handle daisy chain sleep issue
+    # place files to handle daisy chain sleep issue:
+    # when using daisy chaining on nvidia graphics card on debian,
+    # primary monitor is on but the rest of the daisy chained
+    # monitors are asleep, and does not wake up.
     '/usr/lib/pm-utils/sleep.d/999fix-daisy':
       mode   => '0755',
       source => 'puppet:///modules/ocf_desktop/suspend/fix-daisy';
 
-    # place files to handle daisy chain sleep issue
+    # place files to handle daisy chain sleep issue as described above
     '/usr/lib/pm-utils/power.d/fix-daisy':
       mode   => '0755',
       source => 'puppet:///modules/ocf_desktop/suspend/fix-daisy';


### PR DESCRIPTION
Continuing from puppet/PR #572, this PR will allow for a reliable daisy chained, multi-monitor setup.

As dkess mentioned in the reference PR
>This PR also includes a commit to disable the triple-monitor special case on eruption, which isn't needed anymore.