### PR TITLE
Revert "Removing printhost check for Google Docs"

### DIFF
--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -122,7 +122,9 @@ NOTIFY_PROBLEMATIC_FILE_SOURCE = dedent("""\
         Please download your file as a PDF and print from desktop instead of web browser.\
 """)
 
-PROBLEMATIC_FILE_SOURCE = []
+PROBLEMATIC_FILE_SOURCE = [
+    ('Google Docs', lambda job: job.doc_name.endswith(' - Google Docs'))
+]
 
 
 def read_config():


### PR DESCRIPTION
Apparently, printing from Google Docs still results in some problems (as noted on Slack today), so I'm undoing the commit that removes the Google Docs check in enforcer.