### PR TITLE
backups: stop backing up ldap:/etc/ldap/slapd.d/

### DIFF
--- a/modules/ocf_backups/files/rsnapshot.conf
+++ b/modules/ocf_backups/files/rsnapshot.conf
@@ -55,7 +55,6 @@ backup_script	/opt/share/backups/backup-pgsql	pgsql/
 backup	ocfbackups@kerberos:/var/lib/heimdal-kdc/	servers/kerberos/
 backup	ocfbackups@kerberos:/var/backups/kerberos/	servers/kerberos/
 
-backup	ocfbackups@ldap:/etc/ldap/slapd.d/	servers/ldap/
 backup	ocfbackups@ldap:/var/lib/ldap/	servers/ldap/
 backup	ocfbackups@ldap:/var/backups/ldap/	servers/ldap/
 


### PR DESCRIPTION
With #661 this directory no longer exists. It's been causing rsnapshot sync operations to silently fail (and by extension causing the actual backup operation to neve run). We don't need to back this up anymore anyways since it's now managed within Puppet.