### PR TITLE
Add sudo rules and files for makexmpp

### DIFF
--- a/modules/ocf/manifests/extrapackages.pp
+++ b/modules/ocf/manifests/extrapackages.pp
@@ -171,6 +171,7 @@ class ocf::extrapackages {
     'python3-progressbar',
     'python3-pytest',
     'python3-pytest-cov',
+    'python3-sleekxmpp',
     'python3-stdeb',
     'python3-sympy',
     'python3-tk',

--- a/modules/ocf_irc/templates/prosody.cfg.lua.erb
+++ b/modules/ocf_irc/templates/prosody.cfg.lua.erb
@@ -1,4 +1,4 @@
-admins = {}
+admins = { "root@ocf.berkeley.edu" }
 
 use_libevent = true
 

--- a/modules/ocf_ssh/manifests/makeservices.pp
+++ b/modules/ocf_ssh/manifests/makeservices.pp
@@ -1,7 +1,19 @@
 class ocf_ssh::makeservices {
+  user { 'ocfmakexmpp':
+    comment => 'OCF user to create XMPP accounts',
+    groups  => ['sys'],
+    shell   => '/bin/false',
+    system  => true,
+  }
+
   # enable regular users to run makemysql.py as mysql
   file { '/etc/sudoers.d/makeservices':
     content => "ALL ALL=(mysql) NOPASSWD: /opt/share/utils/makeservices/makemysql-real\n",
+  }
+
+  # enable regular users to run makexmpp.py as ocfmakexmpp
+  file { '/etc/sudoers.d/makexmpp':
+    content => "ALL ALL=(ocfmakexmpp) NOPASSWD: /opt/share/utils/makeservices/makexmpp-real\n",
   }
 
   file {
@@ -12,6 +24,15 @@ class ocf_ssh::makeservices {
 
     '/opt/share/makeservices/makemysql.conf':
       source    => 'puppet:///private/makeservices/makemysql.conf',
+      show_diff => false;
+
+    '/opt/share/makexmpp':
+      ensure => directory,
+      mode   => '0700',
+      owner  => 'ocfmakexmpp';
+
+    '/opt/share/makexmpp/makexmpp.conf':
+      source    => 'puppet:///private/makeservices/makexmpp.conf',
       show_diff => false;
   }
 }


### PR DESCRIPTION
`makexmpp` will be a utility (in the utils repo) for creating an XMPP account, operated in a manner similar to that of `makemysql`. This sets up the necessary configuration to get it working.