### PR TITLE
Add ocf_lb for front end kubernetes termination

### DIFF
--- a/hieradata/nodes/monsoon.yaml
+++ b/hieradata/nodes/monsoon.yaml
@@ -1,0 +1,2 @@
+classes:
+    - ocf_lb

--- a/hieradata/nodes/pileup.yaml
+++ b/hieradata/nodes/pileup.yaml
@@ -1,0 +1,2 @@
+classes:
+    - ocf_lb

--- a/hieradata/nodes/whirlwind.yaml
+++ b/hieradata/nodes/whirlwind.yaml
@@ -1,0 +1,2 @@
+classes:
+    - ocf_lb

--- a/modules/ocf_lb/functions/gen_aliases.pp
+++ b/modules/ocf_lb/functions/gen_aliases.pp
@@ -1,0 +1,29 @@
+# Expands ['mastodon', ('pma', ['phpmyadmin'])]
+# to { 'mastodon.ocf.berkeley.edu' => 'mastodon.ocf.io', 'mastodon']
+#      'pma.ocf.berkeley.edu       => ['pma.ocf.io', 'pma', 'phpmyadmin.ocf.berkeley.edu',
+#                                      'phpmyadmin.ocf.io', 'phymyadmin'] }
+
+function ocf_lb::gen_aliases(Array $services) >> Hash[String, Array[String]] {
+  $expanded_services = $services.map |$service| {
+    case $service {
+      String : {
+        ["${service}.ocf.berkeley.edu", [$service, "${service}.ocf.io"]]
+      }
+      Tuple[String, Array[String]] : {
+        $service_name = $service[0]
+  $other_aliases = $service[1].map |$alias_name| {
+          ["${alias_name}.ocf.berkeley.edu", "${alias_name}.ocf.io", $alias_name]
+  }
+        $aliases = [$service_name, "${service_name}.ocf.io"] + flatten($other_aliases)
+
+        ["${service_name}.ocf.berkeley.edu", $aliases]
+      }
+
+      default: {
+        fail('Expected String or Tuple[String, Array[String]]')
+      }
+    }
+  }
+
+  Hash($expanded_services)
+}

--- a/modules/ocf_lb/manifests/init.pp
+++ b/modules/ocf_lb/manifests/init.pp
@@ -1,0 +1,55 @@
+class ocf_lb {
+  include ocf::firewall::allow_web
+  include ocf_lb::keepalived
+
+  $ssl_cert = "/etc/ssl/private/${::fqdn}.pem"
+
+  $kubernetes_prod_worker_nodes = lookup('kubernetes::worker_nodes')
+  $kubernetes_prod_workers = $kubernetes_prod_worker_nodes.map |$worker| { [$worker, ldap_attr($worker, 'ipHostNumber')] }
+
+  $kubernetes_prod_services =
+  [
+    'auth',
+    'grafana',
+    'ircbot',
+    'kanboard',
+    'labmap',
+    'mastodon',
+    ['pma', ['phpmyadmin']],
+    'metabase',
+    'rt',
+    'inventory',
+    ['sourcegraph', ['sg']],
+    'static',
+    'templates',
+  ]
+
+  $kubernetes_prod_aliases = ocf_lb::gen_aliases($kubernetes_prod_services)
+
+  $kubernetes_prod_proxy =
+  [
+    'irc',
+    'puppet',
+    'snmp-exporter',
+    'www',
+  ]
+
+  package { 'haproxy': }
+
+  file { '/etc/haproxy/haproxy.cfg':
+    content => template('ocf_lb/haproxy.cfg.erb'),
+    require => Package['haproxy'],
+  }
+
+  service { 'haproxy': }
+
+  class { 'ocf_lb::ssl':
+    vip => 'lb',
+  }
+
+  # Reload HAProxy if any of the certs change
+  Concat[$ssl_cert] ~> Service[haproxy]
+
+  # Reload HAProxy if the config changes
+  File['/etc/haproxy/haproxy.cfg'] ~> Service[haproxy]
+}

--- a/modules/ocf_lb/manifests/keepalived.pp
+++ b/modules/ocf_lb/manifests/keepalived.pp
@@ -1,0 +1,27 @@
+# Virtual IP configuration for the load balancer
+class ocf_lb::keepalived {
+
+  # At any given time, only one load balancer will hold
+  # the first IP. The master holding the IP will handle all
+  # HAProxy requests and forward them.
+
+  # IPv6 addresses have to be specified separately as they cannot be in the vrrp
+  # packet together (keepalived 1.2.20+) so they need to be in a
+  # virtual_ipaddress_excluded block instead.
+  $virtual_addresses = [
+    # Primary load balancer IP (v4)
+    '169.229.226.53',
+  ]
+  $virtual_addresses_v6 = [
+    # Primary load balancer IP (v6)
+    '2607:f140:8801::1:53',
+  ]
+  $keepalived_secret = lookup('lb::keepalived::secret')
+
+  package { 'keepalived':; } ->
+  file { '/etc/keepalived/keepalived.conf':
+    content => template('ocf_lb/keepalived.conf.erb'),
+    mode    => '0400',
+  } ~>
+  service { 'keepalived': }
+}

--- a/modules/ocf_lb/manifests/ssl.pp
+++ b/modules/ocf_lb/manifests/ssl.pp
@@ -1,0 +1,19 @@
+class ocf_lb::ssl(
+  String $vip,
+  String $owner = 'ocfletsencrypt',
+  String $group = 'ssl-cert',
+  Array $domains = ['ocf.berkeley.edu', 'ocf.io'],
+) {
+  # Get all the cnames from the VIP
+  $cnames = ldap_attr($vip, 'dnsCname', true)
+
+  $vfqdns = $cnames.map |$cname| {
+    $domains.map |$domain| { "${cname}.${domain}" }
+  }
+
+  ocf::ssl::bundle { $::fqdn:
+    domains => [$::fqdn] + flatten($vfqdns),
+    owner   => $owner,
+    group   => $group,
+  }
+}

--- a/modules/ocf_lb/templates/haproxy.cfg.erb
+++ b/modules/ocf_lb/templates/haproxy.cfg.erb
@@ -1,0 +1,57 @@
+global
+  daemon
+  log localhost local0
+  # TODO: send to syslog
+  maxconn 4000
+  pidfile /var/run/haproxy.pid
+  user haproxy
+  group sys
+  chroot /var/lib/haproxy
+
+defaults
+  timeout connect 10s
+  timeout client 30s
+  timeout server 30s
+  option httplog
+  log global
+  option redispatch
+  retries 3
+
+frontend lb-http
+  bind 0.0.0.0:80
+  mode http
+
+  # https redirect
+  redirect scheme https code 301 if !{ ssl_fc }
+
+frontend lb-https
+  bind 0.0.0.0:443 ssl crt /etc/ssl/private/<%= @fqdn %>.pem
+  mode http
+
+  <%- @kubernetes_prod_aliases.each do |service_name, aliases| -%>
+  redirect prefix https://<%= service_name %> code 301 if { hdr(host) -i <%= aliases.join(' ') %> }
+  use_backend kubernetes-prod if { hdr(host) -i <%= service_name %> }
+  <%- end -%>
+
+
+# Some services don't need SSL termination
+# Either because it has already been done (ocfweb, irc)
+# Or because it doesn't need it (snmp_exporter)
+# As all such traffic should be internal, it is placed on a firewall'd port
+frontend lb-proxy
+  bind 0.0.0.0:4080
+
+  <%- @kubernetes_prod_proxy.each do |proxy_name| -%>
+  use_backend kubernetes-prod if { hdr(host) -i <%= proxy_name %>.ocf.berkeley.edu }
+  <%- end -%>
+
+backend kubernetes-prod
+  balance source
+  hash-type consistent
+  http-request add-header X-Forwarded-Proto https if { ssl_fc }
+  http-request add-header X-Forwarded-Port %[dst_port]
+  mode http
+  option forwardfor
+  <%- @kubernetes_prod_workers.each do |hostname, ip| -%>
+  server <%= hostname %> <%= ip %>:31234
+  <%- end -%>

--- a/modules/ocf_lb/templates/keepalived.conf.erb
+++ b/modules/ocf_lb/templates/keepalived.conf.erb
@@ -1,0 +1,23 @@
+vrrp_instance VI_1 {
+    interface <%= @networking['primary'] %>
+    state MASTER
+    virtual_router_id 52
+    priority 100
+
+    authentication {
+        auth_type PASS
+        auth_pass $ <%= @keepalived_secret %>
+    }
+
+    virtual_ipaddress {
+        <% @virtual_addresses.each do |ip| %>
+            <%= ip %>
+        <% end %>
+    }
+
+    virtual_ipaddress_excluded {
+        <% @virtual_addresses_v6.each do |ip| %>
+            <%= ip %>
+        <% end %>
+    }
+}


### PR DESCRIPTION
This is the start of creating an OCF-wide SSL-terminating reverse proxy. Currently all this does is replace the load balancer on the existing kubernetes masters, in a way that easily supports adding new kubernetes clusters (which is coming soon I promise). This also fixes the weird slowness that all of kubernetes has right now.