### PR TITLE
ocf_ldap: Add ocf-ldap-overlay module

### DIFF
--- a/modules/ocf_ldap/manifests/init.pp
+++ b/modules/ocf_ldap/manifests/init.pp
@@ -3,12 +3,13 @@ class ocf_ldap {
 
   # Install libarchive-zip-perl for crc32 command for calculating hashes of
   # ldif files in /etc/ldap/slapd.d, slapd is the ldap server
-  package { ['slapd', 'libarchive-zip-perl']:; }
+  package { ['slapd', 'ocf-ldap-overlay', 'libarchive-zip-perl']:; }
   service { 'slapd':
     subscribe => [
       File['/etc/ldap/schema/ocf.schema',
         '/etc/ldap/schema/puppet.schema',
         '/etc/ldap/sasl2/slapd.conf',
+        '/etc/ldap/slapd.conf',
         '/etc/ldap/krb5.keytab'],
       Augeas['/etc/default/slapd'],
       Class['ocf::ssl::default'],
@@ -23,7 +24,7 @@ class ocf_ldap {
   file {
     '/etc/ldap/slapd.conf':
       content => template('ocf_ldap/slapd.conf.erb'),
-      require => Package['slapd'];
+      require => Package['slapd', 'ocf-ldap-overlay'];
 
     '/etc/ldap/schema/ocf.schema':
       source  => 'puppet:///modules/ocf_ldap/ocf.schema',

--- a/modules/ocf_ldap/templates/slapd.conf.erb
+++ b/modules/ocf_ldap/templates/slapd.conf.erb
@@ -33,6 +33,10 @@ moduleload   back_mdb
 database     mdb
 suffix       dc=OCF,dc=Berkeley,dc=EDU
 
+## OCF virtual attribute overlay
+moduleload   ocfvirt
+overlay      ocfvirt
+
 ## LMDB database parameters
 directory    /var/lib/ldap
 maxsize      2147483648


### PR DESCRIPTION
Load the overlay and enable the module.

The schema created in https://github.com/ocf/puppet/pull/668 will still
work as a virtual attribute.

The code for the overlay can be found at
https://github.com/ocf/ldap-overlay. It builds packages for Debian
Stretch and Debian Buster.