### PR TITLE
prometheus: switch to snmp_exporter on kubernetes

### DIFF
--- a/modules/ocf_prometheus/manifests/server.pp
+++ b/modules/ocf_prometheus/manifests/server.pp
@@ -118,7 +118,7 @@ class ocf_prometheus::server {
           },
           {
             target_label => '__address__',
-            replacement  => 'lb.ocf.berkeley.edu:10020',
+            replacement  => 'snmp-exporter.ocf.berkeley:4080',
           },
         ]
       },


### PR DESCRIPTION
Depends on https://github.com/ocf/snmp_exporter/pull/5