### PR TITLE
mail: remove expansion_limit for vhosts

### DIFF
--- a/modules/ocf_mail/templates/site_vhost/mysql-alias-map.erb
+++ b/modules/ocf_mail/templates/site_vhost/mysql-alias-map.erb
@@ -5,4 +5,4 @@ dbname = ocfmail
 query = SELECT forward_to FROM addresses WHERE address = '%s'
 
 # sanity check on forwarding expansions (can be multiple forwarding addresses)
-expansion_limit = 300
+expansion_limit = 1000


### PR DESCRIPTION
A group was hosting a large mailing list with vhosted mail, and this limit was causing it to break (rt#8335). This commit allows for arbitrarily large vhost lists.

In the future, we should look into providing a proper mailing-list service for users who want this functionality.