### PR TITLE
Simple puppet-trigger motd modification (still kinda WIP)

### DIFF
--- a/modules/ocf/files/puppet-trigger
+++ b/modules/ocf/files/puppet-trigger
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Trigger puppet agent runs."""
 import argparse
+import datetime
 import os
 import re
 import socket
@@ -49,6 +50,20 @@ def switch_to_environment(env):
     )
 
 
+def update_motd(env, reason):
+    dt = datetime.datetime.now()
+    user = os.environ.get('SUDO_USER', 'unknown')
+    if env is None:
+        env = ''
+    with open('/etc/motd', 'a') as f:
+        f.write('[{dt}] Switched to current environment {env} by user {user} for reason: {reason}\n'.format(
+            dt=dt,
+            env=env,
+            user=user,
+            reason=reason,
+        ))
+
+
 def validate_environment(environment):
     if not re.match(r'[a-zA-Z_\-0-9]+$', environment):
         raise ValueError('environment has weird characters')
@@ -75,6 +90,10 @@ def main(argv=None):
         '--no-daemonize', action='store_true',
         help='run in foreground'
     )
+    parser.add_argument(
+        '-r', '--reason',
+        help='reason for switching environments; will update the motd'
+    )
 
     args = parser.parse_args(argv)
 
@@ -83,6 +102,9 @@ def main(argv=None):
         return 1
 
     if args.environment:
+        if args.environment != 'production' and not args.reason:
+            log('You must specify a reason to switch to a non-production environment')
+            return 1
         switch_to_environment(args.environment)
 
     if args.test:
@@ -96,6 +118,9 @@ def main(argv=None):
         flags.append('--no-daemonize')
 
     trigger_run(flags)
+
+    if args.reason:
+        update_motd(args.environment, args.reason)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Something like this would be helpful to have visibility as to why a host was switched to a specific environment.

We include a `--reason` flag in the script (and make it mandatory if we're switching to a non-production env), and write to `/etc/motd` after puppet has ran.

I'm not too sure how to make this work well if `-t` flag isn't included, since I think the puppet run is in the background, so it's likely it would overwrite the file after we finish editing it.

Another issue is after a host is already switched to an environment, if someone just uses `-t` to retrigger puppet without `-e` flag, it would also just wipe out the `/etc/motd` file

Any suggestions for these two problems would be appreciated, this is still very much WIP