### PR TITLE
irc: disable inspircd AppArmor profile for buster

### DIFF
--- a/modules/ocf_irc/manifests/ircd.pp
+++ b/modules/ocf_irc/manifests/ircd.pp
@@ -17,6 +17,16 @@ class ocf_irc::ircd {
 
   $passwords = parsejson(file("/opt/puppet/shares/private/${::hostname}/ircd-passwords"))
 
+  if $::lsbdistcodename == 'buster' {
+    # Disable the AppArmor profile for inspircd, since it prevents us from
+    # accessing the necessary TLS certs
+    file { '/etc/apparmor.d/disable/usr.sbin.inspircd':
+      ensure  => 'link',
+      target  => '/etc/apparmor.d/usr.sbin.inspircd',
+      require => Package['inspircd'],
+    }
+  }
+
   file {
     default:
       require => Package['inspircd'],


### PR DESCRIPTION
Revised from #724. This should be all that's necessary to upgrade `flood` to Buster.