### PR TITLE
added a package that I want to use

### DIFF
--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -154,6 +154,7 @@ class ocf::packages {
       [
         'aactivator',
         'fluffy',
+        'xournal',
       ]:;
     }
   }


### PR DESCRIPTION
Xournal is a note taking software that I use to take notes (huh)
Every once in a while I wish our computers can open up the notes. So instead of installing it either system-wide or user-only everywhere, I decide to make a PR.

Raspi apparently doesn't need this.

I don't really know if this is fine, but since we have minecraft installed everywhere I guess it's fine.