### PR TITLE
lb-kubernetes: reload nginx when there are new SSL certs

### DIFF
--- a/modules/ocf_kubernetes/manifests/master/loadbalancer/ssl.pp
+++ b/modules/ocf_kubernetes/manifests/master/loadbalancer/ssl.pp
@@ -18,5 +18,7 @@ class ocf_kubernetes::master::loadbalancer::ssl(
     domains => [$::fqdn] + flatten($vfqdns),
     owner   => $owner,
     group   => $group,
-  }
+  } ~>
+  # Restart nginx if any cert changes occur
+  Class['Nginx::Service']
 }


### PR DESCRIPTION
Based on https://sourcegraph.ocf.berkeley.edu/github.com/ocf/puppet/-/blob/modules/ocf_mesos/manifests/master/load_balancer/http_vhost.pp#L25, I'm not sure this is actually correct though.