### PR TITLE
Install moinmoin on death and tsunami

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -12,7 +12,7 @@ mod 'camptocamp-systemd',                  '2.1.0' # Dependency of puppet-promet
 mod 'herculesteam-augeasproviders_core',   '2.4.0' # Dependency of puppetlabs-kubernetes
 mod 'herculesteam-augeasproviders_sysctl', '2.3.1' # Dependency of puppetlabs-kubernetes
 mod 'puppet-nginx',                        '0.16.0'
-mod 'puppet-archive',                      '3.2.0' # Dependency of puppet-prometheus
+mod 'puppet-archive',                      '3.2.1'
 mod 'puppet-prometheus',                   '6.2.0'
 mod 'puppetlabs-apache',                   '3.1.0'
 mod 'puppetlabs-apt',                      '6.3.0'

--- a/modules/ocf/manifests/moinmoin.pp
+++ b/modules/ocf/manifests/moinmoin.pp
@@ -1,0 +1,18 @@
+class ocf::moinmoin {
+  # Version number is paired with its sha256 hash
+  # See https://moinmo.in/MoinMoinDownload
+  $versions = {
+    '1.9.10' => '4a264418e886082abd457c26991f4a8f4847cd1a2ffc11e10d66231da8a5053c',
+  }
+
+  $versions.each |String $version, String $sha256| {
+    archive { "/tmp/moinmoin-${version}.tar.gz":
+      ensure        => present,
+      source        => "https://static.moinmo.in/files/moin-${version}.tar.gz",
+      checksum      => $sha256,
+      checksum_type => 'sha256',
+      extract       => true,
+      extract_path  => '/opt',
+    }
+  }
+}

--- a/modules/ocf_ssh/manifests/init.pp
+++ b/modules/ocf_ssh/manifests/init.pp
@@ -4,6 +4,7 @@ class ocf_ssh {
   include ocf::hostkeys
   include ocf::limits
   include ocf::firewall::allow_mosh
+  include ocf::moinmoin
   include ocf::packages::cups
   include ocf::ssl::default
 

--- a/modules/ocf_www/manifests/init.pp
+++ b/modules/ocf_www/manifests/init.pp
@@ -15,6 +15,7 @@ class ocf_www {
   include ocf::extrapackages
   include ocf::firewall::allow_web
   include ocf::limits
+  include ocf::moinmoin
   include ocf::tmpfs
   include ocf::ssl::default
 


### PR DESCRIPTION
MoinMoin is a web wiki software that we could offer to our users. This installs the base package in /opt, which will streamline the installation process-- users won't need to download this, since it'll already be installed.

The plan is to have an `easymoinmoin` script which installs the wiki in a user's webspace. Downloading and extracting this takes some time (lots of small files on NFS), so a pre-download will make this a lot faster!