### PR TITLE
Add XMPP server to dev-flood

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -11,6 +11,7 @@ mod 'camptocamp-kmod',                     '2.3.0' # Dependency of puppetlabs-ku
 mod 'camptocamp-systemd',                  '2.1.0' # Dependency of puppet-prometheus
 mod 'herculesteam-augeasproviders_core',   '2.4.0' # Dependency of puppetlabs-kubernetes
 mod 'herculesteam-augeasproviders_sysctl', '2.3.1' # Dependency of puppetlabs-kubernetes
+mod 'mayflower-prosody',                   '0.4.0'
 mod 'puppet-nginx',                        '0.16.0'
 mod 'puppet-archive',                      '3.2.0' # Dependency of puppet-prometheus
 mod 'puppet-prometheus',                   '6.2.0'

--- a/hieradata/nodes/dev-flood.yaml
+++ b/hieradata/nodes/dev-flood.yaml
@@ -1,2 +1,3 @@
 classes:
     - ocf_irc
+    - ocf_xmpp

--- a/modules/ocf_xmpp/manifests/init.pp
+++ b/modules/ocf_xmpp/manifests/init.pp
@@ -1,0 +1,57 @@
+class ocf_xmpp {
+  # Needed to connect to MySQL
+  package { ['lua-dbi-mysql']: }
+
+  user { 'prosody':
+    groups  => 'ssl-cert',
+    require => [Package['prosody'], Package['ssl-cert']],
+  }
+
+  ocf::firewall::firewall46 {
+    '101 allow xmpp':
+      opts   => {
+        chain  => 'PUPPET-INPUT',
+        proto  => 'tcp',
+        dport  => [5222, 5269],
+        action => 'accept',
+      }
+  };
+
+  $vhost_name = $::host_env ? {
+    'dev'  => 'dev-xmpp.ocf.berkeley.edu',
+    'prod' => 'ocf.berkeley.edu',
+  }
+
+  class { 'prosody':
+    modules                => [
+      'register',
+    ],
+
+    # Might want to change this depending on how we want registration to work
+    allow_registration     => false,
+
+    ssl_key                => "/etc/ssl/private/${::fqdn}.key",
+    ssl_cert               => "/etc/ssl/private/${::fqdn}.bundle",
+
+    c2s_require_encryption => true,
+
+    authentication         => internal_hashed,
+    storage                => sql,
+
+    sql                    => {
+      driver   => 'MySQL',
+      database => 'prosody',
+      host     => 'mysql',
+      port     => 3306,
+      username => 'prosody',
+      password => lookup('xmpp::prosody_mysql_password'),
+    },
+  }
+
+  prosody::virtualhost {
+    $vhost_name:
+      ensure   => present,
+      ssl_key  => "/etc/ssl/private/${::fqdn}.key",
+      ssl_cert => "/etc/ssl/private/${::fqdn}.bundle",
+  }
+}


### PR DESCRIPTION
I want to install an XMPP server so we can get Biboumi running, which will allow users to access IRC from XMPP clients (could be good for mobile). It's a Slack alternative that's easy for us to set up and maintain.

We can also potentially provide XMPP as a service to our users.

Next PR will be adding this to actual flood. Then I'll work on Biboumi.