### PR TITLE
mail: add prometheus-postfix-exporter

### DIFF
--- a/modules/ocf_mail/manifests/init.pp
+++ b/modules/ocf_mail/manifests/init.pp
@@ -67,4 +67,7 @@ class ocf_mail {
         action => 'accept',
       };
   }
+
+  # Backported from sid
+  package { ['prometheus-postfix-exporter']:; }
 }


### PR DESCRIPTION
This lets us monitor the mail queue. I've backported the package from Debian sid, which includes a nice systemd unit for this. Next PR will be configuring Prometheus to scrape from this endpoint.