### PR TITLE
ocf_syslog: Send kubernetes service logs to /var/log/remote/services

### DIFF
--- a/modules/ocf_syslog/files/ocf.conf
+++ b/modules/ocf_syslog/files/ocf.conf
@@ -73,7 +73,7 @@ ruleset(name="ocf-remote") {
     # through docker hosts quite quickly and we want to group logs by service
     # for docker, not by host.
     if (re_match($hostname, '^[a-f0-9]{12}$') and re_match($syslogtag, '^[a-zA-Z0-9:_-]+$')) or
-       re_match($hostname, '^.*deployment-[a-f0-9]+-[a-z0-9]+$') then {
+       re_match($hostname, '^.*-[a-f0-9]{8,9}-[a-z0-9]{5}$') then {
         action(type="omfile" dynaFile="ocf-docker-file" template="ocf-docker")
     } else {
         # Logs from hosts are a bit more sensitive than logs from docker

--- a/modules/ocf_syslog/files/ocf.conf
+++ b/modules/ocf_syslog/files/ocf.conf
@@ -72,7 +72,8 @@ ruleset(name="ocf-remote") {
     # separate them out into service logs instead of per host since we go
     # through docker hosts quite quickly and we want to group logs by service
     # for docker, not by host.
-    if re_match($hostname, '^[a-f0-9]{12}$') and re_match($syslogtag, '^[a-zA-Z0-9:_-]+$') then {
+    if (re_match($hostname, '^[a-f0-9]{12}$') and re_match($syslogtag, '^[a-zA-Z0-9:_-]+$')) or
+       re_match($hostname, '^.*deployment-[a-f0-9]+-[a-z0-9]+$') then {
         action(type="omfile" dynaFile="ocf-docker-file" template="ocf-docker")
     } else {
         # Logs from hosts are a bit more sensitive than logs from docker


### PR DESCRIPTION
Currently these are just piling up in `/var/log/remote/deployment-*` instead of being filtered per service (which also means ocfstaff cannot read them as-is since they are owned by `root:ocfroot` if they are not identified as per-service logs). This also adds information to the log about which kubernetes agent the log came from, which could be useful in debugging.