### PR TITLE
Add size checks to raster-filter

### DIFF
--- a/modules/ocf/files/packages/cups/raster-filter
+++ b/modules/ocf/files/packages/cups/raster-filter
@@ -18,6 +18,14 @@ if [ "${mimetype%%;*}" != "application/pdf" ]; then
     exit
 fi
 
+# Don't rasterize if size >5M
+size=$(du "$input" | cut -f1)
+[ "$size" -lt 5120 ] || exec cat "$input"
+
+# Or if size > 20 pages
+len=$(pdftk "$input" dump_data | awk '/NumberOfPages/{print $2}')
+[ -z "$len" -o "$len" -gt 20 ] && exec cat "$input"
+
 # Rasterizing PDF...
 output=$(mktemp --suffix='.pdf')
 error=$(mktemp)


### PR DESCRIPTION
convert explodes sizes of some scanned PDFs. This causes ipps to fail when confronted with a 0.5gb pdf. This PR adds some checks to make sure that rasterizing doesn't happen in those cases.