### PR TITLE
Don't send debconf emails on desktops

### DIFF
--- a/modules/ocf_desktop/manifests/drivers.pp
+++ b/modules/ocf_desktop/manifests/drivers.pp
@@ -1,6 +1,14 @@
 class ocf_desktop::drivers {
   include ocf::apt::i386
 
+  # Don't send emails from Debconf on configuring desktops since they aren't
+  # useful emails (we reboot after setting up a new desktop with drivers, etc.
+  # anyway) https://manpages.debian.org/stable/debconf-doc/debconf.conf.5.en.html
+  file { '/root/.debconfrc':
+    content => "Admin-Email:\n",
+    before  => Package['xserver-xorg-video-nvidia'],
+  }
+
   # install proprietary nvidia drivers
   if $::gfx_brand == 'nvidia' {
     # Install nvidia-driver from backports so that it loads properly


### PR DESCRIPTION
These emails aren't really useful and happen whenever a new desktop is provisioned or video drivers are updated. For instance, this has emailed in the past for the `libcuda1`, `xserver-xorg-video-nvidia`, and `libgl1-nvidia-glx` packages and just warns about a mismatch in video drivers and a need to reboot the desktop, which we do after provisioning them anyway.

I still need to actually test this on a desktop, testing on a newly provisioned one would be the easiest way to figure out if setting this in `/root/.debconfrc` actually works or not, although the manpages say that it should work in that file.