### PR TITLE
gen-desktop-leases: handle missing desktop-leases.conf

### DIFF
--- a/modules/ocf_dhcp/files/gen-desktop-leases
+++ b/modules/ocf_dhcp/files/gen-desktop-leases
@@ -7,8 +7,11 @@ DESKTOP_LEASES_FILE = '/etc/dhcp/desktop-leases.conf'
 
 desktops = hosts_by_filter('(type=desktop)')
 
-with open(DESKTOP_LEASES_FILE, 'r') as f:
-    old_contents = sorted([line.strip() for line in f])
+try:
+    with open(DESKTOP_LEASES_FILE, 'r') as f:
+        old_contents = sorted([line.strip() for line in f])
+except FileNotFoundError:
+    old_contents = []
 
 new_contents = []
 for desktop in sorted(desktops, key=lambda d: d['cn'][0]):


### PR DESCRIPTION
This has been a bug all along, but we never noticed until I spun up dev-pestilence which didn't have a desktop-leases.conf (because this script was supposed to generate it).