### PR TITLE
kubernetes: make riptide a worker node

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -70,6 +70,7 @@ kubernetes::controller_address: 169.229.226.75:6443
 kubernetes::nginx_version: '0.21.0'
 kubernetes::worker_nodes:
     - pandemic
+    - riptide
     - hozer-73
     - hozer-74
 kubernetes::master_nodes:

--- a/hieradata/nodes/riptide.yaml
+++ b/hieradata/nodes/riptide.yaml
@@ -1,5 +1,6 @@
 classes:
     - ocf_kvm
+    - ocf_kubernetes::worker
 
 ocf::networking::bridge: true
 ocf::networking::bond: true


### PR DESCRIPTION
Riptide used to be a Marathon slave anyways, so I don't think this is problematic.