### PR TITLE
Add textfile exporter for Puppet environment

### DIFF
--- a/modules/ocf/manifests/node_exporter.pp
+++ b/modules/ocf/manifests/node_exporter.pp
@@ -3,6 +3,10 @@ class ocf::node_exporter {
     ensure => directory;
   }
 
+  file { '/srv/prometheus/ocf-environment.prom':
+    content => template('ocf/environment.prom.erb'),
+  }
+
   if $::lsbdistid != 'Raspbian' {
     include prometheus::node_exporter
   }

--- a/modules/ocf/templates/environment.prom.erb
+++ b/modules/ocf/templates/environment.prom.erb
@@ -1,0 +1,8 @@
+<%
+def prometheus_escape(text)
+    return text.gsub(/([\\"\n])/, {"\n"=>"\\n", "\\"=>"\\\\", "\""=>"\\\""})
+end
+-%>
+# HELP ocf_env The Puppet environment this node is on
+# TYPE ocf_env gauge
+ocf_env{environment="<%= prometheus_escape(@environment) %>"} 1.0


### PR DESCRIPTION
This adds an `ocf_env` environment, which always has an associated label that says which environment the host is on. This could make alerts a bit more verbose, since they can now show if the machine is on someone's environment. We could also expand this later to include other info, like type (desktop, server, etc).