### PR TITLE
kubernetes: Masters allow death to access 4080

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -51,6 +51,9 @@ internal_zone_range_6: 2607:f140:8801::1:5-2607:f140:8801::1:90
 desktop_src_range_6: 2607:f140:8801::1:100-2607:f140:8801::1:139
 staffvm_src_range_6: 2607:f140:8801::1:200-2607:f140:8801::1:252
 
+death_ipv4: 169.229.226.23
+death_ipv6: 2607:f140:8801::1:23
+
 # Don't configure the default Apache vhost unless otherwise specified
 apache::default_vhost: false
 # Avoid ISP alerts about supposedly outdated Apache

--- a/modules/ocf_kubernetes/manifests/master/loadbalancer.pp
+++ b/modules/ocf_kubernetes/manifests/master/loadbalancer.pp
@@ -2,6 +2,26 @@ class ocf_kubernetes::master::loadbalancer {
   include ocf::firewall::allow_web
 
   $kubernetes_worker_nodes = lookup('kubernetes::worker_nodes')
+  $death_ipv4 = lookup('death_ipv4')
+  $death_ipv6 = lookup('death_ipv6')
+
+  # Allow death to talk to Kubernetes (ocfweb)
+  firewall_multi {
+    '101 accept from death (IPv4)':
+      chain  => 'PUPPET-INPUT',
+      source => $death_ipv4,
+      proto  => 'tcp',
+      dport  => [4080],
+      action => 'accept';
+
+    '101 accept from death (IPv6)':
+      chain    => 'PUPPET-INPUT',
+      source   => $death_ipv6,
+      proto    => 'tcp',
+      dport    => [4080],
+      action   => 'accept',
+      provider => 'ip6tables';
+  }
 
   # At any given time, only one kubernetes master will hold
   # the first IP. The master holding the IP will handle all


### PR DESCRIPTION
Death terminates SSL and access Kubernetes directly.