### PR TITLE
prometheus: increase PrinterDown alert grace period

### DIFF
--- a/modules/ocf_prometheus/files/rules.d/printer.rules.yaml
+++ b/modules/ocf_prometheus/files/rules.d/printer.rules.yaml
@@ -61,6 +61,6 @@ groups:
         description: "{{ $labels.instance }} toner is at level {{ $value }}, replace it soon!"
     - alert: PrinterDown
       expr: up{job="printer"} == 0
-      for: 1m
+      for: 2m
       annotations:
         summary: "Printer {{ $labels.instance }} is down"


### PR DESCRIPTION
This alert has been a bit noisy, so I'll increase the `for` period. This is almost never an urgent alert anyways so it's not a huge deal.