### PR TITLE
Run nvidia-modprobe on reboot on HPC compute nodes.

### DIFF
--- a/modules/ocf_hpc/manifests/compute.pp
+++ b/modules/ocf_hpc/manifests/compute.pp
@@ -8,6 +8,14 @@ class ocf_hpc::compute {
     # The nvidia-uvm kernel module, which is needed for CUDA apps, can't be loaded as needed from within Singularity.
     content => "nvidia-uvm\n";
   }
+  # This has to be run for software within a singularity container to use CUDA after a boot:
+  # see https://github.com/sylabs/singularity/issues/2203
+  cron { 'nvidia-modprobe':
+    command => 'nvidia-modprobe -u -c=0',
+    special => 'reboot',
+    user    => 'root',
+    require => Package['nvidia-driver'],
+  }
 
   file { '/etc/slurm-llnl/gres.conf':
     content => template('ocf_hpc/gres.conf.erb'),


### PR DESCRIPTION
Mitigates [this bug](https://github.com/sylabs/singularity/issues/2203).

I have no idea why this works; the `nvidia-uvm` kernel module is already loaded on boot, and just `nvidia-modprobe -u` doesn't fix it.