### PR TITLE
only disable sleep on double monitors and up

### DIFF
--- a/modules/ocf_desktop/files/suspend/fix-daisy
+++ b/modules/ocf_desktop/files/suspend/fix-daisy
@@ -6,6 +6,11 @@
 #
 # below code forces the monitors to wake up
 
-xset dpms force off
-xset dpms force on
-xset dpms 0 0 0
+# only run xset commands if there are more than one monitors
+if (( $(xrandr | grep -ce '\sconnected') > 1 ))
+then
+    echo "42"
+    xset dpms force off
+    xset dpms force on
+    xset dpms 0 0 0
+fi

--- a/modules/ocf_desktop/files/suspend/fix-daisy
+++ b/modules/ocf_desktop/files/suspend/fix-daisy
@@ -9,7 +9,6 @@
 # only run xset commands if there are more than one monitors
 if (( $(xrandr | grep -ce '\sconnected') > 1 ))
 then
-    echo "42"
     xset dpms force off
     xset dpms force on
     xset dpms 0 0 0


### PR DESCRIPTION
As referenced in #588, we don't need single monitor desktops to be kept awake to prevent DisplayPort MST display issue.

More refined solution would be to apply the `fix-daisy` script to only the daisy chained monitors.