### PR TITLE
irc: minor changes for buster compatibility

### DIFF
--- a/modules/ocf_irc/manifests/biboumi.pp
+++ b/modules/ocf_irc/manifests/biboumi.pp
@@ -1,7 +1,13 @@
 class ocf_irc::biboumi {
-  ocf::repackage { 'biboumi':
-    backport_on => ['stretch'],
-    require     => Package['prosody'],
+  if $::lsbdistcodename != 'buster' {
+    ocf::repackage { 'biboumi':
+      backport_on => ['stretch'],
+      require     => Package['prosody'],
+    }
+  } else {
+    package { 'biboumi':
+      require => Package['prosody'],
+    }
   }
 
   service { 'biboumi':

--- a/modules/ocf_irc/manifests/ircd.pp
+++ b/modules/ocf_irc/manifests/ircd.pp
@@ -17,6 +17,17 @@ class ocf_irc::ircd {
 
   $passwords = parsejson(file("/opt/puppet/shares/private/${::hostname}/ircd-passwords"))
 
+  if $::lsbdistcodename == 'buster' {
+    # Disable the AppArmor profile for inspircd, since it prevents us from
+    # accessing the necessary TLS certs
+    file { '/etc/apparmor.d/disable/usr.sbin.inspircd':
+      ensure  => 'link',
+      target  => '/etc/apparmor.d/usr.sbin.inspircd',
+      require => Package['inspircd'],
+    }
+  }
+
+
   file {
     default:
       require => Package['inspircd'],

--- a/modules/ocf_irc/manifests/xmpp.pp
+++ b/modules/ocf_irc/manifests/xmpp.pp
@@ -1,19 +1,30 @@
 class ocf_irc::xmpp {
   # When upgrading to buster, these can be installed from the regular buster
   # repo
-  ocf::repackage {
-    # lua-dbi-mysql is needed to connect to MySQL
-    'lua-dbi-common':
-      backport_on => ['stretch'];
+  if $::lsbdistcodename != 'buster' {
+    ocf::repackage {
+      # lua-dbi-mysql is needed to connect to MySQL
+      'lua-dbi-common':
+        backport_on => ['stretch'];
 
-    'lua-dbi-mysql':
-      backport_on => ['stretch'];
+      'lua-dbi-mysql':
+        backport_on => ['stretch'];
 
-    'prosody':
-      backport_on => ['stretch'];
+      'prosody':
+        backport_on => ['stretch'];
 
-    'prosody-modules':
-      backport_on => ['stretch'];
+      'prosody-modules':
+        backport_on => ['stretch'];
+    }
+  } else {
+    package {
+      [
+        'prosody',
+        'prosody-modules',
+        'lua-dbi-common',
+        'lua-dbi-mysql'
+      ]:;
+    }
   }
 
   service { 'prosody':


### PR DESCRIPTION
This ensures we use Buster packages on Buster (instead of stretch-backports) and disables the AppArmor profile for inspircd.