### PR TITLE
use fqdn for ipp

### DIFF
--- a/modules/ocf/files/packages/cups/printers.conf
+++ b/modules/ocf/files/packages/cups/printers.conf
@@ -6,7 +6,7 @@ UUID urn:uuid:20252536-e9c1-33cf-6b2d-fe314c77286c
 AuthInfoRequired none
 Info OCF double-sided printing
 Location OCF lab
-DeviceURI tea4cups:ipps://printhost:631/printers/double
+DeviceURI tea4cups:ipps://printhost.ocf.berkeley.edu/printers/double
 State Idle
 StateTime 1558127668
 ConfigTime 1558127267
@@ -25,7 +25,7 @@ UUID urn:uuid:779eda6f-7628-3aca-7010-c6593dcc07ce
 AuthInfoRequired none
 Info OCF single-sided printing
 Location OCF lab
-DeviceURI tea4cups:ipps://printhost:631/printers/single
+DeviceURI tea4cups:ipps://printhost.ocf.berkeley.edu/printers/single
 State Idle
 StateTime 1558127486
 ConfigTime 1558127346


### PR DESCRIPTION
Without this, printing was failing with `CUPS backend /usr/lib/cups/backend/ipps returned 4.`

@jxlin123 Thoughts?