### PR TITLE
Make docker.socket depend on network-online when using custom SocketGroup

### DIFF
--- a/modules/ocf/manifests/packages/docker.pp
+++ b/modules/ocf/manifests/packages/docker.pp
@@ -40,6 +40,17 @@ class ocf::packages::docker($admin_group = undef,
       require => Package['docker-ce'],
       notify  => Exec['docker-socket-update'];
     }
+
+    # Make sure that the docker socket only starts after networking is up so it
+    # can set the correct SocketGroup, otherwise it might not be able to
+    # contact LDAP to set the correct owning group and docker will fail to
+    # start entirely on boot.
+    ocf::systemd::override { 'docker-socket-wait-for-networking':
+      unit    => 'docker.socket',
+      content => "[Unit]\nAfter=network-online.target\nWants=network-online.target\n",
+      require => Package['docker-ce'],
+      notify  => Exec['docker-socket-update'];
+    }
   }
 
   if $autoclean {


### PR DESCRIPTION
These groups can use LDAP, which relies on the network, so this should make it more likely docker starts properly on boot.

Before:
```
jvperrin@surge:~$ sudo systemctl status docker                                                                                                                                                                                         
● docker.service - Docker Application Container Engine                                                                                                                                                                                 
   Loaded: loaded (/lib/systemd/system/docker.service; enabled; vendor preset: enabled)                                                                                                                                                
   Active: inactive (dead)                                                                                                                                                                                                             
     Docs: https://docs.docker.com                                                                                                                                                                                                     
                                                                                                                                                                                                                                       
Jul 10 22:18:14 surge systemd[1]: Dependency failed for Docker Application Container Engine.                                                                                                                                           
Jul 10 22:18:14 surge systemd[1]: docker.service: Job docker.service/start failed with result 'dependency'.
jvperrin@surge:~$ sudo systemctl status docker.socket                                                                                                                                                                                  
● docker.socket - Docker Socket for the API                                                                                                                                                                                            
   Loaded: loaded (/lib/systemd/system/docker.socket; enabled; vendor preset: enabled)                                                                                                                                                 
  Drop-In: /etc/systemd/system/docker.socket.d                                                                                                                                                                                         
           └─set-docker-socket-group.conf                                                                                                                                                                                              
   Active: failed (Result: exit-code) since Wed 2019-07-10 22:18:14 PDT; 2 days ago                                                                                                                                                    
   Listen: /var/run/docker.sock (Stream)                                                                                                                                                                                               
                                                                                                                                                                                                                                       
Jul 10 22:18:14 surge systemd[512]: nss_ldap: could not connect to any LDAP server as (null) - Can't contact LDAP server                                                                                                               
Jul 10 22:18:14 surge systemd[512]: nss_ldap: failed to bind to LDAP server ldaps://ldap.ocf.berkeley.edu: Can't contact LDAP server                                                                                                   
Jul 10 22:18:14 surge systemd[512]: docker.socket: Failed to resolve group ocfroot: No such file or directory                                                                                                                          
Jul 10 22:18:14 surge systemd[512]: nss_ldap: reconnecting to LDAP server...                                                                                                                                                           
Jul 10 22:18:14 surge systemd[512]: nss_ldap: could not connect to any LDAP server as (null) - Can't contact LDAP server                                                                                                               
Jul 10 22:18:14 surge systemd[512]: nss_ldap: failed to bind to LDAP server ldaps://ldap.ocf.berkeley.edu: Can't contact LDAP server                                                                                                   
Jul 10 22:18:14 surge systemd[512]: nss_ldap: could not search LDAP server - Server is unavailable                                                                                                                                     
Jul 10 22:18:14 surge systemd[1]: docker.socket: Control process exited, code=exited, status=216/GROUP                                                                                                                                 
Jul 10 22:18:14 surge systemd[1]: docker.socket: Failed with result 'exit-code'.                                                                                                                                                       
Jul 10 22:18:14 surge systemd[1]: Failed to listen on Docker Socket for the API.
```

After:
```
jvperrin@surge:~$ sudo systemctl status docker.service
● docker.service - Docker Application Container Engine
   Loaded: loaded (/lib/systemd/system/docker.service; enabled; vendor preset: enabled)
   Active: active (running) since Sat 2019-07-13 00:44:25 PDT; 28s ago
     Docs: https://docs.docker.com
 Main PID: 1520 (dockerd)
    Tasks: 13
   Memory: 104.7M
   CGroup: /system.slice/docker.service
           └─1520 /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock

Jul 13 00:44:24 surge dockerd[1520]: time="2019-07-13T00:44:24.569632797-07:00" level=warning msg="Your kernel does not support swap memory limit"
Jul 13 00:44:24 surge dockerd[1520]: time="2019-07-13T00:44:24.569676475-07:00" level=warning msg="Your kernel does not support cgroup rt period"
Jul 13 00:44:24 surge dockerd[1520]: time="2019-07-13T00:44:24.569686661-07:00" level=warning msg="Your kernel does not support cgroup rt runtime"
Jul 13 00:44:24 surge dockerd[1520]: time="2019-07-13T00:44:24.570149330-07:00" level=info msg="Loading containers: start."
Jul 13 00:44:25 surge dockerd[1520]: time="2019-07-13T00:44:25.035743395-07:00" level=info msg="Default bridge (docker0) is assigned with an IP address 172.17.0.0/16. Daemon option --bip can be used to set a preferred IP address"
Jul 13 00:44:25 surge dockerd[1520]: time="2019-07-13T00:44:25.112441434-07:00" level=info msg="Loading containers: done."
Jul 13 00:44:25 surge dockerd[1520]: time="2019-07-13T00:44:25.274862485-07:00" level=info msg="Docker daemon" commit=2d0083d graphdriver(s)=overlay2 version=18.09.7
Jul 13 00:44:25 surge dockerd[1520]: time="2019-07-13T00:44:25.276076829-07:00" level=info msg="Daemon has completed initialization"
Jul 13 00:44:25 surge dockerd[1520]: time="2019-07-13T00:44:25.289915933-07:00" level=info msg="API listen on /var/run/docker.sock"
Jul 13 00:44:25 surge systemd[1]: Started Docker Application Container Engine.
jvperrin@surge:~$ sudo systemctl status docker.socket
● docker.socket - Docker Socket for the API
   Loaded: loaded (/lib/systemd/system/docker.socket; enabled; vendor preset: enabled)
  Drop-In: /etc/systemd/system/docker.socket.d
           └─docker-socket-wait-for-networking.conf, set-docker-socket-group.conf
   Active: active (running) since Sat 2019-07-13 00:44:24 PDT; 27s ago
   Listen: /var/run/docker.sock (Stream)
    Tasks: 0 (limit: 4915)
   Memory: 0B
   CGroup: /system.slice/docker.socket

Jul 13 00:44:22 surge systemd[1]: Starting Docker Socket for the API.
Jul 13 00:44:24 surge systemd[1]: Listening on Docker Socket for the API.
```