### PR TITLE
Use private hiera and templates where possible instead of secret config files

### DIFF
--- a/modules/ocf_admin/manifests/create.pp
+++ b/modules/ocf_admin/manifests/create.pp
@@ -1,15 +1,18 @@
 class ocf_admin::create {
   package { 'ocf-approve':; }
 
+  $redis_create_password = lookup('broker::redis::password')
+  $mysql_create_password = lookup('create::mysql::password')
   file {
     '/etc/ocf-create':
       ensure => directory;
 
     # TODO: ideally this file wouldn't be directly readable by staff
     '/etc/ocf-create/ocf-create.conf':
-      group   => ocfstaff,
-      content => template('ocf_admin/create.conf.erb'),
-      mode    => '0440';
+      group     => ocfstaff,
+      content   => template('ocf_admin/create.conf.erb'),
+      mode      => '0440',
+      show_diff => false;
 
     '/etc/ocf-create/create.keytab':
       mode   => '0400',

--- a/modules/ocf_admin/manifests/create.pp
+++ b/modules/ocf_admin/manifests/create.pp
@@ -7,9 +7,9 @@ class ocf_admin::create {
 
     # TODO: ideally this file wouldn't be directly readable by staff
     '/etc/ocf-create/ocf-create.conf':
-      group  => ocfstaff,
-      source => 'puppet:///private/create.conf',
-      mode   => '0440';
+      group   => ocfstaff,
+      content => template('ocf_admin/create.conf.erb'),
+      mode    => '0440';
 
     '/etc/ocf-create/create.keytab':
       mode   => '0400',

--- a/modules/ocf_admin/manifests/init.pp
+++ b/modules/ocf_admin/manifests/init.pp
@@ -26,6 +26,7 @@ class ocf_admin {
     ]:;
   }
 
+  $ocfprinting_mysql_password = lookup('ocfprinting::mysql::password')
   file {
     '/opt/passwords':
       source    => 'puppet:///private/passwords',

--- a/modules/ocf_admin/manifests/init.pp
+++ b/modules/ocf_admin/manifests/init.pp
@@ -34,13 +34,13 @@ class ocf_admin {
       show_diff => false;
 
     '/etc/ocfprinting.json':
-      source    => 'puppet:///private/ocfprinting.json',
+      content   => template('ocf_admin/ocfprinting.json.erb'),
       group     => ocfstaff,
       mode      => '0640',
       show_diff => false;
 
     '/etc/ocfstats-ro.passwd':
-      source    => 'puppet:///private/ocfstats-ro.passwd',
+      content   => lookup('ocfstats::mysql::ro_password'),
       group     => ocfstaff,
       mode      => '0640',
       show_diff => false;

--- a/modules/ocf_admin/templates/create.conf.erb
+++ b/modules/ocf_admin/templates/create.conf.erb
@@ -1,0 +1,16 @@
+[encryption]
+key=/etc/ocf-create/create.key
+
+[redis]
+uri=rediss://:<%= scope['broker::redis::password'] -%>@broker.ocf.berkeley.edu:6378
+
+[mysql]
+uri=mysql+pymysql://ocfcreate:<%= scope['create::mysql::password'] -%>@mysql/ocfcreate
+
+[kerberos]
+keytab=/etc/ocf-create/create.keytab
+principal=create/admin
+
+[celery]
+broker=rediss://:<%= scope['broker::redis::password'] -%>@broker.ocf.berkeley.edu:6378
+backend=rediss://:<%= scope['broker::redis::password'] -%>@broker.ocf.berkeley.edu:6378

--- a/modules/ocf_admin/templates/create.conf.erb
+++ b/modules/ocf_admin/templates/create.conf.erb
@@ -2,15 +2,15 @@
 key=/etc/ocf-create/create.key
 
 [redis]
-uri=rediss://:<%= scope['broker::redis::password'] -%>@broker.ocf.berkeley.edu:6378
+uri=rediss://:<%= @redis_create_password -%>@broker.ocf.berkeley.edu:6378
 
 [mysql]
-uri=mysql+pymysql://ocfcreate:<%= scope['create::mysql::password'] -%>@mysql/ocfcreate
+uri=mysql+pymysql://ocfcreate:<%= @mysql_create_password -%>@mysql/ocfcreate
 
 [kerberos]
 keytab=/etc/ocf-create/create.keytab
 principal=create/admin
 
 [celery]
-broker=rediss://:<%= scope['broker::redis::password'] -%>@broker.ocf.berkeley.edu:6378
-backend=rediss://:<%= scope['broker::redis::password'] -%>@broker.ocf.berkeley.edu:6378
+broker=rediss://:<%= @redis_create_password -%>@broker.ocf.berkeley.edu:6378
+backend=rediss://:<%= @redis_create_password -%>@broker.ocf.berkeley.edu:6378

--- a/modules/ocf_admin/templates/ocfprinting.json.erb
+++ b/modules/ocf_admin/templates/ocfprinting.json.erb
@@ -1,0 +1,4 @@
+{
+    "user": "ocfprinting",
+    "password": "<%= scope['ocfprinting::mysql::password'] -%>"
+}

--- a/modules/ocf_admin/templates/ocfprinting.json.erb
+++ b/modules/ocf_admin/templates/ocfprinting.json.erb
@@ -1,4 +1,4 @@
 {
     "user": "ocfprinting",
-    "password": "<%= scope['ocfprinting::mysql::password'] -%>"
+    "password": "<%= @ocfprinting_mysql_password -%>"
 }

--- a/modules/ocf_backups/manifests/mysql.pp
+++ b/modules/ocf_backups/manifests/mysql.pp
@@ -3,7 +3,7 @@ class ocf_backups::mysql {
 
   file {
     '/opt/share/backups/my.cnf':
-      source    => 'puppet:///private/backups/my.cnf',
+      content   => template('ocf_backups/my.cnf.erb'),
       mode      => '0600',
       show_diff => false;
 

--- a/modules/ocf_backups/manifests/mysql.pp
+++ b/modules/ocf_backups/manifests/mysql.pp
@@ -1,6 +1,7 @@
 class ocf_backups::mysql {
   include ocf::packages::mysql
 
+  $ocfbackups_mysql_password = lookup('ocfbackups::mysql::password')
   file {
     '/opt/share/backups/my.cnf':
       content   => template('ocf_backups/my.cnf.erb'),

--- a/modules/ocf_backups/manifests/offsite.pp
+++ b/modules/ocf_backups/manifests/offsite.pp
@@ -2,6 +2,8 @@
 class ocf_backups::offsite {
   package { ['lftp', 'python3-pycurl']:; }
 
+  $box_creds = lookup('ocfbackups::box')
+  $ocfbackups_mysql_password = lookup('ocfbackups::mysql::password')
   file {
     '/opt/share/backups/create-encrypted-backup':
       source => 'puppet:///modules/ocf_backups/create-encrypted-backup',

--- a/modules/ocf_backups/manifests/offsite.pp
+++ b/modules/ocf_backups/manifests/offsite.pp
@@ -22,7 +22,7 @@ class ocf_backups::offsite {
 
     # Box.com credentials and API id/secret
     '/opt/share/backups/box-creds.json':
-      source    => 'puppet:///private/box-creds.json',
+      content   => template('ocf_backups/box-creds.json.erb'),
       mode      => '0600',
       show_diff => false;
   }

--- a/modules/ocf_backups/templates/box-creds.json.erb
+++ b/modules/ocf_backups/templates/box-creds.json.erb
@@ -1,0 +1,7 @@
+{
+  "email": "ocf@berkeley.edu",
+  "password": "<%= scope['ocfbackups::box::password'] -%>",
+  "api_client_id": "<%= scope['ocfbackups::box::api_client_id'] -%>",
+  "api_client_secret": "<%= scope['ocfbackups::box::api_client_secret'] -%>",
+  "mysql_password": "<%= scope['ocfbackups::mysql::password'] -%>"
+}

--- a/modules/ocf_backups/templates/box-creds.json.erb
+++ b/modules/ocf_backups/templates/box-creds.json.erb
@@ -1,7 +1,7 @@
 {
   "email": "ocf@berkeley.edu",
-  "password": "<%= scope['ocfbackups::box::password'] -%>",
-  "api_client_id": "<%= scope['ocfbackups::box::api_client_id'] -%>",
-  "api_client_secret": "<%= scope['ocfbackups::box::api_client_secret'] -%>",
-  "mysql_password": "<%= scope['ocfbackups::mysql::password'] -%>"
+  "password": "<%= @box_creds['password'] -%>",
+  "api_client_id": "<%= @box_creds['api_client_id'] -%>",
+  "api_client_secret": "<%= @box_creds['api_client_secret'] -%>",
+  "mysql_password": "<%= @ocfbackups_mysql_password -%>"
 }

--- a/modules/ocf_backups/templates/my.cnf.erb
+++ b/modules/ocf_backups/templates/my.cnf.erb
@@ -1,0 +1,9 @@
+[mysqldump]
+host = mysql.ocf.berkeley.edu
+user = ocfbackups
+password = <%= scope['ocfbackups::mysql::password'] -%>
+
+[mysql]
+host = mysql.ocf.berkeley.edu
+user = ocfbackups
+password = <%= scope['ocfbackups::mysql::password'] -%>

--- a/modules/ocf_backups/templates/my.cnf.erb
+++ b/modules/ocf_backups/templates/my.cnf.erb
@@ -1,9 +1,9 @@
 [mysqldump]
 host = mysql.ocf.berkeley.edu
 user = ocfbackups
-password = <%= scope['ocfbackups::mysql::password'] -%>
+password = <%= @ocfbackups_mysql_password %>
 
 [mysql]
 host = mysql.ocf.berkeley.edu
 user = ocfbackups
-password = <%= scope['ocfbackups::mysql::password'] -%>
+password = <%= @ocfbackups_mysql_password %>

--- a/modules/ocf_desktop/manifests/grub.pp
+++ b/modules/ocf_desktop/manifests/grub.pp
@@ -1,4 +1,6 @@
 class ocf_desktop::grub {
+  $hashed_root_password = lookup('ocf_desktop::hashed_root_password')
+
   # password protection to prevent modifying kernel options
   file { '/etc/grub.d/01_ocf':
     content   => template('ocf_desktop/01_ocf.erb'),

--- a/modules/ocf_desktop/manifests/grub.pp
+++ b/modules/ocf_desktop/manifests/grub.pp
@@ -1,7 +1,7 @@
 class ocf_desktop::grub {
   # password protection to prevent modifying kernel options
   file { '/etc/grub.d/01_ocf':
-    content   => file('/opt/puppet/shares/private/desktop/grub/01_ocf'),
+    content   => template('ocf_desktop/01_ocf.erb'),
     mode      => '0500',
     show_diff => false,
     notify    => Exec['update-grub'];

--- a/modules/ocf_desktop/manifests/init.pp
+++ b/modules/ocf_desktop/manifests/init.pp
@@ -24,6 +24,7 @@ class ocf_desktop {
   include ocf_desktop::xsession
 
   $opstaff_workstation = lookup('opstaff')
+  $ocfprinting_mysql_password = lookup('ocfprinting::mysql::password')
 
   # Add the printing credentials only on opstaff desktop
   if $opstaff_workstation {

--- a/modules/ocf_desktop/manifests/init.pp
+++ b/modules/ocf_desktop/manifests/init.pp
@@ -29,7 +29,7 @@ class ocf_desktop {
   if $opstaff_workstation {
     file {
       '/etc/ocfprinting.json':
-        source    => 'puppet:///private/ocfprinting.json',
+        content   => template('ocf_admin/ocfprinting.json.erb'),
         group     => opstaff,
         mode      => '0640',
         show_diff => false;

--- a/modules/ocf_desktop/templates/01_ocf.erb
+++ b/modules/ocf_desktop/templates/01_ocf.erb
@@ -3,5 +3,5 @@
 cat << EOF
 set superusers="root"
 export superusers
-password_pbkdf2 root grub.pbkdf2.sha512.10000.<%= scope['ocf_desktop::hashed_root_password'] -%>
+password_pbkdf2 root grub.pbkdf2.sha512.10000.<%= @hashed_root_password %>
 EOF

--- a/modules/ocf_desktop/templates/01_ocf.erb
+++ b/modules/ocf_desktop/templates/01_ocf.erb
@@ -1,0 +1,7 @@
+#!/bin/sh
+# set superuser password to prevent modifying kernel options during boot
+cat << EOF
+set superusers="root"
+export superusers
+password_pbkdf2 root grub.pbkdf2.sha512.10000.<%= scope['ocf_desktop::hashed_root_password'] -%>
+EOF

--- a/modules/ocf_docker/manifests/init.pp
+++ b/modules/ocf_docker/manifests/init.pp
@@ -87,7 +87,7 @@ class ocf_docker {
 
     '/opt/share/docker.htpasswd':
       owner     => 'www-data',
-      source    => 'puppet:///private/htpasswd',
+      content   => "ocfbot:${lookup(ocf_docker::hashed_password)}\n",
       mode      => '0400',
       show_diff => false,
       require   => Package['nginx'];

--- a/modules/ocf_irc/manifests/ircd.pp
+++ b/modules/ocf_irc/manifests/ircd.pp
@@ -15,6 +15,8 @@ class ocf_irc::ircd {
     user    => 'irc',
   }
 
+  $irc_creds = lookup('irc_creds')
+
   file {
     default:
       require => Package['inspircd'],
@@ -40,7 +42,7 @@ class ocf_irc::ircd {
       mode   => '0755';
 
     '/etc/inspircd/reload_pass':
-      content   => lookup('ocf_irc::cert_reload_password'),
+      content   => $irc_creds['cert_reload_password'],
       mode      => '0640',
       show_diff => false;
   }

--- a/modules/ocf_irc/manifests/ircd.pp
+++ b/modules/ocf_irc/manifests/ircd.pp
@@ -15,8 +15,6 @@ class ocf_irc::ircd {
     user    => 'irc',
   }
 
-  $passwords = parsejson(file("/opt/puppet/shares/private/${::hostname}/ircd-passwords"))
-
   file {
     default:
       require => Package['inspircd'],
@@ -42,7 +40,7 @@ class ocf_irc::ircd {
       mode   => '0755';
 
     '/etc/inspircd/reload_pass':
-      content   => $passwords['cert-reload-pass'],
+      content   => lookup('ocf_irc::cert_reload_password'),
       mode      => '0640',
       show_diff => false;
   }

--- a/modules/ocf_irc/manifests/services.pp
+++ b/modules/ocf_irc/manifests/services.pp
@@ -6,8 +6,6 @@ class ocf_irc::services {
     require => Package['anope'],
   }
 
-  $passwords = parsejson(file("/opt/puppet/shares/private/${::hostname}/services-passwords"))
-
   $root_nicks = ['waf', 'nattofriends', 'ckuehl', 'jvperrin', 'mattmcal', 'abizer', 'dkessler']
 
   file {

--- a/modules/ocf_irc/manifests/services.pp
+++ b/modules/ocf_irc/manifests/services.pp
@@ -6,6 +6,7 @@ class ocf_irc::services {
     require => Package['anope'],
   }
 
+  $irc_creds = lookup('irc_creds')
   $root_nicks = ['waf', 'nattofriends', 'ckuehl', 'jvperrin', 'mattmcal', 'abizer', 'dkessler']
 
   file {

--- a/modules/ocf_irc/templates/inspircd.conf.erb
+++ b/modules/ocf_irc/templates/inspircd.conf.erb
@@ -48,15 +48,15 @@
       ipaddr="localhost"
       port="25580"
       allowmask="127.0.0.0/8"
-      sendpass="<%= @passwords['anope-link'] -%>"
-      recvpass="<%= @passwords['anope-link'] -%>">
+      sendpass="<%= scope['ocf_irc::anope_link_password'] -%>"
+      recvpass="<%= scope['ocf_irc::anope_link_password'] -%>">
 
 <uline server="services.irc.ocf.berkeley.edu" silent="yes">
 
 
 # Passwords needed to kill/restart the IRCd while connected to it
-<power diepass="<%= @passwords['diepass'] -%>"
-       restartpass="<%= @passwords['restartpass'] -%>"
+<power diepass="<%= scope['ocf_irc::die_password'] -%>"
+       restartpass="<%= scope['ocf_irc::restart_password'] -%>"
        pause="5">
 
 
@@ -78,7 +78,7 @@
          useident="no" localmax="5" globalmax="5">
 
 # Cloaking for the OCF subnet
-<cloak mode="full" key="<%= @passwords['cloak-key'] -%>" prefix="OCF-">
+<cloak mode="full" key="<%= scope['ocf_irc::cloak_key'] -%>" prefix="OCF-">
 
 
 # Allow overrides when users are opers
@@ -108,7 +108,7 @@
 # Store oper credentials in mysql
 <database name="ocfirc"
           user="ocfirc"
-          pass="<%= @passwords['ocfirc-mysql'] -%>"
+          pass="<%= scope['ocf_irc::mysql_password'] -%>"
           host="mysql.ocf.berkeley.edu"
           port="3306"
           id="irc">
@@ -122,7 +122,7 @@
 
 # Automated user for reloading certs
 <oper name="ocf-cert-reload"
-      password="<%= @passwords['cert-reload-pass'] -%>"
+      password="<%= scope['ocf_irc::cert_reload_password'] -%>"
       host="*@localhost *@<%= @fqdn -%>"
       type="ReloadCert">
 

--- a/modules/ocf_irc/templates/inspircd.conf.erb
+++ b/modules/ocf_irc/templates/inspircd.conf.erb
@@ -48,15 +48,15 @@
       ipaddr="localhost"
       port="25580"
       allowmask="127.0.0.0/8"
-      sendpass="<%= scope['ocf_irc::anope_link_password'] -%>"
-      recvpass="<%= scope['ocf_irc::anope_link_password'] -%>">
+      sendpass="<%= @irc_creds['anope_link_password'] -%>"
+      recvpass="<%= @irc_creds['anope_link_password'] -%>">
 
 <uline server="services.irc.ocf.berkeley.edu" silent="yes">
 
 
 # Passwords needed to kill/restart the IRCd while connected to it
-<power diepass="<%= scope['ocf_irc::die_password'] -%>"
-       restartpass="<%= scope['ocf_irc::restart_password'] -%>"
+<power diepass="<%= @irc_creds['die_password'] -%>"
+       restartpass="<%= @irc_creds['restart_password'] -%>"
        pause="5">
 
 
@@ -78,7 +78,7 @@
          useident="no" localmax="5" globalmax="5">
 
 # Cloaking for the OCF subnet
-<cloak mode="full" key="<%= scope['ocf_irc::cloak_key'] -%>" prefix="OCF-">
+<cloak mode="full" key="<%= @irc_creds['cloak_key'] -%>" prefix="OCF-">
 
 
 # Allow overrides when users are opers
@@ -108,7 +108,7 @@
 # Store oper credentials in mysql
 <database name="ocfirc"
           user="ocfirc"
-          pass="<%= scope['ocf_irc::mysql_password'] -%>"
+          pass="<%= @irc_creds['mysql_password'] -%>"
           host="mysql.ocf.berkeley.edu"
           port="3306"
           id="irc">
@@ -122,7 +122,7 @@
 
 # Automated user for reloading certs
 <oper name="ocf-cert-reload"
-      password="<%= scope['ocf_irc::cert_reload_password'] -%>"
+      password="<%= @irc_creds['cert_reload_password'] -%>"
       host="*@localhost *@<%= @fqdn -%>"
       type="ReloadCert">
 

--- a/modules/ocf_irc/templates/services.conf.erb
+++ b/modules/ocf_irc/templates/services.conf.erb
@@ -14,7 +14,7 @@ uplink {
 
     port = 25580
 
-    password = "<%= scope['ocf_irc::anope_link_password'] -%>"
+    password = "<%= @irc_creds['anope_link_password'] -%>"
 }
 
 serverinfo {
@@ -47,7 +47,7 @@ networkinfo {
 
 options {
     casemap = "rfc1459"
-    seed = <%= scope['ocf_irc::services_seed'] %>
+    seed = <%= @irc_creds['services_seed'] %>
 
     strictpasswords = yes
     badpasslimit = 5
@@ -174,7 +174,7 @@ module {
         database = "ocfirc"
         server = "mysql.ocf.berkeley.edu"
         username = "ocfirc"
-        password = "<%= scope['ocf_irc::mysql_password'] -%>"
+        password = "<%= @irc_creds['mysql_password'] -%>"
         port = 3306
     }
 }

--- a/modules/ocf_irc/templates/services.conf.erb
+++ b/modules/ocf_irc/templates/services.conf.erb
@@ -14,7 +14,7 @@ uplink {
 
     port = 25580
 
-    password = "<%= @passwords['anope-link'] -%>"
+    password = "<%= scope['ocf_irc::anope_link_password'] -%>"
 }
 
 serverinfo {
@@ -47,7 +47,7 @@ networkinfo {
 
 options {
     casemap = "rfc1459"
-    seed = <%= @passwords['seed'] %>
+    seed = <%= scope['ocf_irc::services_seed'] %>
 
     strictpasswords = yes
     badpasslimit = 5
@@ -174,7 +174,7 @@ module {
         database = "ocfirc"
         server = "mysql.ocf.berkeley.edu"
         username = "ocfirc"
-        password = "<%= @passwords['ocfirc-mysql'] -%>"
+        password = "<%= scope['ocf_irc::mysql_password'] -%>"
         port = 3306
     }
 }

--- a/modules/ocf_jenkins/manifests/init.pp
+++ b/modules/ocf_jenkins/manifests/init.pp
@@ -50,6 +50,8 @@ class ocf_jenkins {
     notify  => Service['jenkins'];
   }
 
+  $jenkins_creds = lookup('jenkins_creds')
+
   file {
     '/opt/jenkins':
       ensure => directory;

--- a/modules/ocf_jenkins/manifests/init.pp
+++ b/modules/ocf_jenkins/manifests/init.pp
@@ -79,7 +79,7 @@ class ocf_jenkins {
       show_diff => false;
 
     '/opt/jenkins/deploy/.pypirc':
-      source    => 'puppet:///private/pypirc',
+      content   => template('ocf_jenkins/pypirc'),
       owner     => root,
       group     => jenkins-deploy,
       mode      => '0640',
@@ -92,7 +92,7 @@ class ocf_jenkins {
       mode   => '0750';
 
     '/opt/jenkins/deploy/.docker/config.json':
-      source    => 'puppet:///private/docker-config.json',
+      content   => template('ocf_jenkins/docker-config.json.erb'),
       owner     => root,
       group     => jenkins-deploy,
       mode      => '0640',

--- a/modules/ocf_jenkins/templates/docker-config.json.erb
+++ b/modules/ocf_jenkins/templates/docker-config.json.erb
@@ -1,0 +1,10 @@
+{
+        "auths": {
+                "docker-push.ocf.berkeley.edu": {
+                        "auth": "<%= scope['ocf_jenkins::docker_push_auth'] -%>"
+                },
+                "https://index.docker.io/v1/": {
+                        "auth": "<%= scope['ocf_jenkins::docker_hub_auth'] -%>"
+                }
+        }
+}

--- a/modules/ocf_jenkins/templates/docker-config.json.erb
+++ b/modules/ocf_jenkins/templates/docker-config.json.erb
@@ -1,10 +1,10 @@
 {
         "auths": {
                 "docker-push.ocf.berkeley.edu": {
-                        "auth": "<%= scope['ocf_jenkins::docker_push_auth'] -%>"
+                        "auth": "<%= @jenkins_creds['docker_push_auth'] -%>"
                 },
                 "https://index.docker.io/v1/": {
-                        "auth": "<%= scope['ocf_jenkins::docker_hub_auth'] -%>"
+                        "auth": "<%= @jenkins_creds['docker_hub_auth'] -%>"
                 }
         }
 }

--- a/modules/ocf_jenkins/templates/pypirc
+++ b/modules/ocf_jenkins/templates/pypirc
@@ -1,0 +1,7 @@
+[distutils]
+index-servers=pypi
+
+[pypi]
+repository = https://upload.pypi.org/legacy/
+username = ocfdeploy
+password = <%= scope['ocf_jenkins::pypi_password'] -%>

--- a/modules/ocf_jenkins/templates/pypirc
+++ b/modules/ocf_jenkins/templates/pypirc
@@ -4,4 +4,4 @@ index-servers=pypi
 [pypi]
 repository = https://upload.pypi.org/legacy/
 username = ocfdeploy
-password = <%= scope['ocf_jenkins::pypi_password'] -%>
+password = <%= @jenkins_creds['pypi_password'] %>

--- a/modules/ocf_mirrors/manifests/projects/finnix.pp
+++ b/modules/ocf_mirrors/manifests/projects/finnix.pp
@@ -15,7 +15,7 @@ class ocf_mirrors::projects::finnix {
     # we are registered with the Finnix project and have a password for the
     # master upstream mirror
     '/opt/mirrors/project/finnix/password':
-      source    => 'puppet:///private/mirrors/finnix',
+      content   => lookup('mirrors::finnix_sync_password'),
       mode      => '0600',
       show_diff => false;
   }

--- a/modules/ocf_mysql/manifests/init.pp
+++ b/modules/ocf_mysql/manifests/init.pp
@@ -1,6 +1,8 @@
 class ocf_mysql {
   require ocf::ssl::default;
 
+  $mysql_root_password = lookup('ocf_mysql::root_password')
+
   class { 'ocf::packages::mysql_server':
     manage_service => false,
   } ->

--- a/modules/ocf_mysql/manifests/init.pp
+++ b/modules/ocf_mysql/manifests/init.pp
@@ -13,7 +13,7 @@ class ocf_mysql {
 
     '/root/.my.cnf':
       mode      => '0600',
-      source    => 'puppet:///private/root-my.cnf',
+      content   => template('ocf_mysql/root-my.cnf.erb'),
       show_diff => false;
   } ~>
   service { 'mariadb': }

--- a/modules/ocf_mysql/templates/root-my.cnf.erb
+++ b/modules/ocf_mysql/templates/root-my.cnf.erb
@@ -1,0 +1,3 @@
+[mysql]
+host = mysql.ocf.berkeley.edu
+password = <%= scope['ocf_mysql::root_password'] -%>

--- a/modules/ocf_mysql/templates/root-my.cnf.erb
+++ b/modules/ocf_mysql/templates/root-my.cnf.erb
@@ -1,3 +1,3 @@
 [mysql]
 host = mysql.ocf.berkeley.edu
-password = <%= scope['ocf_mysql::root_password'] -%>
+password = <%= @mysql_root_password %>

--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -37,7 +37,7 @@ class ocf_postgres {
   file {
     # copies proper .pgpass file for ocfbackups to authenticate on backup
     '/opt/share/.pgpass':
-      source    => 'puppet:///private/pgpass',
+      content   => "localhost:5432:*:postgres:${lookup(postgres::rootpw)}\n",
       mode      => '0600',
       owner     => 'ocfbackups',
       show_diff => false;

--- a/modules/ocf_printhost/manifests/enforcer.pp
+++ b/modules/ocf_printhost/manifests/enforcer.pp
@@ -44,7 +44,7 @@ class ocf_printhost::enforcer {
       ';
 
     '/opt/share/enforcer-mysql.defaults':
-      source    => 'puppet:///private/enforcer-mysql.defaults',
+      content   => templates('ocf_printhost/enforcer-mysql.defaults.erb'),
       mode      => '0600',
       show_diff => false;
   }

--- a/modules/ocf_printhost/manifests/enforcer.pp
+++ b/modules/ocf_printhost/manifests/enforcer.pp
@@ -44,7 +44,7 @@ class ocf_printhost::enforcer {
       ';
 
     '/opt/share/enforcer-mysql.defaults':
-      content   => templates('ocf_printhost/enforcer-mysql.defaults.erb'),
+      content   => template('ocf_printhost/enforcer-mysql.defaults.erb'),
       mode      => '0600',
       show_diff => false;
   }

--- a/modules/ocf_printhost/templates/enforcer-mysql.defaults.erb
+++ b/modules/ocf_printhost/templates/enforcer-mysql.defaults.erb
@@ -1,0 +1,5 @@
+[client]
+host = mysql
+user = ocfprinting
+password = <%= scope['ocfprinting::mysql::password'] -%>
+database = ocfprinting

--- a/modules/ocf_printhost/templates/enforcer-mysql.defaults.erb
+++ b/modules/ocf_printhost/templates/enforcer-mysql.defaults.erb
@@ -1,5 +1,5 @@
 [client]
 host = mysql
 user = ocfprinting
-password = <%= scope['ocfprinting::mysql::password'] -%>
+password = <%= @mysql_password %>
 database = ocfprinting

--- a/modules/ocf_ssh/manifests/makeservices.pp
+++ b/modules/ocf_ssh/manifests/makeservices.pp
@@ -21,7 +21,7 @@ class ocf_ssh::makeservices {
       owner  => 'mysql';
 
     '/opt/share/makeservices/makemysql.conf':
-      source    => 'puppet:///private/makeservices/makemysql.conf',
+      content   => template('ocf_ssh/makemysql.conf.erb'),
       show_diff => false;
 
     '/opt/share/makexmpp':
@@ -30,7 +30,7 @@ class ocf_ssh::makeservices {
       owner  => 'ocfmakexmpp';
 
     '/opt/share/makexmpp/makexmpp.conf':
-      source    => 'puppet:///private/makeservices/makexmpp.conf',
+      content   => template('ocf_ssh/makexmpp.conf.erb'),
       show_diff => false;
   }
 }

--- a/modules/ocf_ssh/manifests/makeservices.pp
+++ b/modules/ocf_ssh/manifests/makeservices.pp
@@ -14,6 +14,9 @@ class ocf_ssh::makeservices {
     content => "ALL ALL=(ocfmakexmpp) NOPASSWD: /opt/share/utils/makeservices/makexmpp-real\n",
   }
 
+  $mysql_root_password = lookup('ocf_mysql::root_password')
+  $xmpp_root_password = lookup('xmpp::root_password')
+
   file {
     '/opt/share/makeservices':
       ensure => directory,

--- a/modules/ocf_ssh/templates/makemysql.conf.erb
+++ b/modules/ocf_ssh/templates/makemysql.conf.erb
@@ -1,0 +1,3 @@
+[makemysql]
+host = mysql.ocf.berkeley.edu
+passwd = <%= scope['ocf_mysql::root_password'] -%>

--- a/modules/ocf_ssh/templates/makemysql.conf.erb
+++ b/modules/ocf_ssh/templates/makemysql.conf.erb
@@ -1,3 +1,3 @@
 [makemysql]
 host = mysql.ocf.berkeley.edu
-passwd = <%= scope['ocf_mysql::root_password'] -%>
+passwd = <%= @mysql_root_password %>

--- a/modules/ocf_ssh/templates/makexmpp.conf.erb
+++ b/modules/ocf_ssh/templates/makexmpp.conf.erb
@@ -1,0 +1,3 @@
+[makexmpp]
+jid = root@ocf.berkeley.edu
+passwd = <%= scope['xmpp::root_password'] -%>

--- a/modules/ocf_ssh/templates/makexmpp.conf.erb
+++ b/modules/ocf_ssh/templates/makexmpp.conf.erb
@@ -1,3 +1,3 @@
 [makexmpp]
 jid = root@ocf.berkeley.edu
-passwd = <%= scope['xmpp::root_password'] -%>
+passwd = <%= @xmpp_root_password %>


### PR DESCRIPTION
See #699 for more context, but this essentially switches to using the private hiera file for more stuff instead of using text files in the private share. This has a few purposes:

1. Makes the structure of our repo and code clearer, since more files are publicly visible (like `create.conf.erb`), but without their passwords/secrets. This also means that changes to these files would go through version control.
2. Moves towards something that can more easily work with [octocatalog-diff](https://github.com/github/octocatalog-diff), something I've been wanting to use for around a month and have almost got working. It's much easier to "mock" hieradata by including a dummy value at the bottom level than it is to mock a full filesystem of files that are changing more-or-less silently.
3. Cleans up some code like [this](https://github.com/ocf/puppet/blob/0bffbdb39341eae59fdf31fa8aa9c58c5188550a/modules/ocf_irc/manifests/ircd.pp#L18) that parses json from a secrets file where it's now much easier to just use hiera.

I have tested this on most modules I changed to make sure it's a noop, but it's not all fully tested yet. This is (unfortunately) something that octocatalog-diff would be pretty great for, at least if these weren't secrets being modified (since it won't have access to the actual secrets).