### PR TITLE
chrome/firefox: allow SPNEGO auth for keycloak

### DIFF
--- a/modules/ocf/templates/chrome/ocf_policy.json.erb
+++ b/modules/ocf/templates/chrome/ocf_policy.json.erb
@@ -24,9 +24,9 @@
 	"SyncDisabled": true,
 	"TranslateEnabled": true,
 
-	"//": "Allow SPNEGO for Request Tracker.",
-	"AuthServerWhitelist": "rt.ocf.berkeley.edu",
-	"AuthNegotiateDelegateWhitelist": "rt.ocf.berkeley.edu",
+	"//": "Allow SPNEGO for Keycloak SSO.",
+	"AuthServerWhitelist": "auth.ocf.berkeley.edu",
+	"AuthNegotiateDelegateWhitelist": "auth.ocf.berkeley.edu",
 
 	"//": "Misc settings",
 	"DefaultBrowserSettingEnabled": false,

--- a/modules/ocf/templates/firefox/prefs.js.erb
+++ b/modules/ocf/templates/firefox/prefs.js.erb
@@ -7,7 +7,7 @@ pref("browser.privatebrowsing.autostart", true);
 pref("browser.search.geoSpecificDefaults", false);
 pref("browser.shell.checkDefaultBrowser", false);
 pref("browser.showQuitWarning", true);
-pref("network.negotiate-auth.trusted-uris", "https://rt.ocf.berkeley.edu");
+pref("network.negotiate-auth.trusted-uris", "https://auth.ocf.berkeley.edu");
 pref("pdfjs.disabled", true);
 pref("signon.rememberSignons", false);
 pref("startup.homepage_welcome_url", "");


### PR DESCRIPTION
This is necessary for automatic Keycloak logins from desktops.

This commit also removes RT's SPNEGO, but we stopped using SPNEGO for RT anyways so it won't have an effect.