### PR TITLE
keyserver: add pgp.philihp.com to peers

### DIFF
--- a/modules/ocf_keyserver/files/membership
+++ b/modules/ocf_keyserver/files/membership
@@ -11,3 +11,4 @@ keyserver.vbrandl.net 11370 # Valentin Brandl <vbrandl@riseup.net> 0x7FB00917588
 keys.ppcis.net 11370 # Simon Lange <slange@ppcis.net> 0x8745118D0CF58516
 pgp.pm 11370 # admin@pgp.pm 0x519CEA89130F1B91CC0D482DC477C1EC5E231998
 sks.cloud.icij.org 11370 # jorgegv@icij.org 0xAA976E29616D42D4
+pgp.philihp.com 11370 # Philihp Busby <philihp@gmail.com> 0x5B640B9F9600F122


### PR DESCRIPTION
Would appreciate being added to the sync network.