### PR TITLE
Initial configuration to allow setting up OTP secrets

### DIFF
--- a/modules/ocf/manifests/auth.pp
+++ b/modules/ocf/manifests/auth.pp
@@ -184,6 +184,13 @@ class ocf::auth($glogin = [], $ulogin = [[]], $gsudo = [], $usudo = [], $nopassw
   # sudo user/group access controls
   package { 'sudo': }
   file {
+    '/etc/otp':
+      mode      => '0400',
+      source    => 'puppet:///otp-secrets/',
+      recurse   => true,
+      purge     => true,
+      force     => true,
+      show_diff => false;
     '/etc/pam.d/sudo':
       source  => 'puppet:///modules/ocf/auth/pam/sudo',
       require => Package['sudo'];

--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -41,7 +41,7 @@ class ocf_desktop::packages {
     # notifications
     ['libnotify-bin', 'notification-daemon']:;
     # security tools
-    ['scdaemon']:;
+    ['scdaemon', 'yubikey-manager']:;
     # utilities
     ['wakeonlan']:;
     # Xorg

--- a/modules/ocf_puppet/files/fileserver.conf
+++ b/modules/ocf_puppet/files/fileserver.conf
@@ -11,6 +11,10 @@
   path /opt/puppet/shares/private/kubernetes/secrets
   allow *
 
+[otp-secrets]
+  path /opt/puppet/shares/private/otp
+  allow *
+
 [etc]
   path /opt/puppet/shares/etc/configs
   allow *

--- a/modules/ocf_puppet/manifests/init.pp
+++ b/modules/ocf_puppet/manifests/init.pp
@@ -15,5 +15,8 @@ class ocf_puppet {
 
     # Staff need to use virtualenv to run tests.
     'virtualenv':;
+
+    # Provides google-authenticator utility for generating google authenticator OTP secrets
+    'libpam-google-authenticator':;
   }
 }


### PR DESCRIPTION
This is the first PR that must be merged for OTP sudo. It sets up the puppetserver/desktops to be ready to create and store secrets.