### PR TITLE
Removing obsolete ensure absent statements from PR 684

### DIFF
--- a/modules/ocf_desktop/manifests/defaults.pp
+++ b/modules/ocf_desktop/manifests/defaults.pp
@@ -3,13 +3,4 @@ class ocf_desktop::defaults {
   file { '/usr/share/applications/mimeapps.list':
     source  => 'puppet:///modules/ocf_desktop/xsession/mimeapps.list';
   }
-
-  # temporary only, to get rid of files!
-  file { '/usr/local/bin/pdf-open':
-    ensure => absent;
-  }
-
-  file { '/usr/share/applications/pdfopen.desktop':
-    ensure => absent;
-  }
 }


### PR DESCRIPTION
As I mentioned in my last PR, https://github.com/ocf/puppet/pull/684, one of my commits actually ensures certain files are absent in Puppet. Now that the PR is filed away, there is no need to continue ensuring that those files are absent.