### PR TITLE
kubernetes: add webui

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,8 @@ repos:
     -   id: check-xml
         exclude: ^modules/ocf_desktop/files/pam/.*\.xml$
     -   id: check-yaml
+        args:
+        -   --allow-multiple-documents
     -   id: debug-statements
     -   id: double-quote-string-fixer
     -   id: detect-private-key

--- a/modules/ocf_kubernetes/files/webui/kubernetes_admin_webui
+++ b/modules/ocf_kubernetes/files/webui/kubernetes_admin_webui
@@ -1,0 +1,13 @@
+# Restrict access to the Kubernetes WebUI to ocfroot users only.
+# We do this because it allows some very destructive actions.
+#
+# Note that this PAM service is used only for authentication to the nginx
+# proxy. The WebUI does not support PAM itself-- instead, we pass a bearer token
+# which authenticates to an admin user.
+
+@include common-auth
+@include common-account
+@include common-password
+@include common-session
+
+auth    sufficient    pam_listfile.so onerr=fail item=group sense=allow file=/opt/share/kubernetes-admin-groups

--- a/modules/ocf_kubernetes/files/webui/kubernetes_viewer_webui
+++ b/modules/ocf_kubernetes/files/webui/kubernetes_viewer_webui
@@ -1,0 +1,12 @@
+# Restrict access to the Kubernetes viewer web UI to ocfstaff only.
+#
+# Note that this PAM service is used only for authentication to the nginx
+# proxy. The WebUI does not support PAM itself-- instead, we pass a bearer token
+# which authenticates to a user with staff privileges.
+
+@include common-auth
+@include common-account
+@include common-password
+@include common-session
+
+auth    sufficient    pam_listfile.so onerr=fail item=group sense=allow file=/opt/share/kubernetes-viewer-groups

--- a/modules/ocf_kubernetes/files/webui/webui-ingress.yaml
+++ b/modules/ocf_kubernetes/files/webui/webui-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: webui-ingress
+  namespace: kube-system
+spec:
+  rules:
+    - host: kube.ocf.berkeley.edu
+      http:
+        paths:
+          - backend:
+              serviceName: kubernetes-dashboard
+              servicePort: 80
+
+    - host: kubeadmin.ocf.berkeley.edu
+      http:
+        paths:
+          - backend:
+              serviceName: kubernetes-dashboard
+              servicePort: 80

--- a/modules/ocf_kubernetes/files/webui/webui.yaml
+++ b/modules/ocf_kubernetes/files/webui/webui.yaml
@@ -1,0 +1,144 @@
+# OCF note: this is the "alternative" web UI config, patched to include
+# the --enable-insecure-login argument. It's OK to use this since HTTPS
+# is provided by the reverse proxy.
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ------------------- Dashboard Service Account ------------------- #
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+
+---
+# ------------------- Dashboard Role & Role Binding ------------------- #
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubernetes-dashboard-minimal
+  namespace: kube-system
+rules:
+  # Allow Dashboard to create 'kubernetes-dashboard-key-holder' secret.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+  # Allow Dashboard to create 'kubernetes-dashboard-settings' config map.
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create"]
+  # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["kubernetes-dashboard-key-holder"]
+  verbs: ["get", "update", "delete"]
+  # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["kubernetes-dashboard-settings"]
+  verbs: ["get", "update"]
+  # Allow Dashboard to get metrics from heapster.
+- apiGroups: [""]
+  resources: ["services"]
+  resourceNames: ["heapster"]
+  verbs: ["proxy"]
+- apiGroups: [""]
+  resources: ["services/proxy"]
+  resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
+  verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubernetes-dashboard-minimal
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubernetes-dashboard-minimal
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-dashboard
+  namespace: kube-system
+
+---
+# ------------------- Dashboard Deployment ------------------- #
+
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        k8s-app: kubernetes-dashboard
+    spec:
+      containers:
+      - name: kubernetes-dashboard
+        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        args:
+          - --enable-insecure-login
+        volumeMounts:
+          # Create on-disk volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9090
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+      volumes:
+      - name: tmp-volume
+        emptyDir: {}
+      serviceAccountName: kubernetes-dashboard
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+
+---
+# ------------------- Dashboard Service ------------------- #
+
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  ports:
+  - port: 80
+    targetPort: 9090
+  selector:
+    k8s-app: kubernetes-dashboard

--- a/modules/ocf_kubernetes/manifests/master.pp
+++ b/modules/ocf_kubernetes/manifests/master.pp
@@ -15,6 +15,7 @@ class ocf_kubernetes::master {
   include ocf::packages::docker_kubernetes
   include ocf::packages::kubernetes
   include ocf_kubernetes::master::loadbalancer
+  include ocf_kubernetes::master::webui
 
   $etcd_version = lookup('kubernetes::etcd_version')
   $etcd_archive = "etcd-v${etcd_version}-linux-amd64.tar.gz"
@@ -36,6 +37,10 @@ class ocf_kubernetes::master {
   # Passwords for the static token file
   # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file
   $ocf_jenkins_deploy_token = lookup('kubernetes::jenkins_token')
+
+  # Used for dashboard users
+  $ocf_admin_token = lookup('kubernetes::admin_token')
+  $ocf_viewer_token = lookup('kubernetes::viewer_token')
 
   file {
     '/etc/ocf-kubernetes':

--- a/modules/ocf_kubernetes/manifests/master/loadbalancer.pp
+++ b/modules/ocf_kubernetes/manifests/master/loadbalancer.pp
@@ -35,14 +35,18 @@ class ocf_kubernetes::master::loadbalancer {
     vip => $vip,
   }
 
-  package { ['nginx-extras']:; }
+  # The PAM module is needed for the web UI auth prompt
+  package { ['nginx-extras', 'libnginx-mod-http-auth-pam']:; }
 
   class { 'nginx':
-    manage_repo  => false,
-    confd_purge  => true,
-    server_purge => true,
+    manage_repo       => false,
+    confd_purge       => true,
+    server_purge      => true,
+    nginx_cfg_prepend =>  {
+      'load_module' =>  '"modules/ngx_http_auth_pam_module.so"',
+    },
 
-    require      => Package['nginx-extras'],
+    require           =>  Package['nginx-extras', 'libnginx-mod-http-auth-pam'],
   }
 
   $upstream_workers = Hash.new($kubernetes_worker_nodes.map |String $worker| {
@@ -128,6 +132,16 @@ class ocf_kubernetes::master::loadbalancer {
   ocf_kubernetes::master::loadbalancer::http_redirect { 'kanboard':
     server_name    => 'kanboard.ocf.berkeley.edu',
     server_aliases => ['kanboard', 'kanboard.ocf.io'],
+  }
+
+  ocf_kubernetes::master::loadbalancer::http_redirect { 'kube':
+    server_name    => 'kube.ocf.berkeley.edu',
+    server_aliases => ['kube', 'kube.ocf.io'],
+  }
+
+  ocf_kubernetes::master::loadbalancer::http_redirect { 'kubeadmin':
+    server_name    => 'kubeadmin.ocf.berkeley.edu',
+    server_aliases => ['kubeadmin', 'kubeadmin.ocf.io'],
   }
 
   ocf_kubernetes::master::loadbalancer::http_redirect { 'labmap':

--- a/modules/ocf_kubernetes/manifests/master/webui.pp
+++ b/modules/ocf_kubernetes/manifests/master/webui.pp
@@ -1,0 +1,100 @@
+class ocf_kubernetes::master::webui {
+  file {
+    '/opt/share/kubernetes-admin-groups':
+      content => 'ocfroot\n';
+
+    '/opt/share/kubernetes-viewer-groups':
+      content => 'ocfstaff\n';
+
+    '/etc/pam.d/kubernetes_admin_webui':
+      source  => 'puppet:///modules/ocf_kubernetes/webui/kubernetes_admin_webui',
+      require => File['/opt/share/kubernetes-admin-groups'];
+
+    '/etc/pam.d/kubernetes_viewer_webui':
+      source  => 'puppet:///modules/ocf_kubernetes/webui/kubernetes_viewer_webui',
+      require => File['/opt/share/kubernetes-viewer-groups'];
+
+    '/etc/ocf-kubernetes/manifests/webui.yaml':
+      source => 'puppet:///modules/ocf_kubernetes/webui/webui.yaml';
+
+    '/etc/ocf-kubernetes/manifests/webui-ingress.yaml':
+      source => 'puppet:///modules/ocf_kubernetes/webui/webui-ingress.yaml';
+  }
+
+  ocf_kubernetes::apply {
+    'webui':
+      target    => '/etc/ocf-kubernetes/manifests/webui.yaml',
+      subscribe => File['/etc/ocf-kubernetes/manifests/webui.yaml'];
+
+    'ingress':
+      target    => '/etc/ocf-kubernetes/manifests/webui-ingress.yaml',
+      subscribe => File['/etc/ocf-kubernetes/manifests/webui-ingress.yaml'];
+  }
+
+  $kubernetes_admin_token = lookup('kubernetes::admin_token')
+  $kubernetes_viewer_token = lookup('kubernetes::viewer_token')
+
+  nginx::resource::server {
+    'kubernetes-admin':
+      server_name      => ['kubeadmin.ocf.berkeley.edu'],
+      proxy            => 'http://kubernetes',
+      proxy_set_header => [
+        'Host $host',
+        'X-Forwarded-For $proxy_add_x_forwarded_for',
+        'X-Forwarded-Proto $scheme',
+        'X-Real-IP $remote_addr',
+        "Authorization 'Bearer ${kubernetes_admin_token}'",
+      ],
+
+      listen_port      => 443,
+      ssl              => true,
+      ssl_cert         => "/etc/ssl/private/${::fqdn}.bundle",
+      ssl_key          => "/etc/ssl/private/${::fqdn}.key",
+      ssl_dhparam      => '/etc/ssl/dhparam.pem',
+
+      add_header       => {
+        'Strict-Transport-Security' =>  'max-age=31536000',
+      },
+
+      # has a sensitive authorization header
+      mode             => '0600',
+
+      raw_append       => [
+        'auth_pam "OCF Kubernetes Admin";',
+        'auth_pam_service_name kubernetes_admin_webui;',
+      ],
+
+      require          =>  File['/etc/pam.d/kubernetes_admin_webui'];
+
+    'kubernetes-viewer':
+      server_name      => ['kube.ocf.berkeley.edu'],
+      proxy            => 'http://kubernetes',
+      proxy_set_header => [
+        'Host $host',
+        'X-Forwarded-For $proxy_add_x_forwarded_for',
+        'X-Forwarded-Proto $scheme',
+        'X-Real-IP $remote_addr',
+        "Authorization 'Bearer ${kubernetes_viewer_token}'",
+      ],
+
+      listen_port      => 443,
+      ssl              => true,
+      ssl_cert         => "/etc/ssl/private/${::fqdn}.bundle",
+      ssl_key          => "/etc/ssl/private/${::fqdn}.key",
+      ssl_dhparam      => '/etc/ssl/dhparam.pem',
+
+      add_header       => {
+        'Strict-Transport-Security' =>  'max-age=31536000',
+      },
+
+      # has a sensitive authorization header
+      mode             => '0600',
+
+      raw_append       => [
+        'auth_pam "OCF Kubernetes View";',
+        'auth_pam_service_name kubernetes_viewer_webui;',
+      ],
+
+      require          =>  File['/etc/pam.d/kubernetes_viewer_webui'];
+  }
+}

--- a/modules/ocf_kubernetes/templates/static-tokens.csv.erb
+++ b/modules/ocf_kubernetes/templates/static-tokens.csv.erb
@@ -1,1 +1,3 @@
 <%= @ocf_jenkins_deploy_token %>,jenkins-deploy,jenkins-deploy,"ocfdeploy"
+<%= @ocf_admin_token %>,ocf-admin-webui,ocf-admin-webui,"ocfroot"
+<%= @ocf_viewer_token %>,ocf-viewer-webui,ocf-viewer-webui,"ocfstaff"


### PR DESCRIPTION
This commit adds files that enable the Kubernetes web dashboard, including:

* static bearer tokens that give ocfroot and ocfstaff privileges
* nginx configs to take PAM auth and pass these tokens to the dashboard
* Kubernetes resource definitions for installing the dashboard into the cluster.

We need to pass an "allow insecure login" flag to the dashboard container since it doesn't understand that it's actually being served over HTTPS. Unfortunately, this means we have to copy their whole service definition into version control (`webui.yaml`) to change that one value.