### PR TITLE
mail: Allow forwarding addresses to reply to protected lists

### DIFF
--- a/modules/ocf_mail/files/site_ocf/update-access
+++ b/modules/ocf_mail/files/site_ocf/update-access
@@ -1,11 +1,22 @@
-#!/bin/bash -eu
-# Update addresses that are allowed to send mail to protected addresses.
+#!/bin/bash
+# Update addresses that are allowed to send to protected addresses. Those
+# being OCF addresses and corresponding LDAP forwarding addresses of staff
+set -euo pipefail
 
-set -o pipefail
+TMP=$(mktemp /tmp/staff-access.XXXXX)
+ACCESS_FILE="/etc/postfix/ocf/staff-access"
 
-# staff
-getent group ocfstaff | cut -d: -f4 | \
-	sed 's/,\|$/@ocf.berkeley.edu OK\n/g' \
-	> /etc/postfix/ocf/staff-access
+# Load the keytab so we can pull the mail attr from LDAP
+kinit -t /etc/postfix/ocf/smtp-krb5.keytab smtp/anthrax.ocf.berkeley.edu
 
-/usr/sbin/postmap /etc/postfix/ocf/staff-access
+staff_members="$(getent group ocfstaff | cut -d: -f4 | tr ',' ' ')"
+
+for user in $staff_members; do
+	echo "$user@ocf.berkeley.edu OK" >> "$TMP"
+	attr_mail="$(ldapsearch -Q -LLL uid="$user" mail | grep ^mail: | tr -d ' ' | cut -d: -f2)"
+	echo "$attr_mail OK" >> "$TMP"
+done
+
+mv "$TMP" "$ACCESS_FILE"
+
+/usr/sbin/postmap "$ACCESS_FILE"


### PR DESCRIPTION
Earlier, we only allowed user@ocf.berkeley.edu to reply to mail sent
to staff@ and other protected lists. This prevents staff members
without GApps accounts or mail clients configured to authenticate
againt our SMTP server from replying to messages they receive as a
result of being on staff@ocf.berkeley.edu. This change should allow
staff members to reply to emails from the same addresses that our
systems would send them emails at in the first place.