### PR TITLE
Repuppet slapd.conf

### DIFF
--- a/modules/ocf_ldap/files/ocf.schema
+++ b/modules/ocf_ldap/files/ocf.schema
@@ -1,0 +1,77 @@
+# OCF custom LDAP schema
+# Private Enterprise Number (PEN) assigned to OCF by IANA is 41759:
+#   http://www.iana.org/assignments/enterprise-numbers
+
+attributetype ( 1.3.6.1.4.1.41759.1.2.1
+        NAME 'calnetUid'
+        DESC 'An integer identifying a user in the CalNet Directory'
+        EQUALITY integerMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.4.1.41759.1.3.1
+        NAME 'oslGid'
+        DESC 'An integer identifying a student organization (deprecated)'
+        EQUALITY integerMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.4.1.41759.1.4.1
+        NAME 'callinkOid'
+        DESC 'An integer identifying an organization in CalLink'
+        EQUALITY integerMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+        SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.4.1.41759.1.5.1
+        NAME 'lastRenewal'
+        DESC 'Last virtual host renewal date'
+        EQUALITY generalizedTimeMatch
+        ORDERING generalizedTimeOrderingMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+        SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.4.1.41759.1.6.1
+        NAME 'creationTime'
+        DESC 'Account creation date'
+        EQUALITY generalizedTimeMatch
+        ORDERING generalizedTimeOrderingMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+        SINGLE-VALUE )
+
+objectclass ( 1.3.6.1.4.1.41759.1.1.1
+        NAME 'ocfAccount'
+        DESC 'Attributes for OCF accounts'
+        SUP posixAccount
+        AUXILIARY
+        MUST ( cn $ uid $ uidNumber $ gidNumber $ homeDirectory $ loginShell )
+        MAY ( calnetUid $ oslGid $ callinkOid $ mail $ lastRenewal $ creationTime ) )
+
+attributetype ( 1.3.6.1.4.1.41759.2.2.1
+        NAME 'type'
+        DESC 'Host type'
+        EQUALITY caseIgnoreIA5Match
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+        SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.4.1.41759.2.2.2
+        NAME 'dnsCname'
+        DESC 'DNS CNAME record'
+        EQUALITY caseIgnoreMatch
+        SUBSTR caseIgnoreSubstringsMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
+attributetype ( 1.3.6.1.4.1.41759.2.2.3
+        NAME 'dnsA'
+        DESC 'DNS A record'
+        EQUALITY caseIgnoreMatch
+        SUBSTR caseIgnoreSubstringsMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
+objectclass ( 1.3.6.1.4.1.41759.2.1.1
+        NAME 'ocfDevice'
+        DESC 'Attributes for OCF hosts'
+        SUP ( ipHost $ ieee802Device $ puppetClient )
+        AUXILIARY
+        MUST ( cn $ ipHostNumber $ type )
+        MAY ( environment $ dnsCname $ dnsA ) )

--- a/modules/ocf_ldap/files/puppet.schema
+++ b/modules/ocf_ldap/files/puppet.schema
@@ -1,0 +1,31 @@
+# Downloaded from
+# https://github.com/puppetlabs/puppet/blob/master/ext/ldap/puppet.schema
+# (commit 0c32e9d5e7aa87f2bcd9f8a5002c2400b6076456).
+#
+# This is part of the Puppet project and licensed under the Apache license.
+# It has not been modified by the OCF.
+
+attributetype (  1.3.6.1.4.1.34380.1.1.3.10 NAME 'puppetClass'
+	DESC 'Puppet Node Class'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.34380.1.1.3.9 NAME 'parentNode'
+	DESC 'Puppet Parent Node'
+	EQUALITY caseIgnoreIA5Match
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+        SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.4.1.34380.1.1.3.11 NAME 'environment'
+	DESC 'Puppet Node Environment'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+attributetype ( 1.3.6.1.4.1.34380.1.1.3.12 NAME 'puppetVar'
+	DESC 'A variable setting for puppet'
+	EQUALITY caseIgnoreIA5Match
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+objectclass ( 1.3.6.1.4.1.34380.1.1.1.2 NAME 'puppetClient' SUP top AUXILIARY
+	DESC 'Puppet Client objectclass'
+	MAY ( puppetclass $ parentnode $ environment $ puppetvar ))

--- a/modules/ocf_ldap/manifests/init.pp
+++ b/modules/ocf_ldap/manifests/init.pp
@@ -21,6 +21,10 @@ class ocf_ldap {
   }
 
   file {
+    '/etc/ldap/slapd.conf':
+      content => template('ocf_/ldap/slapd.conf.erb'),
+      require => Package['slapd'];
+
     '/etc/ldap/schema/ocf.schema':
       source  => 'puppet:///modules/ocf_ldap/ocf.schema',
       require => Package['slapd'];

--- a/modules/ocf_ldap/manifests/init.pp
+++ b/modules/ocf_ldap/manifests/init.pp
@@ -6,10 +6,10 @@ class ocf_ldap {
   package { ['slapd', 'libarchive-zip-perl']:; }
   service { 'slapd':
     subscribe => [
-      File[
-        '/etc/ldap/krb5.keytab',
+      File['/etc/ldap/schema/ocf.schema',
+        '/etc/ldap/schema/puppet.schema',
         '/etc/ldap/sasl2/slapd.conf',
-      ],
+        '/etc/ldap/krb5.keytab'],
       Augeas['/etc/default/slapd'],
       Class['ocf::ssl::default'],
     ],
@@ -21,6 +21,14 @@ class ocf_ldap {
   }
 
   file {
+    '/etc/ldap/schema/ocf.schema':
+      source  => 'puppet:///modules/ocf_ldap/ocf.schema',
+      require => Package['slapd'];
+
+    '/etc/ldap/schema/puppet.schema':
+      source  => 'puppet:///modules/ocf_ldap/puppet.schema',
+      require => Package['slapd'];
+
     '/etc/ldap/sasl2/slapd.conf':
       source  => 'puppet:///modules/ocf_ldap/sasl2-slapd',
       require => Package['slapd', 'libsasl2-modules-gssapi-mit'];

--- a/modules/ocf_ldap/manifests/init.pp
+++ b/modules/ocf_ldap/manifests/init.pp
@@ -22,7 +22,7 @@ class ocf_ldap {
 
   file {
     '/etc/ldap/slapd.conf':
-      content => template('ocf_/ldap/slapd.conf.erb'),
+      content => template('ocf_ldap/slapd.conf.erb'),
       require => Package['slapd'];
 
     '/etc/ldap/schema/ocf.schema':
@@ -49,6 +49,7 @@ class ocf_ldap {
   augeas { '/etc/default/slapd':
     context => '/files/etc/default/slapd',
     changes => [
+      'set SLAPD_CONF=/etc/ldap/slapd.conf',
       'set SLAPD_SERVICES \'"ldaps:///"\'',
       'touch KRB5_KTNAME/export',
       'set KRB5_KTNAME /etc/ldap/krb5.keytab',

--- a/modules/ocf_ldap/templates/slapd.conf.erb
+++ b/modules/ocf_ldap/templates/slapd.conf.erb
@@ -1,0 +1,87 @@
+## Daemon configuration
+pidfile  /var/run/slapd/slapd.pid
+loglevel 0
+
+## Schema and objectClass definitions
+include /etc/ldap/schema/core.schema
+include /etc/ldap/schema/cosine.schema
+include /etc/ldap/schema/nis.schema
+include /etc/ldap/schema/puppet.schema
+include /etc/ldap/schema/ocf.schema
+
+## Last modified attributes
+lastmod on
+
+## SSL
+TLSCipherSuite SECURE256:!AES-128-CBC:!ARCFOUR-128:!CAMELLIA-128-CBC:!3DES-CBC:!CAMELLIA-128-CBC
+TLSCertificateFile /etc/ssl/private/<%= @fqdn -%>.crt
+TLSCertificateKeyFile /etc/ssl/private/<%= @fqdn -%>.key
+TLSCACertificateFile /etc/ssl/certs/incommon-intermediate.crt
+
+## Map Kerberos principals to LDAP
+sasl-realm OCF.BERKELEY.EDU
+# users
+authz-regexp ^uid=([^,/]+),cn=OCF.BERKELEY.EDU,cn=GSSAPI,cn=auth$ uid=$1,ou=People,dc=OCF,dc=Berkeley,dc=EDU
+# hosts
+authz-regexp ^uid=host/([^,/]+)\.ocf\.berkeley\.edu,cn=OCF.BERKELEY.EDU,cn=GSSAPI,cn=auth$ cn=$1,ou=Hosts,dc=OCF,dc=Berkeley,dc=EDU
+
+## Database general configuration
+moduleload   back_mdb
+database     mdb
+suffix       dc=OCF,dc=Berkeley,dc=EDU
+
+## LMDB database parameters
+directory    /var/lib/ldap
+maxsize      2147483648
+
+## Indexing
+index objectClass                 eq
+index uid,uidNumber               eq
+index memberUid,uniqueMember      eq
+index cn                          eq,sub
+index calnetUid,oslGid,callinkOid eq,pres
+tool-threads 2
+
+# schema is readable by everyone
+access to dn.base="" by * read
+
+# allow only admins to change userPassword, allow owner to read
+access to dn.subtree="ou=People,dc=OCF,dc=Berkeley,dc=EDU" attrs=userPassword
+    by sasl_ssf=56 dn.regex="^uid=[^,/]+/admin,cn=OCF.BERKELEY.EDU,cn=GSSAPI,cn=auth$$" write
+    by sasl_ssf=56 self read
+    by sasl_ssf=56 anonymous auth
+    by * none
+
+# allow hosts to change their own puppet environments (used by puppet-trigger)
+access to dn.subtree="ou=Hosts,dc=OCF,dc=Berkeley,dc=EDU" attrs=environment
+    by sasl_ssf=56 dn.regex="^uid=[^,/]+/admin,cn=OCF.BERKELEY.EDU,cn=GSSAPI,cn=auth$$" write
+    by sasl_ssf=56 self write
+    by sasl_ssf=56 users read
+    by tls_ssf=256 anonymous read
+
+# prevent changing own shell when sorried
+access to dn.subtree="ou=People,dc=OCF,dc=Berkeley,dc=EDU" filter=(loginShell=/opt/share/utils/bin/sorried) attrs=loginShell
+    by sasl_ssf=56 dn.regex="^uid=[^,/]+/admin,cn=OCF.BERKELEY.EDU,cn=GSSAPI,cn=auth$$" write
+    by sasl_ssf=56 users read
+    by tls_ssf=256 anonymous read
+
+# allow changing own shell if not sorried
+access to dn.subtree="ou=People,dc=OCF,dc=Berkeley,dc=EDU" attrs=loginShell
+    by sasl_ssf=56 dn.regex="^uid=[^,/]+/admin,cn=OCF.BERKELEY.EDU,cn=GSSAPI,cn=auth$$" write
+    by sasl_ssf=56 self write
+    by sasl_ssf=56 users read
+    by tls_ssf=256 anonymous read
+
+# protect user emails, allow changing own email
+access to dn.subtree="ou=People,dc=OCF,dc=Berkeley,dc=EDU" attrs=mail
+    by sasl_ssf=56 dn.regex="^uid=[^,/]+/admin,cn=OCF.BERKELEY.EDU,cn=GSSAPI,cn=auth$$" write
+    by sasl_ssf=56 dn.regex="^uid=[^,/]+/root,cn=OCF.BERKELEY.EDU,cn=GSSAPI,cn=auth$$" read
+    by sasl_ssf=56 dn="uid=smtp/anthrax.ocf.berkeley.edu,cn=OCF.BERKELEY.EDU,cn=GSSAPI,cn=auth" read
+    by sasl_ssf=56 self write
+    by * none
+
+# allow read over ssl or kerberos, and write by only admins
+access to *
+    by sasl_ssf=56 dn.regex="^uid=[^,/]+/admin,cn=OCF.BERKELEY.EDU,cn=GSSAPI,cn=auth$$" write
+    by sasl_ssf=56 users read
+    by tls_ssf=256 anonymous read


### PR DESCRIPTION
I tested this on dev-firestorm and it works. We should keep as much configuration as possible in puppet, instead of in the incomprehendable mess that is /etc/ldap/slapd.d.