### PR TITLE
update-groups: don't add pubstaff

### DIFF
--- a/modules/ocf_labstats/files/bin/update-groups
+++ b/modules/ocf_labstats/files/bin/update-groups
@@ -31,7 +31,7 @@ def main():
     with open('/opt/stats/ocfstats-password') as f:
         ocfstats_password = f.read().rstrip()
 
-    update_group(ocfstats_password, 'staff', list_staff() + ['pubstaff'])
+    update_group(ocfstats_password, 'staff', list_staff())
     update_group(ocfstats_password, 'opstaff', list_staff('opstaff'))
 
 if __name__ == '__main__':


### PR DESCRIPTION
I don't remember why we continue to add them, but since the pubstaff account isn't used anymore, I think it should be safe to remove