### PR TITLE
printhost: add queue size to monitoring

### DIFF
--- a/modules/ocf_printhost/files/monitor-cups
+++ b/modules/ocf_printhost/files/monitor-cups
@@ -22,11 +22,28 @@ def main():
         registry=registry,
     )
 
+    queue = Gauge(
+        'cups_queue_total',
+        'Size of job queue',
+        ['hostname', 'state'],
+        registry=registry,
+    )
+
     conn = cups.Connection()
     for cups_class, printers in conn.getClasses().items():
         for printer in printers:
             # class is a reserved keyword, so we have to pass it via dictionary
             classes.labels(**{'class': cups_class, 'printer': printer}).set(1)
+
+    for job_id in conn.getJobs():
+        try:
+            job_attrs = conn.getJobAttributes(job_id)
+            queue.labels(
+                hostname=job_attrs['job-originating-host-name'],
+                state=job_attrs['job-state'],
+            ).inc()
+        except cups.IPPError:
+            pass
 
     write_to_textfile(sys.argv[1], registry)
 


### PR DESCRIPTION
This lets us monitor the print queue size with Prometheus. We aggregate based on originating hostname (ie the desktop it was printed from) and "state". I'm not actually sure what state means at this point (it's just an integer) but if we collect data for long enough perhaps its meaning will become clear to us.