### PR TITLE
xmpp: add support for encrypted MUCs at xmpp.o.b.e

### DIFF
--- a/modules/ocf_irc/manifests/xmpp.pp
+++ b/modules/ocf_irc/manifests/xmpp.pp
@@ -45,6 +45,14 @@ class ocf_irc::xmpp {
     'prod' => 'ocf.berkeley.edu',
   }
 
+  # The subdomain used for Multi-User Chats (MUCs)
+  $muc_name = $::host_env ? {
+    # This doesn't resolve in DNS, but it doesn't matter since this won't be
+    # exposed publicly. See https://prosody.im/doc/chatrooms#dns
+    'dev'  => 'dev-xmpp-muc.ocf.berkeley.edu',
+    'prod' => 'xmpp.ocf.berkeley.edu',
+  }
+
   $irc_server = $::host_env ? {
     'dev'  => 'dev-irc.ocf.berkeley.edu',
     'prod' =>  'irc.ocf.berkeley.edu',

--- a/modules/ocf_irc/templates/prosody.cfg.lua.erb
+++ b/modules/ocf_irc/templates/prosody.cfg.lua.erb
@@ -77,4 +77,9 @@ VirtualHost "<%= @vhost_name %>"
 Component "<%= @irc_server %>"
   component_secret = "<%= @component_password %>"
 
+Component "<%= @muc_name %>" "muc"
+  modules_enabled = { "muc_mam" }
+  muc_log_presences = true
+  restrict_room_creation = "local"
+
 Include "conf.d/*.cfg.lua"


### PR DESCRIPTION
This adds a new "component" where multi-user-chats can take place. It also adds the necessary configuration for facilitating OMEMO encryption in these MUCs.