### PR TITLE
printhost: use require instead of include for /srv/prometheus

### DIFF
--- a/modules/ocf_printhost/manifests/monitor.pp
+++ b/modules/ocf_printhost/manifests/monitor.pp
@@ -1,6 +1,4 @@
 class ocf_printhost::monitor {
-  include ocf::node_exporter
-
   package { ['libcups2-dev', 'python3-cups', 'python3-prometheus-client']: }
 
   file {
@@ -11,6 +9,7 @@ class ocf_printhost::monitor {
   exec { 'monitor-cups-initial':
     command => '/usr/local/bin/monitor-cups /srv/prometheus/cups.prom',
     creates => '/srv/prometheus/cups.prom',
+    require => File['/srv/prometheus'],
   } ->
   cron { 'monitor-cups':
     command => '/usr/local/bin/monitor-cups /srv/prometheus/cups.prom',


### PR DESCRIPTION
This makes the code a bit cleaner. Credit to @jvperrin for mentioning it in https://github.com/ocf/puppet/pull/600#pullrequestreview-234278776.