### PR TITLE
Snipe-IT on k8s

### DIFF
--- a/modules/ocf/manifests/nginx_proxy.pp
+++ b/modules/ocf/manifests/nginx_proxy.pp
@@ -20,6 +20,7 @@ define ocf::nginx_proxy(
   $base_headers = [
     'Host $host',
     'X-Forwarded-For $proxy_add_x_forwarded_for',
+    'X-Forwarded-Port $server_port',
     'X-Forwarded-Proto $scheme',
     'X-Real-IP $remote_addr',
   ]

--- a/modules/ocf_kubernetes/manifests/master/loadbalancer.pp
+++ b/modules/ocf_kubernetes/manifests/master/loadbalancer.pp
@@ -164,6 +164,11 @@ class ocf_kubernetes::master::loadbalancer {
     server_aliases => ['rt', 'rt.ocf.io'],
   }
 
+  ocf_kubernetes::master::loadbalancer::http_vhost { 'inventory':
+    server_name    => 'inventory.ocf.berkeley.edu',
+    server_aliases => ['inventory', 'inventory.ocf.io'],
+  }
+
   ocf_kubernetes::master::loadbalancer::http_vhost { 'sourcegraph':
     server_name    => 'sourcegraph.ocf.berkeley.edu',
     server_aliases => ['sg', 'sg.ocf.io', 'sourcegraph', 'sourcegraph.ocf.io', 'sg.ocf.berkeley.edu'],


### PR DESCRIPTION
This sets up the k8s vhost for inventory.obe to snipe-it.

It also adds the `X-Forwarded-Port` to `ocf::nginx_proxy` which was needed to get this (and keycloak) to work.