### PR TITLE
Stop frequent root spam from report-sizes

### DIFF
--- a/modules/ocf_mirrors/files/report-sizes
+++ b/modules/ocf_mirrors/files/report-sizes
@@ -9,7 +9,7 @@ set -euo pipefail
         sort |
         cut -d/ -f2 |
         grep -vE '^\.' |
-        (xargs nice ionice du -hs || true)
+        (xargs nice ionice du -hs || true) \
         2> >(grep -v '^du: cannot access' >&2)
 
     echo -n 'Last updated: '

--- a/modules/ocf_mirrors/files/report-sizes
+++ b/modules/ocf_mirrors/files/report-sizes
@@ -7,9 +7,10 @@ set -euo pipefail
     cd /opt/mirrors/ftp
     find -mindepth 1 -maxdepth 1 -type d |
         sort |
-	cut -d/ -f2 |
-	grep -vE '^\.' |
-	xargs nice ionice du -hs
+        cut -d/ -f2 |
+        grep -vE '^\.' |
+        (xargs nice ionice du -hs || true)
+        2> >(grep -v '^du: cannot access' >&2)
 
     echo -n 'Last updated: '
     date


### PR DESCRIPTION
This should stop messages like `du: cannot access <blah>` from showing up in report-sizes output, since we don't really care about these errors anyway. It should also make `du` exit with a success code (0) so that the updated at line is actually written to the mirror sizes file on each update while still surfacing regular errors that happen in the script.

I'm currently testing this on `fallingrocks`, but the script itself takes quite a while to actually run.