### PR TITLE
xmpp: remove register module

### DIFF
--- a/modules/ocf_irc/templates/prosody.cfg.lua.erb
+++ b/modules/ocf_irc/templates/prosody.cfg.lua.erb
@@ -15,7 +15,6 @@ modules_enabled = {
     "pep";
     "ping";
     "posix";
-    "register";
     "roster";
     "saslauth";
     "smacks";
@@ -28,10 +27,6 @@ modules_enabled = {
 
 -- mam: never expire archived messages
 archive_expires_after = "never"
-
--- We may want to change this later, dpeending on how self-service account
--- registration ends up working
-allow_registration = false
 
 daemonize = true
 


### PR DESCRIPTION
mod_register handles account creation and password changes. We don't need either, since both of these are handled by the makexmpp script.

We could wait until https://github.com/ocf/utils/pull/112 is merged to merge this, but since we're not getting account creation requests anyways I don't think it matters so much.