### PR TITLE
kubernetes: solidify ocfroot-binding and ocfstaff-view-binding

### DIFF
--- a/modules/ocf_kubernetes/files/rbac.yaml
+++ b/modules/ocf_kubernetes/files/rbac.yaml
@@ -1,0 +1,27 @@
+# Allow ocfroot to do anything (cluster-admin)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ocfroot-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: ocfroot
+---
+# Allow ocfstaff to view anything
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ocfstaff-view-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: ocfstaff

--- a/modules/ocf_kubernetes/manifests/master.pp
+++ b/modules/ocf_kubernetes/manifests/master.pp
@@ -60,6 +60,16 @@ class ocf_kubernetes::master {
     '/etc/ocf-kubernetes/abac.jsonl':
       source => 'puppet:///modules/ocf_kubernetes/abac.jsonl',
       mode   => '0755';
+
+    '/etc/ocf-kubernetes/manifests/rbac.yaml':
+      source => 'puppet:///modules/ocf_kubernetes/rbac.yaml',
+      mode   => '0755';
+  }
+
+  ocf_kubernetes::apply {
+    'rbac':
+      target    => '/etc/ocf-kubernetes/manifests/rbac.yaml',
+      subscribe => File['/etc/ocf-kubernetes/manifests/rbac.yaml'];
   }
 
   # These are needed because puppetlabs-kubernetes sets the permissions to 600


### PR DESCRIPTION
These ClusterRoleBindings were applied but never actually codified anywhere. This puts them in Puppet, so they'll get re-applied if we ever need to reprovision the cluster.