### PR TITLE
Don't run ldap-lint on dev-ldap (it checks prod anyway)

### DIFF
--- a/modules/ocf_ldap/manifests/init.pp
+++ b/modules/ocf_ldap/manifests/init.pp
@@ -112,11 +112,13 @@ class ocf_ldap {
     }
   }
 
-  cron { 'ldap-lint':
-    command => '/opt/share/utils/sbin/ldap-lint',
-    user    => root,
-    special => 'daily',
-    require => Vcsrepo['/opt/share/utils'];
+  if $::host_env == 'prod' {
+    cron { 'ldap-lint':
+      command => '/opt/share/utils/sbin/ldap-lint',
+      user    => root,
+      special => 'daily',
+      require => Vcsrepo['/opt/share/utils'];
+    }
   }
 
   ocf::munin::plugin { 'slapd-open-files':


### PR DESCRIPTION
Maybe we should move this to a different host or just have it check `localhost`? Anyway, we probably don't want this running on `dev-ldap` anyway since we don't really care if that is broken or not, we only care about the consistency of the prod ldap.