### PR TITLE
[HPC] Add timeout to nvidia_gpu_info, and add persistence daemon

### DIFF
--- a/modules/ocf_hpc/facts.d/nvidia_gpu_info
+++ b/modules/ocf_hpc/facts.d/nvidia_gpu_info
@@ -14,7 +14,12 @@ def main():
         print('nvidia_gpu_info={}')
         return
 
-    nvidia_smi_output = subprocess.check_output(('nvidia-smi', '--query-gpu=name,index', '--format=csv,noheader'))
+    try:
+        nvidia_smi_output = subprocess.check_output(('nvidia-smi', '--query-gpu=name,index', '--format=csv,noheader'),
+                                                    timeout=10)
+    except subprocess.TimeoutExpired:
+        print('nvidia_gpu_info={}')
+        return
     nvidia_gpu_list = nvidia_smi_output.decode('utf-8').split('\n')[:-1]
     nvidia_gpu_info_dict = {}
 

--- a/modules/ocf_hpc/manifests/compute.pp
+++ b/modules/ocf_hpc/manifests/compute.pp
@@ -2,7 +2,7 @@ class ocf_hpc::compute {
   require ocf_hpc
 
   # install proprietary nvidia drivers and CUDA.
-  ocf::repackage { ['nvidia-driver', 'nvidia-settings', 'nvidia-cuda-toolkit']:
+  ocf::repackage { ['nvidia-driver', 'nvidia-settings', 'nvidia-cuda-toolkit', 'nvidia-persistenced']:
       backport_on => stretch;
   } -> file { '/etc/modules-load.d/nvidia-uvm.conf':
     # The nvidia-uvm kernel module, which is needed for CUDA apps, can't be loaded as needed from within Singularity.


### PR DESCRIPTION
In case NVIDIA crashes completely, `nvidia-smi` will hang, so we don't want puppet to hang forever or fail.

Adding the `nvidia-persistenced` package should load the `/dev/nvidia` files on boot; right now, they aren't loaded until someone runs a command that references them, and they can't be loaded from within a Singularity container.