### PR TITLE
extrapackages: add python3-requests-oauthlib

### DIFF
--- a/modules/ocf/manifests/extrapackages.pp
+++ b/modules/ocf/manifests/extrapackages.pp
@@ -171,6 +171,7 @@ class ocf::extrapackages {
     'python3-progressbar',
     'python3-pytest',
     'python3-pytest-cov',
+    'python3-requests-oauthlib',
     'python3-sleekxmpp',
     'python3-stdeb',
     'python3-sympy',


### PR DESCRIPTION
This package will be used for an upcoming utils script (easyfilters). It can be used to interact with Google APIs.