### PR TITLE
kubernetes: move ocfdeploy perms from abac to rbac

### DIFF
--- a/modules/ocf_kubernetes/files/abac.jsonl
+++ b/modules/ocf_kubernetes/files/abac.jsonl
@@ -1,1 +1,0 @@
-{"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"group":"ocfdeploy", "namespace": "*", "resource": "*", "apiGroup": "*"}}

--- a/modules/ocf_kubernetes/files/rbac.yaml
+++ b/modules/ocf_kubernetes/files/rbac.yaml
@@ -25,3 +25,17 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: ocfstaff
+---
+# Allow jenkins (ocfdeploy group) to do anything
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ocfroot-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: ocfdeploy

--- a/modules/ocf_kubernetes/manifests/master.pp
+++ b/modules/ocf_kubernetes/manifests/master.pp
@@ -57,10 +57,6 @@ class ocf_kubernetes::master {
       mode      => '0400',
       show_diff => false;
 
-    '/etc/ocf-kubernetes/abac.jsonl':
-      source => 'puppet:///modules/ocf_kubernetes/abac.jsonl',
-      mode   => '0755';
-
     '/etc/ocf-kubernetes/manifests/rbac.yaml':
       source => 'puppet:///modules/ocf_kubernetes/rbac.yaml',
       mode   => '0755';
@@ -108,9 +104,8 @@ class ocf_kubernetes::master {
     ],
 
     apiserver_extra_arguments => [
-      'authorization-mode: Node,RBAC,ABAC',
+      'authorization-mode: Node,RBAC',
       'token-auth-file: /etc/ocf-kubernetes/static-tokens.csv',
-      'authorization-policy-file: /etc/ocf-kubernetes/abac.jsonl',
     ],
 
     apiserver_extra_volumes   => {


### PR DESCRIPTION
ABAC is deprecated, so this also removes all ABAC from Kubernetes