### PR TITLE
ocf/hidepid: remount proc with gid=ocfstaff

### DIFF
--- a/modules/ocf/manifests/hidepid.pp
+++ b/modules/ocf/manifests/hidepid.pp
@@ -36,7 +36,7 @@ class ocf::hidepid {
     remounts => true,
     device   => '/proc',
     fstype   => 'procfs',
-    options  => "rw,hidepid=2,gid=${group_cap_ptrace}",
+    options  => "rw,hidepid=2,gid=${group_cap_ptrace},gid=ocfstaff",
     require  => Group[$group_cap_ptrace];
   }
 }


### PR DESCRIPTION
Users in ocfroot can already see all processes with sudo.