### PR TITLE
Make buster the new netboot stable, add bullseye

### DIFF
--- a/modules/ocf_dhcp/files/netboot/ocf-netboot
+++ b/modules/ocf_dhcp/files/netboot/ocf-netboot
@@ -13,7 +13,7 @@ set -euo pipefail
 # Whichever architecture and distribution is first in the arrays is the default,
 # and is (ab)used for the PXE boot menu.
 archs=(amd64)
-dists=(stretch buster)
+dists=(stretch buster bullseye)
 menu_arch="${archs[0]}"
 menu_dist="${dists[0]}"
 menu_path="debian-installer/$menu_arch"
@@ -42,12 +42,12 @@ chmod 755 $tftpdir
 
 for dist in "${dists[@]}"; do
     for arch in "${archs[@]}"; do
-        if [ "$dist" != "buster" ]; then
+        if [ "$dist" != "bullseye" ]; then
             netboot="http://mirrors/debian/dists/$dist/main/installer-$arch/current/images/netboot/netboot.tar.gz"
             fw="http://cdimage.debian.org/cdimage/unofficial/non-free/firmware/$dist/current/firmware.tar.gz"
         else
             # TODO: Currently the daily image is broken, so use one that works with the firmware
-            # Once buster becomes stable this should be removed and added to the section above,
+            # Once bullseye becomes stable this should be removed and added to the section above,
             # and replaced with the new testing release.
             netboot="https://d-i.debian.org/daily-images/amd64/daily/netboot/netboot.tar.gz"
             fw=""


### PR DESCRIPTION
Without this, making a new buster host was failing due to package issues with sid (hash sum mismatches, which are probably an issue with our mirror, but that's not really related to this).

I ran this on `pestilence`/`dhcp` and then ran `sudo /usr/local/sbin/ocf-netboot` (otherwise it only runs once a week) and booted a new buster host with less problems (got past the part it failed at before anyways).