### PR TITLE
Move puppetlabs-kubernetes to working patched version

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -17,7 +17,7 @@ mod 'puppetlabs-concat',               '4.2.1'
 mod 'puppetlabs-firewall',             '1.12.0'
 mod 'puppetlabs-hocon',                '1.0.0'
 mod 'puppetlabs-inifile',              '2.2.2' # Dependency of puppetlabs-puppetdb
-mod 'puppetlabs-kubernetes',           '3.1.0'
+mod 'puppetlabs-kubernetes',           '4.0.1'
 mod 'puppetlabs-haproxy',              '2.2.0'
 mod 'puppetlabs-postgresql',           '5.4.0' # Dependency of puppetlabs-puppetdb
 mod 'puppetlabs-puppet_authorization', '0.4.0'

--- a/modules/ocf_kubernetes/manifests/master.pp
+++ b/modules/ocf_kubernetes/manifests/master.pp
@@ -60,6 +60,19 @@ class ocf_kubernetes::master {
     '/etc/ocf-kubernetes/abac.jsonl':
       source => 'puppet:///modules/ocf_kubernetes/abac.jsonl',
       mode   => '0755';
+
+  }
+
+  File['/etc/kubernetes/pki'] {
+    owner  => 'kubernetes-ca',
+  }
+
+  File['/etc/kubernetes/pki/ca.crt'] {
+    owner  => 'kubernetes-ca',
+  }
+
+  File['/etc/kubernetes/pki/ca.key'] {
+    owner  => 'kubernetes-ca',
   }
 
   class { 'kubernetes':
@@ -88,15 +101,11 @@ class ocf_kubernetes::master {
       'authorization-policy-file: /etc/ocf-kubernetes/abac.jsonl',
     ],
 
-    kubeadm_extra_config      => {
-      apiServerExtraVolumes => [
-        {
-          name      => 'ocf-auth',
-          hostPath  => '/etc/ocf-kubernetes',
-          mountPath => '/etc/ocf-kubernetes',
-          writeable => false,
-        },
-      ],
+    apiserver_extra_volumes   => {
+      'ocf-auth' => {
+        hostPath  => '/etc/ocf-kubernetes',
+        mountPath => '/etc/ocf-kubernetes',
+      },
     },
   }
 

--- a/modules/ocf_kubernetes/manifests/master.pp
+++ b/modules/ocf_kubernetes/manifests/master.pp
@@ -60,8 +60,10 @@ class ocf_kubernetes::master {
     '/etc/ocf-kubernetes/abac.jsonl':
       source => 'puppet:///modules/ocf_kubernetes/abac.jsonl',
       mode   => '0755';
-
   }
+
+  # These are needed because puppetlabs-kubernetes sets the permissions to 600
+  # but the certsign script, running under kubernetes-ca, needs to access them
 
   File['/etc/kubernetes/pki'] {
     owner  => 'kubernetes-ca',


### PR DESCRIPTION
Upstream PR is open, should be merged in the next release. Meanwhile this allows the kubernetes masters to be set back to production.