### PR TITLE
Automatically install Jenkins plugin updates

### DIFF
--- a/modules/ocf_jenkins/files/update-plugins
+++ b/modules/ocf_jenkins/files/update-plugins
@@ -1,0 +1,13 @@
+#!/bin/bash -eu
+
+ssh_cmd="ssh -p 2222 -o StrictHostKeyChecking=no -i /opt/jenkins/deploy/ssh_cli jenkins-deploy@localhost"
+
+# Taken from https://stackoverflow.com/a/25647793 and modified to use SSH
+# instead of the jenkins-cli jar
+updates=$($ssh_cmd list-plugins | grep -e ')$' | awk '{ print $1 }');
+if [ ! -z "${updates}" ]; then
+    echo "Updating Jenkins Plugins: ${updates}"
+    $ssh_cmd install-plugin ${updates}
+    echo "Restarting Jenkins..."
+    $ssh_cmd safe-restart
+fi


### PR DESCRIPTION
This uses the Jenkins SSH interface to install plugin updates on a regular basis instead of having a human (often me) go and install updates to plugins. It should also email root@ when plugin updates are installed. Maybe in the future some information could be added to the email to show what version the dependencies are too, but I wasn't thinking of including that initially, just for simplicity.

I've set everything up on the Jenkins side, it only consisted of adding user permissions for `jenkins-deploy` and adding a SSH public key.

I also moved the comment about user setup to be next to the `user` resource definition, which I think feels a bit more natural. (it's also in [our docs](https://www.ocf.berkeley.edu/docs/staff/backend/jenkins/#h2_jenkins-security-model) anyway)