### PR TITLE
brave: download PGP key from official location

### DIFF
--- a/modules/ocf/manifests/packages/brave/apt.pp
+++ b/modules/ocf/manifests/packages/brave/apt.pp
@@ -2,8 +2,8 @@
 class ocf::packages::brave::apt {
   apt::key { 'brave':
     ensure => refreshed,
-    id     => 'D8BAD4DE7EE17AF52A834B2D0BB75829C2D4E821',
-    server => 'pgp.ocf.berkeley.edu',
+    id     =>  'D8BAD4DE7EE17AF52A834B2D0BB75829C2D4E821',
+    source => 'https://brave-browser-apt-release.s3.brave.com/brave-core.asc',
   }
 
   apt::source { 'brave':


### PR DESCRIPTION
The PGP infra is under attack, this will protect us from the attack in case the Brave key gets hit.

See https://gist.github.com/rjhansen/67ab921ffb4084c865b3618d6955275f