### PR TITLE
Use /srv/prometheus as default textfile dir

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -91,3 +91,4 @@ kubernetes::master_nodes:
 
 # Prometheus config
 prometheus::node_exporter::version: 0.17.0
+prometheus::node_exporter::extra_options: '--collector.textfile.directory /srv/prometheus'

--- a/hieradata/nodes/dev-whiteout.yaml
+++ b/hieradata/nodes/dev-whiteout.yaml
@@ -1,4 +1,2 @@
 classes:
     - ocf_printhost
-
-prometheus::node_exporter::extra_options: "--collector.textfile.directory /srv/prometheus"

--- a/hieradata/nodes/dev-whiteout.yaml
+++ b/hieradata/nodes/dev-whiteout.yaml
@@ -1,4 +1,4 @@
 classes:
     - ocf_printhost
 
-prometheus::node_exporter::extra_options: "--collector.textfile.directory /var/local/prometheus"
+prometheus::node_exporter::extra_options: "--collector.textfile.directory /srv/prometheus"

--- a/hieradata/nodes/fallingrocks.yaml
+++ b/hieradata/nodes/fallingrocks.yaml
@@ -3,5 +3,3 @@ ocf::networking::bond: true
 classes:
     - ocf_apt
     - ocf_mirrors
-
-prometheus::node_exporter::extra_options: "--collector.textfile.directory /srv/prometheus"

--- a/hieradata/nodes/fallingrocks.yaml
+++ b/hieradata/nodes/fallingrocks.yaml
@@ -4,4 +4,4 @@ classes:
     - ocf_apt
     - ocf_mirrors
 
-prometheus::node_exporter::extra_options: "--collector.textfile.directory /opt/mirrors/prometheus"
+prometheus::node_exporter::extra_options: "--collector.textfile.directory /srv/prometheus"

--- a/hieradata/nodes/whiteout.yaml
+++ b/hieradata/nodes/whiteout.yaml
@@ -1,4 +1,2 @@
 classes:
     - ocf_printhost
-
-prometheus::node_exporter::extra_options: "--collector.textfile.directory /srv/prometheus"

--- a/hieradata/nodes/whiteout.yaml
+++ b/hieradata/nodes/whiteout.yaml
@@ -1,4 +1,4 @@
 classes:
     - ocf_printhost
 
-prometheus::node_exporter::extra_options: "--collector.textfile.directory /var/local/prometheus"
+prometheus::node_exporter::extra_options: "--collector.textfile.directory /srv/prometheus"

--- a/modules/ocf/manifests/init.pp
+++ b/modules/ocf/manifests/init.pp
@@ -12,6 +12,7 @@ class ocf {
   include ocf::motd
   include ocf::munin::node
   include ocf::networking
+  include ocf::node_exporter
   include ocf::packages
   include ocf::puppet
   include ocf::rootpw
@@ -19,8 +20,4 @@ class ocf {
   include ocf::systemd
   include ocf::utils
   include ocf::walldeny
-
-  if $::lsbdistid != 'Raspbian' {
-    include prometheus::node_exporter
-  }
 }

--- a/modules/ocf/manifests/node_exporter.pp
+++ b/modules/ocf/manifests/node_exporter.pp
@@ -1,0 +1,9 @@
+class ocf::node_exporter {
+  file { '/srv/prometheus':
+    ensure => directory;
+  }
+
+  if $::lsbdistid != 'Raspbian' {
+    include prometheus::node_exporter
+  }
+}

--- a/modules/ocf_mirrors/files/healthcheck
+++ b/modules/ocf_mirrors/files/healthcheck
@@ -126,7 +126,7 @@ def write_prometheus(project, local, upstream):
     last_run.labels(project=project).set(time.time())
 
     write_to_textfile(
-        '/opt/mirrors/prometheus/{}.prom'.format(project),
+        '/srv/prometheus/{}.prom'.format(project),
         registry,
     )
 

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -193,10 +193,6 @@ class ocf_mirrors {
   }
 
   package { ['python3-prometheus-client']: }
-  # Temporary-- to be moved to all hosts
-  file { '/srv/prometheus':
-    ensure =>directory;
-  } ->
   File<|title == '/srv/prometheus'|> {
     owner => 'mirrors',
     group => 'mirrors',

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -193,10 +193,12 @@ class ocf_mirrors {
   }
 
   package { ['python3-prometheus-client']: }
-  file {
-    '/opt/mirrors/prometheus':
-      ensure => directory,
-      owner  => 'mirrors',
-      group  => 'mirrors',
+  # Temporary-- to be moved to all hosts
+  file { '/srv/prometheus':
+    ensure =>directory;
+  } ->
+  File<|title == '/srv/prometheus'|> {
+    owner => 'mirrors',
+    group => 'mirrors',
   }
 }

--- a/modules/ocf_printhost/manifests/monitor.pp
+++ b/modules/ocf_printhost/manifests/monitor.pp
@@ -2,7 +2,7 @@ class ocf_printhost::monitor {
   package { ['libcups2-dev', 'python3-cups', 'python3-prometheus-client']: }
 
   file {
-    '/var/local/prometheus':
+    '/srv/prometheus':
       ensure => directory;
   } ->
   file {
@@ -11,11 +11,11 @@ class ocf_printhost::monitor {
       mode   => '0755';
   } ->
   exec { 'monitor-cups-initial':
-    command => '/usr/local/bin/monitor-cups /var/local/prometheus/cups.prom',
-    creates => '/var/local/prometheus/cups.prom',
+    command => '/usr/local/bin/monitor-cups /srv/prometheus/cups.prom',
+    creates => '/srv/prometheus/cups.prom',
   } ->
   cron { 'monitor-cups':
-    command => '/usr/local/bin/monitor-cups /var/local/prometheus/cups.prom',
+    command => '/usr/local/bin/monitor-cups /srv/prometheus/cups.prom',
     # Run every minute
   }
 }


### PR DESCRIPTION
This consolidates us to a single folder, present on every host, that can be used for textfile metrics. Now, adding custom metrics to a host is as easy as writing to `/srv/prometheus`!

The first two commits in this PR move the existing textfile hosts (`mirrors` and `printhost`) to the new folder. The final commit solidifies it as the default.