### PR TITLE
ldap: add ocfEmail attribute

### DIFF
--- a/modules/ocf_ldap/files/ocf.schema
+++ b/modules/ocf_ldap/files/ocf.schema
@@ -39,13 +39,21 @@ attributetype ( 1.3.6.1.4.1.41759.1.6.1
         SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
         SINGLE-VALUE )
 
+attributetype ( 1.3.6.1.4.1.41759.1.7.1
+        NAME 'ocfEmail'
+        DESC 'OCF email address'
+        EQUALITY caseIgnoreIA5Match
+        SUBSTR caseIgnoreIA5SubstringsMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256}
+        SINGLE-VALUE )
+
 objectclass ( 1.3.6.1.4.1.41759.1.1.1
         NAME 'ocfAccount'
         DESC 'Attributes for OCF accounts'
         SUP posixAccount
         AUXILIARY
         MUST ( cn $ uid $ uidNumber $ gidNumber $ homeDirectory $ loginShell )
-        MAY ( calnetUid $ oslGid $ callinkOid $ mail $ lastRenewal $ creationTime ) )
+        MAY ( calnetUid $ oslGid $ callinkOid $ mail $ lastRenewal $ creationTime $ ocfEmail ) )
 
 attributetype ( 1.3.6.1.4.1.41759.2.2.1
         NAME 'type'


### PR DESCRIPTION
This attribute is intended to contain the "OCF email address" of a user, which is just username + `@ocf.berkeley.edu`. This will make it easier for us to use certain programs that LDAP integrations and want an email address.

This change hasn't been tested or applied anywhere, so I missed something there's still room to correct mistakes.

Some of the fields here are filled in based on the `mail` attribute, copied from [the spec](https://docs.ldap.com/specs/rfc4524.txt) (ctrl+f for `0.9.2342.19200300.100.1.3 NAME 'mail'`).

After this is done, I'll modify [creation.py](https://github.com/ocf/ocflib/blob/master/ocflib/account/creation.py) to fill this in, and then run a script to backfill the field for old accounts.