### PR TITLE
modules/ocf: Add hidepid to all OCF systems

### DIFF
--- a/modules/ocf/facts.d/polkit-priv-drop
+++ b/modules/ocf/facts.d/polkit-priv-drop
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+FACT="polkit_priv_drop"
+pkg=$(dpkg-query -s policykit-1 2>/dev/null)
+[[ $? -ne 0 ]] && echo "$FACT=false"
+version=$(echo "$pkg" | grep Version | cut -d' ' -f2)
+if dpkg --compare-versions "$version" 'ge' '0.115'; then
+    echo "$FACT=true"
+else
+    echo "$FACT=false"
+fi

--- a/modules/ocf/manifests/hidepid.pp
+++ b/modules/ocf/manifests/hidepid.pp
@@ -1,0 +1,12 @@
+class ocf::hidepid {
+  mount { '/proc':
+    # Remounts proc with hidepid=2. This prevents users from seeing
+    # processes that aren't their own using command line tools and
+    # by manually going into /proc/<pid>.
+    ensure   => mounted,
+    remounts => true,
+    device   => '/proc',
+    fstype   => 'procfs',
+    options  => 'remount,rw,hidepid=2',
+  }
+}

--- a/modules/ocf/manifests/hidepid.pp
+++ b/modules/ocf/manifests/hidepid.pp
@@ -7,15 +7,26 @@ class ocf::hidepid {
     name   => $group_cap_ptrace,
     system => true,
     before => Mount['/proc'];
-  } ->
-
-  ocf::systemd::override { 'hidepid':
-    unit    => 'systemd-logind.service',
-    content => "[Service]\nSupplementaryGroups=${group_cap_ptrace}\n",
   }
 
-  # NOTE: When policykit is eventually upgraded to version 0.115 we will need
-  # to make a similar change to that unit file.
+  # systemd-logind and policykit need to access info about all processes.
+  # see here: https://wiki.debian.org/Hardening#Mounting_.2Fproc_with_hidepid
+  ocf::systemd::override { 'hidepid-logind':
+    unit    => 'systemd-logind.service',
+    content => "[Service]\nSupplementaryGroups=${group_cap_ptrace}\n",
+    require => Group[$group_cap_ptrace];
+  }
+
+  if str2bool($::polkit_priv_drop) {
+    # Futureproof for policykit for version 0.115. policykit will create this
+    # user, we just need to add it to capptrace
+    user { 'polkitd':
+      name    => 'polkitd',
+      groups  => $group_cap_ptrace,
+      system  => true,
+      require => Group[$group_cap_ptrace];
+    }
+  }
 
   mount { '/proc':
     # Remounts proc with hidepid=2. This prevents users from seeing
@@ -25,6 +36,7 @@ class ocf::hidepid {
     remounts => true,
     device   => '/proc',
     fstype   => 'procfs',
-    options  => "rw,hidepid=2,gid=${group_cap_ptrace}";
+    options  => "rw,hidepid=2,gid=${group_cap_ptrace}",
+    require  => Group[$group_cap_ptrace];
   }
 }

--- a/modules/ocf/manifests/init.pp
+++ b/modules/ocf/manifests/init.pp
@@ -5,6 +5,7 @@ class ocf {
   include ocf::etc
   include ocf::firewall
   include ocf::groups
+  include ocf::hidepid
   include ocf::kerberos
   include ocf::ldap
   include ocf::locale


### PR DESCRIPTION
Remount procfs with the hidepid flag set to 2. This prevents non-root
users from seeing processes that aren't their own using either command
line tools or by going into /proc/<pid> directly.