### PR TITLE
Backup VM XML from hypervisors (#463)

### DIFF
--- a/modules/ocf_backups/files/rsnapshot.conf
+++ b/modules/ocf_backups/files/rsnapshot.conf
@@ -52,6 +52,12 @@ backup_script	/opt/share/backups/backup-git	git/
 backup_script	/opt/share/backups/backup-pgsql	pgsql/
 
 # remote servers
+backup	ocfbackups@hal:/etc/libvirt/qemu/	servers/vm_xml/hal/
+backup	ocfbackups@jaws:/etc/libvirt/qemu/	servers/vm_xml/jaws/
+backup	ocfbackups@pandemic:/etc/libvirt/qemu/	servers/vm_xml/pandemic/
+backup	ocfbackups@riptide:/etc/libvirt/qemu/	servers/vm_xml/riptide/
+backup	ocfbackups@scurvy:/etc/libvirt/qemu/	servers/vm_xml/scurvy/
+
 backup	ocfbackups@kerberos:/var/lib/heimdal-kdc/	servers/kerberos/
 backup	ocfbackups@kerberos:/var/backups/kerberos/	servers/kerberos/
 


### PR DESCRIPTION
This ends up with a tree like this in `hal:/opt/backups/live/`: https://i.fluffy.cc/gKpD2XcwfrXfpt8b97WqhkkVpMXX75Vx.html

I've been running this for a couple weeks now (at least since July 20th anyway from backup dates), and it seems to be going smoothly.

Closes #463