### PR TITLE
Make ocf::utils depend on the git package

### DIFF
--- a/modules/ocf/manifests/utils.pp
+++ b/modules/ocf/manifests/utils.pp
@@ -3,6 +3,7 @@ class ocf::utils {
     ensure   => latest,
     provider => git,
     revision => 'master',
-    source   => 'https://github.com/ocf/utils.git';
+    source   => 'https://github.com/ocf/utils.git',
+    require  => Package['git'];
   }
 }


### PR DESCRIPTION
I just had a puppet run fail because ocf::utils tried to execute before git was installed.