### PR TITLE
Remove backing up for ldap configuration database

### DIFF
--- a/modules/ocf_ldap/manifests/init.pp
+++ b/modules/ocf_ldap/manifests/init.pp
@@ -66,7 +66,7 @@ class ocf_ldap {
     #
     # Make sure this occurs before the rsync backup for rsnapshot, since this
     # ensures we have a more recent daily backup stored on our backup server
-    command => "/usr/sbin/ldap-git-backup --ldif-cmd 'slapcat -s cn=config; slapcat'",
+    command => '/usr/sbin/ldap-git-backup',
     minute  => 0,
     hour    => 1,
     require => Package['ldap-git-backup'];


### PR DESCRIPTION
We've removed the ldap configuration database so we can safely remove backing up cn=config.
By default, ldap-git-backup runs `safe-ldif`, which does `Runs the command given by "--ldif-cmd" (default slapcat) multiple times and returns the last output as soon as there are two consecutive invocations giving the same number of LDIF stanzas.`
I think this is marginally better than just having ldap-git-backup running slapcat.