### PR TITLE
Add octocatalog-diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # ignore Puppet resource types
 /.resource_types/
+
+# ignore octocatalog-diff cache
+/.octocatalog-diff-cache

--- a/.octocatalog-diff.cfg.rb
+++ b/.octocatalog-diff.cfg.rb
@@ -29,7 +29,7 @@ module OctocatalogDiff
 
       # TODO: Figure out why this has SSL errors when setting this to true
       # Have a look at https://github.com/github/octocatalog-diff/blob/master/doc/advanced-storeconfigs.md
-      #settings[:storeconfigs] = true
+      settings[:storeconfigs] = true
 
       settings[:bootstrap_script] = 'bin/bootstrap'
 

--- a/.octocatalog-diff.cfg.rb
+++ b/.octocatalog-diff.cfg.rb
@@ -21,22 +21,21 @@ module OctocatalogDiff
       settings[:hiera_path] = 'hieradata'
 
       settings[:puppetdb_url] = 'https://puppetdb:8081'
-      settings[:puppetdb_ssl_ca] = 'keys/ca.pem'
-      settings[:puppetdb_ssl_client_key] = File.read("keys/puppetboard.puppetdb.pem.private")
-      settings[:puppetdb_ssl_client_cert] = File.read("keys/puppetboard.puppetdb.pem.cert")
+      # TODO: Don't piggyback off the ocfweb puppet key/certs
+      settings[:puppetdb_ssl_ca] = '/etc/ocfweb/puppet-certs/puppet-ca.pem'
+      settings[:puppetdb_ssl_client_key] = File.read("/etc/ocfweb/puppet-certs/puppet-private.pem")
+      settings[:puppetdb_ssl_client_cert] = File.read("/etc/ocfweb/puppet-certs/puppet-cert.pem")
 
       settings[:enc] = 'modules/ocf_puppet/files/ldap-enc'
-
-      # TODO: Figure out why this has SSL errors when setting this to true
-      # Have a look at https://github.com/github/octocatalog-diff/blob/master/doc/advanced-storeconfigs.md
       settings[:storeconfigs] = true
-
       settings[:bootstrap_script] = 'bin/bootstrap'
-
       settings[:puppet_binary] = '/opt/puppetlabs/bin/puppet'
 
       # TODO: Set this back to origin/master once my changes are merged to master
       settings[:from_env] = 'origin/octocatalog-diff-test'
+      # This is used to cache third-party/vendored modules so that they don't
+      # have to be installed each time (saves about 2 minutes per run)
+      settings[:master_cache_branch] = settings[:from_env]
 
       settings[:validate_references] = %w(before notify require subscribe)
       settings[:header] = :default

--- a/.octocatalog-diff.cfg.rb
+++ b/.octocatalog-diff.cfg.rb
@@ -1,0 +1,54 @@
+# This is a configuration file for octocatalog-diff (https://github.com/github/octocatalog-diff).
+#
+# To test this configuration file, run:
+#   octocatalog-diff --config-test
+#
+# NOTE: This example file contains some of the more popular configuration options, but is
+# not exhaustive of all possible configuration options. Any options that can be declared via the
+# command line can also be set via this file. Please consult the options reference for more:
+#   https://github.com/github/octocatalog-diff/blob/master/doc/optionsref.md
+# And reference the source code to see how the underlying settings are constructed:
+#   https://github.com/github/octocatalog-diff/tree/master/lib/octocatalog-diff/cli/options
+# Also see the sample configuration file that includes more detailed comments about each option:
+#   https://github.com/github/octocatalog-diff/blob/master/examples/octocatalog-diff.cfg.rb
+
+module OctocatalogDiff
+  class Config
+    def self.config
+      settings = {}
+
+      settings[:hiera_config] = 'hiera.yaml'
+      settings[:hiera_path] = 'hieradata'
+
+      settings[:puppetdb_url] = 'https://puppetdb:8081'
+      settings[:puppetdb_ssl_ca] = 'keys/ca.pem'
+      settings[:puppetdb_ssl_client_key] = File.read("keys/puppetboard.puppetdb.pem.private")
+      settings[:puppetdb_ssl_client_cert] = File.read("keys/puppetboard.puppetdb.pem.cert")
+
+      settings[:enc] = 'modules/ocf_puppet/files/ldap-enc'
+
+      # TODO: Figure out why this has SSL errors when setting this to true
+      # Have a look at https://github.com/github/octocatalog-diff/blob/master/doc/advanced-storeconfigs.md
+      #settings[:storeconfigs] = true
+
+      settings[:bootstrap_script] = 'bin/bootstrap'
+
+      settings[:puppet_binary] = '/opt/puppetlabs/bin/puppet'
+
+      # TODO: Set this back to origin/master once my changes are merged to master
+      settings[:from_env] = 'origin/octocatalog-diff-test'
+
+      settings[:validate_references] = %w(before notify require subscribe)
+      settings[:header] = :default
+
+      settings[:cached_master_dir] = File.join(ENV['HOME'], '.octocatalog-diff-cache')
+      settings[:safe_to_delete_cached_master_dir] = settings[:cached_master_dir]
+
+      settings[:basedir] = Dir.pwd
+      # settings[:basedir] = ENV['WORKSPACE'] # May work with Jenkins
+
+      # This method must return the 'settings' hash.
+      settings
+    end
+  end
+end

--- a/.octocatalog-diff.cfg.rb
+++ b/.octocatalog-diff.cfg.rb
@@ -31,16 +31,22 @@ module OctocatalogDiff
       settings[:bootstrap_script] = 'bin/bootstrap'
       settings[:puppet_binary] = '/opt/puppetlabs/bin/puppet'
 
-      # TODO: Set this back to origin/master once my changes are merged to master
+      # TODO: Set this to origin/master once the octocatalog-diff changes are
+      # merged to master
       settings[:from_env] = 'origin/octocatalog-diff-test'
       # This is used to cache third-party/vendored modules so that they don't
-      # have to be installed each time (saves about 2 minutes per run)
+      # have to be installed each time (saves about 2 minutes per run, at least
+      # on a host with relatively slow I/O like a staff VM, this is much faster
+      # on reaper for instance)
       settings[:master_cache_branch] = settings[:from_env]
 
       settings[:validate_references] = %w(before notify require subscribe)
       settings[:header] = :default
 
-      settings[:cached_master_dir] = File.join(ENV['HOME'], '.octocatalog-diff-cache')
+      settings[:cached_master_dir] = File.join(
+        (ENV['WORKSPACE'] || File.join(ENV['HOME'], '.cache')),
+        '.octocatalog-diff-cache'
+      )
       settings[:safe_to_delete_cached_master_dir] = settings[:cached_master_dir]
 
       settings[:basedir] = Dir.pwd

--- a/.octocatalog-diff.cfg.rb
+++ b/.octocatalog-diff.cfg.rb
@@ -49,8 +49,9 @@ module OctocatalogDiff
       )
       settings[:safe_to_delete_cached_master_dir] = settings[:cached_master_dir]
 
-      settings[:basedir] = Dir.pwd
-      # settings[:basedir] = ENV['WORKSPACE'] # May work with Jenkins
+      # Use the workspace directory if it exists (on Jenkins), otherwise just
+      # the current directory
+      settings[:basedir] = (ENV['WORKSPACE'] || Dir.pwd)
 
       # This method must return the 'settings' hash.
       settings

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,17 @@ pipeline {
         }
       }
       steps {
+        // Fetch in the master branch so that octocatalog-diff can diff against
+        // it. Jenkins by default only clones in branches that are needed and
+        // doesn't add any others.
+        //
+        // See https://github.com/allegro/axion-release-plugin/issues/195 and
+        // https://medium.com/rocket-travel-engineering/running-advanced-git-commands-in-a-declarative-multibranch-jenkinsfile-e82b075dbc53
+        // for example
+        sh 'git config --add remote.origin.fetch +refs/heads/master:refs/remotes/origin/master'
+        // TODO: Remove this branch once octocatalog-diff is switched to origin/master:
+        sh 'git config --add remote.origin.fetch +refs/heads/octocatalog-diff-test:refs/remotes/origin/octocatalog-diff-test'
+        sh 'git fetch --no-tags'
         sh 'make all_diffs'
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,21 @@ pipeline {
       }
     }
 
+    stage('octocatalog-diff') {
+      // Don't run this on the master branch yet, since it's really made for
+      // testing PRs and changes, it should always show no diffs on master.
+      // However, it might be useful on master in the future in some kind of
+      // mode to just show that all catalogs actually compile.
+      when {
+        not {
+          branch 'master'
+        }
+      }
+      steps {
+        sh 'make all_diffs'
+      }
+    }
+
     stage('update-prod') {
       when {
         branch 'master'

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+WORKSPACE ?= ${HOME}/.cache
+
 .PHONY: all
 all: vendor install-hooks
 
@@ -18,11 +20,19 @@ install-hooks: venv
 vendor: Puppetfile
 	r10k puppetfile install --verbose --color
 
+.PHONY: octocatalog-diff-uncached
+$(WORKSPACE)/.octocatalog-diff-cache:
+octocatalog-diff-uncached:
+	octocatalog-diff \
+		--bootstrap-then-exit \
+		--bootstrapped-from-dir=$(WORKSPACE)/.octocatalog-diff-cache
+
 # Run octocatalog-diff for a particular hostname
 # Add a --debug flag to get much more verbose output
-diff_%:
+diff_%: $(WORKSPACE)/.octocatalog-diff-cache
 	octocatalog-diff \
 		-n $*.ocf.berkeley.edu \
+		--bootstrapped-to-dir=$(WORKSPACE)/.octocatalog-diff-cache \
 		--enc-override environment=production,parameters::use_private_share=false \
 		--ignore 'Ini_setting[puppet.conf/master/storeconfigs]' \
 		--ignore 'Ini_setting[puppet.conf/master/storeconfigs_backend]' \
@@ -33,8 +43,9 @@ diff_%:
 
 # Run octocatalog-diff across all nodes that can be fetched from puppetdb
 # TODO: Make this faster by just selecting a single node from each class we
-# care about (or not selecting all desktops/hozers for example)
-all_diffs:
+# care about (not selecting all desktops/hozers for example)
+#all_diffs: $(WORKSPACE)/.octocatalog-diff-cache
+all_diffs: octocatalog-diff-uncached
 	curl -s --tlsv1 \
 		--cacert /etc/ocfweb/puppet-certs/puppet-ca.pem \
 		--cert /etc/ocfweb/puppet-certs/puppet-cert.pem \
@@ -43,4 +54,4 @@ all_diffs:
 	| jq -r '.[] | .certname' \
 	| cut -d '.' -f 1 \
 	| sort \
-	| xargs -n 1 -P $(shell grep -c ^processor /proc/cpuinfo) -I @ $(MAKE) -i -s diff_@
+	| xargs -n 1 -P $(shell grep -c ^processor /proc/cpuinfo) -I @ $(MAKE) -s diff_@

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make vendor

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -31,3 +31,6 @@ hierarchy:
 
   - name: "Kubernetes os"
     path: "kubernetes/os/%{::osfamily}.yaml"
+
+  - name: "Dummy secrets"
+    path: "dummy_secrets.yaml"

--- a/hieradata/dummy_secrets.yaml
+++ b/hieradata/dummy_secrets.yaml
@@ -1,97 +1,115 @@
-ocfmail::mysql::ro_password: dummy_password
-ocfmail::mysql::dev_password: dummy_password
+ocfmail::mysql::ro_password: dummypassword
+ocfmail::mysql::dev_password: dummypassword
 
-create::redis::password: dummy_password
-create::mysql::password: dummy_password
+create::redis::password: dummypassword
+create::mysql::password: dummypassword
 
-ocfprinting::mysql::password: dummy_password
+ocfprinting::mysql::password: dummypassword
 
-ocfstats::mysql::password: dummy_password
-ocfstats::mysql::dev_password: dummy_password
-ocfstats::mysql::ro_password: dummy_password
+ocfstats::mysql::password: dummypassword
+ocfstats::mysql::dev_password: dummypassword
+ocfstats::mysql::ro_password: dummypassword
 
-ocfbackups::box::password: dummy_password
-ocfbackups::box::api_client_id: dummy_client_id
-ocfbackups::box::api_client_secret: dummy_client_secret
-ocfbackups::mysql::password: dummy_password
+ocfbackups::box:
+  password: dummypassword
+  api_client_id: dummy_client_id
+  api_client_secret: dummy_client_secret
+ocfbackups::mysql::password: dummypassword
 
-sensu::redis::password: dummy_password
+sensu::redis::password: dummypassword
 
-hpc::slurm::password: dummy_password
-hpc::controller::slurmdbd_mysql_password: dummy_password
+hpc::slurm::password: dummypassword
+hpc::controller::slurmdbd_mysql_password: dummypassword
 
-broker::redis::password: dummy_password
+broker::redis::password: dummypassword
 
 letsencrypt::ddns::key: ZHVtbXlfYmFzZTY0X2tleQ== # 'dummy_base64_key'
 
-postgres::rootpw: dummy_password
-postgres::ocfpgbackups: dummy_password
+postgres::rootpw: dummypassword
+postgres::ocfpgbackups: dummypassword
 
-puppetdb::postgres_password: dummy_password
+puppetdb::postgres_password: dummypassword
 
-ocf::broker::uri: rediss://:dummy_password@broker.ocf.berkeley.edu:6378
+ocf::broker::uri: rediss://:dummypassword@broker.ocf.berkeley.edu:6378
 
 prometheus::slack_webhook: https://hooks.slack.com/services/T02EV1K1G/blah/dummy_path
 
 # Password for ldap.berkeley.edu
-ucbldap::password: dummy_password
+ucbldap::password: dummypassword
 # Password for ldap-test.berkeley.edu
-ucbldap::test_password: dummy_password
+ucbldap::test_password: dummypassword
 
 # Kubernetes token used for jenkins-deploy user
-kubernetes::jenkins_token: dummy_token
+kubernetes::jenkins_token: dummytoken
 #
 # Kubernetes tokens used in the webui for the admin and viewer users
-kubernetes::admin_token: dummy_token
-kubernetes::viewer_token: dummy_token
+kubernetes::admin_token: dummytoken
+kubernetes::viewer_token: dummytoken
 
 # Kubernetes token used by Prometheus for service discovery
-kubernetes::prometheus_token: dummy_token
+kubernetes::prometheus_token: dummytoken
 
-kubernetes::keepalived::secret: dummy_secret
+kubernetes::keepalived::secret: dummysecret
 
 # Used for collecting metrics from docker targets (marathon/kubernetes)
 # Currently only used for ocweb-- a hashed version is in the htaccess file in
 # privshare/docker/ocfweb
-prometheus::docker_metrics_password: dummy_password
+prometheus::docker_metrics_password: dummypassword
 
-mirrors::archlinuxcn_sync_password: dummy_password
-mirrors::finnix_sync_password: dummy_password
+mirrors::archlinuxcn_sync_password: dummypassword
+mirrors::finnix_sync_password: dummypassword
 
-xmpp::root_password: dummy_password
-xmpp::prosody_mysql_password: dummy_password
-xmpp::biboumi_psql_password: dummy_password
-xmpp::dev_biboumi_psql_password: dummy_password
-xmpp::biboumi_component_password: dummy_password
-xmpp::dev_biboumi_component_password: dummy_password
+xmpp::root_password: dummypassword
+xmpp::prosody_mysql_password: dummypassword
+xmpp::biboumi_psql_password: dummypassword
+xmpp::dev_biboumi_psql_password: dummypassword
+xmpp::biboumi_component_password: dummypassword
+xmpp::dev_biboumi_component_password: dummypassword
 
 ceph::mon_key: ZHVtbXlfYmFzZTY0X2tleQ== # 'dummy_base64_key'
 ceph::bootstrap_osd_key: ZHVtbXlfYmFzZTY0X2tleQ== # 'dummy_base64_key'
 ceph::admin_key: ZHVtbXlfYmFzZTY0X2tleQ== # 'dummy_base64_key'
 
-lb::keepalived::secret: dummy_secret
+lb::keepalived::secret: dummysecret
 
-discourse::psql_password: dummy_password
+discourse::psql_password: dummypassword
 
-ocf_docker::hashed_password: dummy_hashed_password
+ocf_docker::hashed_password: dummyhashedpassword
 
-ocf_mysql::root_password: dummy_password
+ocf_mysql::root_password: dummypassword
 
-ocf_jenkins::pypi_password: dummy_password
-ocf_jenkins::docker_push_auth: dummy_password
-ocf_jenkins::docker_hub_auth: dummy_password
+jenkins_creds:
+  pypi_password: dummypassword
+  docker_push_auth: dummypassword
+  docker_hub_auth: dummypassword
 
-ocf_desktop::hashed_root_password: dummy_hashed_password
+ocf_desktop::hashed_root_password: dummyhashedpassword
 
-ocf_irc::anope_link_password: dummy_password
-ocf_irc::die_password: dummy_password
-ocf_irc::restart_password: dummy_password
-ocf_irc::cloak_key: dummy_key
-ocf_irc::mysql_password: dummy_password
-ocf_irc::cert_reload_password: dummy_password
-ocf_irc::services_seed: dummy_seed
+irc_creds:
+  anope_link_password: dummypassword
+  die_password: dummypassword
+  restart_password: dummypassword
+  cloak_key: dummykey
+  mysql_password: dummypassword
+  cert_reload_password: dummypassword
+  services_seed: dummyseed
 
 ### TEMPORARY REMOVE ONCE ALL PUPPET STUFF IS REBASED
-mesos::master::password: dummy_password
-mesos::slave::password: dummy_password
-mesos::zookeeper::password: dummy_password
+mesos::master::password: dummypassword
+mesos::slave::password: dummypassword
+mesos::zookeeper::password: dummypassword
+
+kubernetes::token: dummytoken
+kubernetes::discovery_token_hash: dummyhash
+kubernetes::etcd_ca_crt: dummycert
+kubernetes::etcd_ca_key: dummykey
+kubernetes::etcdclient_crt: dummycert
+kubernetes::etcdclient_key: dummykey
+kubernetes::etcdserver_crt: dummycert
+kubernetes::etcdserver_key: dummykey
+kubernetes::etcdpeer_crt: dummycert
+kubernetes::etcdpeer_key: dummykey
+kubernetes::kubernetes_ca_crt: dummycert
+kubernetes::kubernetes_ca_key: dummykey
+kubernetes::sa_pub: dummykey
+kubernetes::sa_key: dummykey

--- a/hieradata/dummy_secrets.yaml
+++ b/hieradata/dummy_secrets.yaml
@@ -83,6 +83,7 @@ jenkins_creds:
   docker_push_auth: dummypassword
   docker_hub_auth: dummypassword
 
+ocf::root_password: $6$rounds=65536$dummyhashhere
 ocf_desktop::hashed_root_password: dummyhashedpassword
 
 irc_creds:

--- a/hieradata/dummy_secrets.yaml
+++ b/hieradata/dummy_secrets.yaml
@@ -1,0 +1,97 @@
+ocfmail::mysql::ro_password: dummy_password
+ocfmail::mysql::dev_password: dummy_password
+
+create::redis::password: dummy_password
+create::mysql::password: dummy_password
+
+ocfprinting::mysql::password: dummy_password
+
+ocfstats::mysql::password: dummy_password
+ocfstats::mysql::dev_password: dummy_password
+ocfstats::mysql::ro_password: dummy_password
+
+ocfbackups::box::password: dummy_password
+ocfbackups::box::api_client_id: dummy_client_id
+ocfbackups::box::api_client_secret: dummy_client_secret
+ocfbackups::mysql::password: dummy_password
+
+sensu::redis::password: dummy_password
+
+hpc::slurm::password: dummy_password
+hpc::controller::slurmdbd_mysql_password: dummy_password
+
+broker::redis::password: dummy_password
+
+letsencrypt::ddns::key: ZHVtbXlfYmFzZTY0X2tleQ== # 'dummy_base64_key'
+
+postgres::rootpw: dummy_password
+postgres::ocfpgbackups: dummy_password
+
+puppetdb::postgres_password: dummy_password
+
+ocf::broker::uri: rediss://:dummy_password@broker.ocf.berkeley.edu:6378
+
+prometheus::slack_webhook: https://hooks.slack.com/services/T02EV1K1G/blah/dummy_path
+
+# Password for ldap.berkeley.edu
+ucbldap::password: dummy_password
+# Password for ldap-test.berkeley.edu
+ucbldap::test_password: dummy_password
+
+# Kubernetes token used for jenkins-deploy user
+kubernetes::jenkins_token: dummy_token
+#
+# Kubernetes tokens used in the webui for the admin and viewer users
+kubernetes::admin_token: dummy_token
+kubernetes::viewer_token: dummy_token
+
+# Kubernetes token used by Prometheus for service discovery
+kubernetes::prometheus_token: dummy_token
+
+kubernetes::keepalived::secret: dummy_secret
+
+# Used for collecting metrics from docker targets (marathon/kubernetes)
+# Currently only used for ocweb-- a hashed version is in the htaccess file in
+# privshare/docker/ocfweb
+prometheus::docker_metrics_password: dummy_password
+
+mirrors::archlinuxcn_sync_password: dummy_password
+mirrors::finnix_sync_password: dummy_password
+
+xmpp::root_password: dummy_password
+xmpp::prosody_mysql_password: dummy_password
+xmpp::biboumi_psql_password: dummy_password
+xmpp::dev_biboumi_psql_password: dummy_password
+xmpp::biboumi_component_password: dummy_password
+xmpp::dev_biboumi_component_password: dummy_password
+
+ceph::mon_key: ZHVtbXlfYmFzZTY0X2tleQ== # 'dummy_base64_key'
+ceph::bootstrap_osd_key: ZHVtbXlfYmFzZTY0X2tleQ== # 'dummy_base64_key'
+ceph::admin_key: ZHVtbXlfYmFzZTY0X2tleQ== # 'dummy_base64_key'
+
+lb::keepalived::secret: dummy_secret
+
+discourse::psql_password: dummy_password
+
+ocf_docker::hashed_password: dummy_hashed_password
+
+ocf_mysql::root_password: dummy_password
+
+ocf_jenkins::pypi_password: dummy_password
+ocf_jenkins::docker_push_auth: dummy_password
+ocf_jenkins::docker_hub_auth: dummy_password
+
+ocf_desktop::hashed_root_password: dummy_hashed_password
+
+ocf_irc::anope_link_password: dummy_password
+ocf_irc::die_password: dummy_password
+ocf_irc::restart_password: dummy_password
+ocf_irc::cloak_key: dummy_key
+ocf_irc::mysql_password: dummy_password
+ocf_irc::cert_reload_password: dummy_password
+ocf_irc::services_seed: dummy_seed
+
+### TEMPORARY REMOVE ONCE ALL PUPPET STUFF IS REBASED
+mesos::master::password: dummy_password
+mesos::slave::password: dummy_password
+mesos::zookeeper::password: dummy_password

--- a/modules/ocf/manifests/hostkeys.pp
+++ b/modules/ocf/manifests/hostkeys.pp
@@ -1,22 +1,24 @@
 class ocf::hostkeys {
-  file {
-    '/etc/ssh/ssh_host_dsa_key':
-      mode   => '0600',
-      source => 'puppet:///private/hostkeys/ssh_host_dsa_key';
-    '/etc/ssh/ssh_host_dsa_key.pub':
-      mode   => '0644',
-      source => 'puppet:///private/hostkeys/ssh_host_dsa_key.pub';
-    '/etc/ssh/ssh_host_rsa_key':
-      mode   => '0600',
-      source => 'puppet:///private/hostkeys/ssh_host_rsa_key';
-    '/etc/ssh/ssh_host_rsa_key.pub':
-      mode   => '0644',
-      source => 'puppet:///private/hostkeys/ssh_host_rsa_key.pub';
-    '/etc/ssh/ssh_host_ecdsa_key':
-      mode   => '0600',
-      source => 'puppet:///private/hostkeys/ssh_host_ecdsa_key';
-    '/etc/ssh/ssh_host_ecdsa_key.pub':
-      mode   => '0644',
-      source => 'puppet:///private/hostkeys/ssh_host_ecdsa_key.pub';
+  if $::use_private_share {
+    file {
+      '/etc/ssh/ssh_host_dsa_key':
+        mode   => '0600',
+        source => 'puppet:///private/hostkeys/ssh_host_dsa_key';
+      '/etc/ssh/ssh_host_dsa_key.pub':
+        mode   => '0644',
+        source => 'puppet:///private/hostkeys/ssh_host_dsa_key.pub';
+      '/etc/ssh/ssh_host_rsa_key':
+        mode   => '0600',
+        source => 'puppet:///private/hostkeys/ssh_host_rsa_key';
+      '/etc/ssh/ssh_host_rsa_key.pub':
+        mode   => '0644',
+        source => 'puppet:///private/hostkeys/ssh_host_rsa_key.pub';
+      '/etc/ssh/ssh_host_ecdsa_key':
+        mode   => '0600',
+        source => 'puppet:///private/hostkeys/ssh_host_ecdsa_key';
+      '/etc/ssh/ssh_host_ecdsa_key.pub':
+        mode   => '0644',
+        source => 'puppet:///private/hostkeys/ssh_host_ecdsa_key.pub';
+    }
   }
 }

--- a/modules/ocf/manifests/hostkeys.pp
+++ b/modules/ocf/manifests/hostkeys.pp
@@ -1,24 +1,22 @@
 class ocf::hostkeys {
-  if $::use_private_share {
-    file {
-      '/etc/ssh/ssh_host_dsa_key':
-        mode   => '0600',
-        source => 'puppet:///private/hostkeys/ssh_host_dsa_key';
-      '/etc/ssh/ssh_host_dsa_key.pub':
-        mode   => '0644',
-        source => 'puppet:///private/hostkeys/ssh_host_dsa_key.pub';
-      '/etc/ssh/ssh_host_rsa_key':
-        mode   => '0600',
-        source => 'puppet:///private/hostkeys/ssh_host_rsa_key';
-      '/etc/ssh/ssh_host_rsa_key.pub':
-        mode   => '0644',
-        source => 'puppet:///private/hostkeys/ssh_host_rsa_key.pub';
-      '/etc/ssh/ssh_host_ecdsa_key':
-        mode   => '0600',
-        source => 'puppet:///private/hostkeys/ssh_host_ecdsa_key';
-      '/etc/ssh/ssh_host_ecdsa_key.pub':
-        mode   => '0644',
-        source => 'puppet:///private/hostkeys/ssh_host_ecdsa_key.pub';
-    }
+  ocf::privatefile {
+    '/etc/ssh/ssh_host_dsa_key':
+      mode   => '0600',
+      source => 'puppet:///private/hostkeys/ssh_host_dsa_key';
+    '/etc/ssh/ssh_host_dsa_key.pub':
+      mode   => '0644',
+      source => 'puppet:///private/hostkeys/ssh_host_dsa_key.pub';
+    '/etc/ssh/ssh_host_rsa_key':
+      mode   => '0600',
+      source => 'puppet:///private/hostkeys/ssh_host_rsa_key';
+    '/etc/ssh/ssh_host_rsa_key.pub':
+      mode   => '0644',
+      source => 'puppet:///private/hostkeys/ssh_host_rsa_key.pub';
+    '/etc/ssh/ssh_host_ecdsa_key':
+      mode   => '0600',
+      source => 'puppet:///private/hostkeys/ssh_host_ecdsa_key';
+    '/etc/ssh/ssh_host_ecdsa_key.pub':
+      mode   => '0644',
+      source => 'puppet:///private/hostkeys/ssh_host_ecdsa_key.pub';
   }
 }

--- a/modules/ocf/manifests/kerberos.pp
+++ b/modules/ocf/manifests/kerberos.pp
@@ -19,14 +19,11 @@ class ocf::kerberos {
     }
   }
 
-  if $::use_private_share {
-    # provide Kerberos private keytab
-    file { '/etc/krb5.keytab':
-      mode   => '0600',
-      backup => false,
-      source => 'puppet:///private/krb5.keytab',
-      before => Augeas['/etc/ssh/sshd_config/GSSAPIKeyExchange'],
-    }
+  # provide Kerberos private keytab
+  ocf::privatefile { '/etc/krb5.keytab':
+    mode   => '0600',
+    source => 'puppet:///private/krb5.keytab',
+    before => Augeas['/etc/ssh/sshd_config/GSSAPIKeyExchange'],
   }
 
   # enable SSH host key verification

--- a/modules/ocf/manifests/kerberos.pp
+++ b/modules/ocf/manifests/kerberos.pp
@@ -19,18 +19,21 @@ class ocf::kerberos {
     }
   }
 
-  # provide Kerberos private keytab
-  file { '/etc/krb5.keytab':
-    mode   => '0600',
-    backup => false,
-    source => 'puppet:///private/krb5.keytab'
+  if $::use_private_share {
+    # provide Kerberos private keytab
+    file { '/etc/krb5.keytab':
+      mode   => '0600',
+      backup => false,
+      source => 'puppet:///private/krb5.keytab',
+      before => Augeas['/etc/ssh/sshd_config/GSSAPIKeyExchange'],
+    }
   }
 
   # enable SSH host key verification
   augeas { '/etc/ssh/sshd_config/GSSAPIKeyExchange':
     context => '/files/etc/ssh/sshd_config',
     changes => 'set GSSAPIKeyExchange yes',
-    require => [ Package['openssh-server'], File['/etc/krb5.conf'], File['/etc/krb5.keytab'] ],
+    require => [ Package['openssh-server'], File['/etc/krb5.conf'] ],
     notify  => Service['ssh']
   }
 

--- a/modules/ocf/manifests/kerberos.pp
+++ b/modules/ocf/manifests/kerberos.pp
@@ -23,14 +23,13 @@ class ocf::kerberos {
   ocf::privatefile { '/etc/krb5.keytab':
     mode   => '0600',
     source => 'puppet:///private/krb5.keytab',
-    before => Augeas['/etc/ssh/sshd_config/GSSAPIKeyExchange'],
   }
 
   # enable SSH host key verification
   augeas { '/etc/ssh/sshd_config/GSSAPIKeyExchange':
     context => '/files/etc/ssh/sshd_config',
     changes => 'set GSSAPIKeyExchange yes',
-    require => [ Package['openssh-server'], File['/etc/krb5.conf'] ],
+    require => [ Package['openssh-server'], File['/etc/krb5.conf'], Ocf::Privatefile['/etc/krb5.keytab'] ],
     notify  => Service['ssh']
   }
 

--- a/modules/ocf/manifests/privatefile.pp
+++ b/modules/ocf/manifests/privatefile.pp
@@ -1,16 +1,17 @@
 define ocf::privatefile(
   String $path = $title,
-  Optional[String] $source  = undef,
-  Optional[String] $content = undef,
-  Optional[String] $mode    = undef,
-  String $owner    = 'root',
-  String $group    = 'root',
-  Boolean $force   = false,
-  Boolean $purge   = false,
+  Optional[String] $source = undef,
+  Optional[String] $content_path = undef,
+  Optional[String] $mode = undef,
+  String $owner = 'root',
+  String $group = 'root',
+  Boolean $force = false,
+  Boolean $purge = false,
   Boolean $recurse = false,
+  Enum['file', 'directory'] $ensure = 'file',
 ) {
-  if $source and $content {
-    fail('Both source and content parameters cannot be set for a file resource')
+  if $source and $content_path {
+    fail('Both source and content_path parameters cannot be set for an ocf::privatefile resource')
   }
 
   $opts = {
@@ -21,17 +22,23 @@ define ocf::privatefile(
     force   => $force,
     purge   => $purge,
     recurse => $recurse,
+    ensure  => $ensure,
   }
 
   if $::use_private_share {
-    if $content {
-      $file_opts = $opts + {content => $content}
+    if $content_path {
+      # For some reason, puppet-lint thinks the file function call (or
+      # $content) are top-scope variables when they are not, so the check is
+      # ignored for now.
+      $file_opts = $opts + {content => file($content)} # lint:ignore:variable_scope
     } elsif $source {
       $file_opts = $opts + {source => $source}
     }
   } else {
-    # Provide a dummy file as a fallback with some pre-defined contents
-    $file_opts = ($opts - [source, content]) + {content => 'dummy private file'}
+    # Provide a dummy file as a fallback with some pre-defined contents since
+    # the private share where the source/content would have come from is not
+    # available
+    $file_opts = $opts + {content => 'dummy private file'}
   }
 
   file { $title:

--- a/modules/ocf/manifests/privatefile.pp
+++ b/modules/ocf/manifests/privatefile.pp
@@ -4,13 +4,12 @@
 # share, since it could accidentally leak secrets and will show output in
 # jenkins logs that are public.
 #
-# Initially this defined type didn't exist and conditionals using the
-# $::use_private_share conditional were used around everything that used the
-# private share. This worked ok, but led to dependency issues where a resource
-# that would normally exist was then hidden behind a conditional and wouldn't
-# be seen by octocatalog-diff. This approach is better because it can provide a
-# dummy file and a more consistent experience across all usages of the private
-# share.
+# Initially this defined type didn't exist and conditionals using the were used
+# around everything that used the private share. This worked ok, but led to
+# dependency issues where a resource that would normally exist was then hidden
+# behind a conditional and wouldn't be seen by octocatalog-diff. This approach
+# is better because it can provide a dummy file and a more consistent
+# experience across all uses of the private share.
 #
 # This also gives a convenient interface to enforce file parameters like
 # show_diff and backup that we don't want to be set to true for any private
@@ -42,17 +41,17 @@ define ocf::privatefile(
     ensure  => $ensure,
   }
 
-  if $::use_private_share {
+  if $::dummy_secrets {
+    # Provide a dummy file as a fallback with some pre-defined contents since
+    # the private share where the source/content would have come from is not
+    # available
+    $file_opts = $opts + {content => 'dummy private file'}
+  } else {
     if $content_path {
       $file_opts = $opts + {content => file($content_path)}
     } elsif $source {
       $file_opts = $opts + {source => $source}
     }
-  } else {
-    # Provide a dummy file as a fallback with some pre-defined contents since
-    # the private share where the source/content would have come from is not
-    # available
-    $file_opts = $opts + {content => 'dummy private file'}
   }
 
   file { $title:

--- a/modules/ocf/manifests/privatefile.pp
+++ b/modules/ocf/manifests/privatefile.pp
@@ -1,0 +1,42 @@
+define ocf::privatefile(
+  String $path = $title,
+  Optional[String] $source  = undef,
+  Optional[String] $content = undef,
+  Optional[String] $mode    = undef,
+  String $owner    = 'root',
+  String $group    = 'root',
+  Boolean $force   = false,
+  Boolean $purge   = false,
+  Boolean $recurse = false,
+) {
+  if $source and $content {
+    fail('Both source and content parameters cannot be set for a file resource')
+  }
+
+  $opts = {
+    path    => $path,
+    mode    => $mode,
+    owner   => $owner,
+    group   => $group,
+    force   => $force,
+    purge   => $purge,
+    recurse => $recurse,
+  }
+
+  if $::use_private_share {
+    if $content {
+      $file_opts = $opts + {content => $content}
+    } elsif $source {
+      $file_opts = $opts + {source => $source}
+    }
+  } else {
+    # Provide a dummy file as a fallback with some pre-defined contents
+    $file_opts = ($opts - [source, content]) + {content => 'dummy private file'}
+  }
+
+  file { $title:
+    backup    => false,
+    show_diff => false,
+    *         => $file_opts,
+  }
+}

--- a/modules/ocf/manifests/rootpw.pp
+++ b/modules/ocf/manifests/rootpw.pp
@@ -6,8 +6,10 @@
 #
 # To regenerate the root password, see /opt/share/utils/staff/puppet/gen-rootpw
 class ocf::rootpw($stage = 'first') {
-  user { 'root':
-    groups   => ['root'],
-    password => Sensitive(file('/opt/puppet/shares/private/rootpw')),
+  if $::use_private_share {
+    user { 'root':
+      groups   => ['root'],
+      password => Sensitive(file('/opt/puppet/shares/private/rootpw')),
+    }
   }
 }

--- a/modules/ocf/manifests/rootpw.pp
+++ b/modules/ocf/manifests/rootpw.pp
@@ -4,12 +4,10 @@
 # The root password is a last resort that is only used in rare cases where
 # there is no other option.
 #
-# To regenerate the root password, see /opt/share/utils/staff/puppet/gen-rootpw
+# To regenerate the root password, see the gen-rootpw script from utils
 class ocf::rootpw($stage = 'first') {
-  if $::use_private_share {
-    user { 'root':
-      groups   => ['root'],
-      password => Sensitive(file('/opt/puppet/shares/private/rootpw')),
-    }
+  user { 'root':
+    groups   => ['root'],
+    password => Sensitive(lookup('ocf::root_password')),
   }
 }

--- a/modules/ocf/manifests/ssl/setup.pp
+++ b/modules/ocf/manifests/ssl/setup.pp
@@ -37,15 +37,18 @@ class ocf::ssl::setup {
       ensure => directory,
       owner  => ocfletsencrypt;
 
-    '/etc/ssl/lets-encrypt/le-account.key':
-      content   => file('/opt/puppet/shares/private/lets-encrypt-account.key'),
-      owner     => ocfletsencrypt,
-      show_diff => false,
-      mode      => '0400';
-
     '/var/lib/lets-encrypt':
       ensure => directory,
       owner  => ocfletsencrypt,
       group  => ssl-cert;
+  }
+
+  if $::use_private_share {
+    file { '/etc/ssl/lets-encrypt/le-account.key':
+      content   => file('/opt/puppet/shares/private/lets-encrypt-account.key'),
+      owner     => ocfletsencrypt,
+      show_diff => false,
+      mode      => '0400';
+    }
   }
 }

--- a/modules/ocf/manifests/ssl/setup.pp
+++ b/modules/ocf/manifests/ssl/setup.pp
@@ -43,12 +43,9 @@ class ocf::ssl::setup {
       group  => ssl-cert;
   }
 
-  if $::use_private_share {
-    file { '/etc/ssl/lets-encrypt/le-account.key':
-      content   => file('/opt/puppet/shares/private/lets-encrypt-account.key'),
-      owner     => ocfletsencrypt,
-      show_diff => false,
-      mode      => '0400';
-    }
+  ocf::privatefile { '/etc/ssl/lets-encrypt/le-account.key':
+    content_path => '/opt/puppet/shares/private/lets-encrypt-account.key',
+    owner        => ocfletsencrypt,
+    mode         => '0400';
   }
 }

--- a/modules/ocf_admin/manifests/apt_dater.pp
+++ b/modules/ocf_admin/manifests/apt_dater.pp
@@ -1,9 +1,11 @@
 class ocf_admin::apt_dater {
   package { 'apt-dater':; }
 
-  file { '/root/apt-dater.keytab':
-    mode   => '0600',
-    backup => false,
-    source => 'puppet:///private/apt-dater.keytab';
+  if $::use_private_share {
+    file { '/root/apt-dater.keytab':
+      mode   => '0600',
+      backup => false,
+      source => 'puppet:///private/apt-dater.keytab';
+    }
   }
 }

--- a/modules/ocf_admin/manifests/apt_dater.pp
+++ b/modules/ocf_admin/manifests/apt_dater.pp
@@ -1,11 +1,8 @@
 class ocf_admin::apt_dater {
   package { 'apt-dater':; }
 
-  if $::use_private_share {
-    file { '/root/apt-dater.keytab':
-      mode   => '0600',
-      backup => false,
-      source => 'puppet:///private/apt-dater.keytab';
-    }
+  ocf::privatefile { '/root/apt-dater.keytab':
+    mode   => '0600',
+    source => 'puppet:///private/apt-dater.keytab';
   }
 }

--- a/modules/ocf_admin/manifests/create.pp
+++ b/modules/ocf_admin/manifests/create.pp
@@ -15,19 +15,17 @@ class ocf_admin::create {
       show_diff => false;
   }
 
-  if $::use_private_share {
-    file {
-      '/etc/ocf-create/create.keytab':
-        mode   => '0400',
-        source => 'puppet:///private/create.keytab';
+  ocf::privatefile {
+    '/etc/ocf-create/create.keytab':
+      mode   => '0400',
+      source => 'puppet:///private/create.keytab';
 
-      '/etc/ocf-create/create.key':
-        mode   => '0400',
-        source => 'puppet:///private/create.key';
+    '/etc/ocf-create/create.key':
+      mode   => '0400',
+      source => 'puppet:///private/create.key';
 
-      '/etc/ocf-create/create.pub':
-        mode   => '0444',
-        source => 'puppet:///private/create.pub';
-    }
+    '/etc/ocf-create/create.pub':
+      mode   => '0444',
+      source => 'puppet:///private/create.pub';
   }
 }

--- a/modules/ocf_admin/manifests/create.pp
+++ b/modules/ocf_admin/manifests/create.pp
@@ -13,17 +13,21 @@ class ocf_admin::create {
       content   => template('ocf_admin/create.conf.erb'),
       mode      => '0440',
       show_diff => false;
+  }
 
-    '/etc/ocf-create/create.keytab':
-      mode   => '0400',
-      source => 'puppet:///private/create.keytab';
+  if $::use_private_share {
+    file {
+      '/etc/ocf-create/create.keytab':
+        mode   => '0400',
+        source => 'puppet:///private/create.keytab';
 
-    '/etc/ocf-create/create.key':
-      mode   => '0400',
-      source => 'puppet:///private/create.key';
+      '/etc/ocf-create/create.key':
+        mode   => '0400',
+        source => 'puppet:///private/create.key';
 
-    '/etc/ocf-create/create.pub':
-      mode   => '0444',
-      source => 'puppet:///private/create.pub';
+      '/etc/ocf-create/create.pub':
+        mode   => '0444',
+        source => 'puppet:///private/create.pub';
+    }
   }
 }

--- a/modules/ocf_admin/manifests/init.pp
+++ b/modules/ocf_admin/manifests/init.pp
@@ -29,10 +29,9 @@ class ocf_admin {
   $ocfprinting_mysql_password = lookup('ocfprinting::mysql::password')
   ocf::privatefile {
     '/opt/passwords':
-      source    => 'puppet:///private/passwords',
-      group     => ocfroot,
-      mode      => '0640',
-      show_diff => false;
+      source => 'puppet:///private/passwords',
+      group  => ocfroot,
+      mode   => '0640';
   }
 
   file {

--- a/modules/ocf_admin/manifests/init.pp
+++ b/modules/ocf_admin/manifests/init.pp
@@ -27,13 +27,19 @@ class ocf_admin {
   }
 
   $ocfprinting_mysql_password = lookup('ocfprinting::mysql::password')
-  file {
-    '/opt/passwords':
-      source    => 'puppet:///private/passwords',
-      group     => ocfroot,
-      mode      => '0640',
-      show_diff => false;
+  if $::use_private_share {
+    file {
+      '/opt/passwords':
+        source    => 'puppet:///private/passwords',
+        group     => ocfroot,
+        mode      => '0640',
+        show_diff => false;
+    }
+  }
 
+  $ocfprinting_mysql_password = lookup('ocfprinting::mysql::password')
+
+  file {
     '/etc/ocfprinting.json':
       content   => template('ocf_admin/ocfprinting.json.erb'),
       group     => ocfstaff,

--- a/modules/ocf_admin/manifests/init.pp
+++ b/modules/ocf_admin/manifests/init.pp
@@ -27,17 +27,13 @@ class ocf_admin {
   }
 
   $ocfprinting_mysql_password = lookup('ocfprinting::mysql::password')
-  if $::use_private_share {
-    file {
-      '/opt/passwords':
-        source    => 'puppet:///private/passwords',
-        group     => ocfroot,
-        mode      => '0640',
-        show_diff => false;
-    }
+  ocf::privatefile {
+    '/opt/passwords':
+      source    => 'puppet:///private/passwords',
+      group     => ocfroot,
+      mode      => '0640',
+      show_diff => false;
   }
-
-  $ocfprinting_mysql_password = lookup('ocfprinting::mysql::password')
 
   file {
     '/etc/ocfprinting.json':

--- a/modules/ocf_apphost/manifests/lets_encrypt.pp
+++ b/modules/ocf_apphost/manifests/lets_encrypt.pp
@@ -13,7 +13,8 @@ class ocf_apphost::lets_encrypt {
       source    => 'puppet:///private/lets-encrypt-vhost.key',
       owner     => ocfletsencrypt,
       show_diff => false,
-      mode      => '0400';
+      mode      => '0400',
+      before    => Cron['lets-encrypt-update'],
     }
   }
 
@@ -23,8 +24,7 @@ class ocf_apphost::lets_encrypt {
       user        => ocfletsencrypt,
       environment => ['MAILTO=root', 'PATH=/bin:/usr/bin:/usr/local/bin'],
       special     => hourly,
-      require     => File['/usr/local/bin/lets-encrypt-update',
-                          '/etc/ssl/lets-encrypt/le-vhost.key'],
+      require     => File['/usr/local/bin/lets-encrypt-update'],
     }
   }
 }

--- a/modules/ocf_apphost/manifests/lets_encrypt.pp
+++ b/modules/ocf_apphost/manifests/lets_encrypt.pp
@@ -6,12 +6,15 @@ class ocf_apphost::lets_encrypt {
       source  => 'puppet:///modules/ocf_www/lets-encrypt-update',
       mode    => '0755',
       require => File['/usr/local/bin/ocf-lets-encrypt'];
+  }
 
-    '/etc/ssl/lets-encrypt/le-vhost.key':
+  if $::use_private_share {
+    file { '/etc/ssl/lets-encrypt/le-vhost.key':
       source    => 'puppet:///private/lets-encrypt-vhost.key',
       owner     => ocfletsencrypt,
       show_diff => false,
       mode      => '0400';
+    }
   }
 
   if $::host_env == 'prod' {

--- a/modules/ocf_apphost/manifests/lets_encrypt.pp
+++ b/modules/ocf_apphost/manifests/lets_encrypt.pp
@@ -12,7 +12,6 @@ class ocf_apphost::lets_encrypt {
     source => 'puppet:///private/lets-encrypt-vhost.key',
     owner  => ocfletsencrypt,
     mode   => '0400',
-    before => Cron['lets-encrypt-update'],
   }
 
   if $::host_env == 'prod' {
@@ -21,7 +20,8 @@ class ocf_apphost::lets_encrypt {
       user        => ocfletsencrypt,
       environment => ['MAILTO=root', 'PATH=/bin:/usr/bin:/usr/local/bin'],
       special     => hourly,
-      require     => File['/usr/local/bin/lets-encrypt-update'],
+      require     => [File['/usr/local/bin/lets-encrypt-update'],
+                      Ocf::Privatefile['/etc/ssl/lets-encrypt/le-vhost.key']],
     }
   }
 }

--- a/modules/ocf_apphost/manifests/lets_encrypt.pp
+++ b/modules/ocf_apphost/manifests/lets_encrypt.pp
@@ -8,14 +8,11 @@ class ocf_apphost::lets_encrypt {
       require => File['/usr/local/bin/ocf-lets-encrypt'];
   }
 
-  if $::use_private_share {
-    file { '/etc/ssl/lets-encrypt/le-vhost.key':
-      source    => 'puppet:///private/lets-encrypt-vhost.key',
-      owner     => ocfletsencrypt,
-      show_diff => false,
-      mode      => '0400',
-      before    => Cron['lets-encrypt-update'],
-    }
+  ocf::privatefile { '/etc/ssl/lets-encrypt/le-vhost.key':
+    source => 'puppet:///private/lets-encrypt-vhost.key',
+    owner  => ocfletsencrypt,
+    mode   => '0400',
+    before => Cron['lets-encrypt-update'],
   }
 
   if $::host_env == 'prod' {

--- a/modules/ocf_apt/manifests/init.pp
+++ b/modules/ocf_apt/manifests/init.pp
@@ -25,10 +25,6 @@ class ocf_apt {
     '/opt/apt/etc/distributions':
       source => 'puppet:///modules/ocf_apt/distributions';
 
-    '/opt/apt/etc/private.key':
-      source => 'puppet:///private/apt/private.key',
-      mode   => '0400';
-
     '/opt/apt/bin':
       ensure  => directory,
       source  => 'puppet:///modules/ocf_apt/bin/',
@@ -41,28 +37,35 @@ class ocf_apt {
       group   => root;
   }
 
-  exec {
-    'import-apt-gpg':
-      command     => 'rm -rf /opt/apt/.gnupg && gpg --import /opt/apt/etc/private.key',
-      user        => ocfapt,
-      refreshonly => true,
-      subscribe   => File['/opt/apt/etc/private.key'];
+  if $::use_private_share {
+    file { '/opt/apt/etc/private.key':
+      source => 'puppet:///private/apt/private.key',
+      mode   => '0400';
+    }
 
-    'export-gpg-pubkey':
-      command => 'gpg --output /opt/apt/ftp/pubkey.gpg --export D72A0AF4',
-      creates => '/opt/apt/ftp/pubkey.gpg',
-      require => Exec['import-apt-gpg'];
+    exec {
+      'import-apt-gpg':
+        command     => 'rm -rf /opt/apt/.gnupg && gpg --import /opt/apt/etc/private.key',
+        user        => ocfapt,
+        refreshonly => true,
+        subscribe   => File['/opt/apt/etc/private.key'];
 
-    'initial-reprepro-export':
-      command => '/opt/apt/bin/reprepro export',
-      user    => ocfapt,
-      creates => '/opt/apt/ftp/dists',
-      require => [
-        Package['reprepro'],
-        File['/opt/apt/bin', '/opt/apt/etc', '/opt/apt/db', '/opt/apt/ftp'],
-        Exec['import-apt-gpg'],
-        User['ocfapt'],
-      ];
+      'export-gpg-pubkey':
+        command => 'gpg --output /opt/apt/ftp/pubkey.gpg --export D72A0AF4',
+        creates => '/opt/apt/ftp/pubkey.gpg',
+        require => Exec['import-apt-gpg'];
+
+      'initial-reprepro-export':
+        command => '/opt/apt/bin/reprepro export',
+        user    => ocfapt,
+        creates => '/opt/apt/ftp/dists',
+        require => [
+          Package['reprepro'],
+          File['/opt/apt/bin', '/opt/apt/etc', '/opt/apt/db', '/opt/apt/ftp'],
+          Exec['import-apt-gpg'],
+          User['ocfapt'],
+        ];
+    }
   }
 
   apache::vhost { 'apt.ocf.berkeley.edu':

--- a/modules/ocf_backups/manifests/init.pp
+++ b/modules/ocf_backups/manifests/init.pp
@@ -15,11 +15,9 @@ class ocf_backups {
       mode   => '0750';
   }
 
-  if $::use_private_share {
-    # keytab for ocfbackups user, used to rsync from remote servers
-    file { '/opt/share/backups/ocfbackups.keytab':
-      source => 'puppet:///private/ocfbackups.keytab',
-      mode   => '0600';
-    }
+  # keytab for ocfbackups user, used to rsync from remote servers
+  ocf::privatefile { '/opt/share/backups/ocfbackups.keytab':
+    source => 'puppet:///private/ocfbackups.keytab',
+    mode   => '0600';
   }
 }

--- a/modules/ocf_backups/manifests/init.pp
+++ b/modules/ocf_backups/manifests/init.pp
@@ -13,10 +13,13 @@ class ocf_backups {
       ensure => directory,
       group  => ocfroot,
       mode   => '0750';
+  }
 
+  if $::use_private_share {
     # keytab for ocfbackups user, used to rsync from remote servers
-    '/opt/share/backups/ocfbackups.keytab':
+    file { '/opt/share/backups/ocfbackups.keytab':
       source => 'puppet:///private/ocfbackups.keytab',
       mode   => '0600';
+    }
   }
 }

--- a/modules/ocf_broker/manifests/init.pp
+++ b/modules/ocf_broker/manifests/init.pp
@@ -18,17 +18,17 @@ class ocf_broker {
     $redis_password = assert_type(Pattern[/^[a-zA-Z0-9]*$/], lookup('broker::redis::password'))
 
     augeas { '/etc/redis/redis.conf':
-        lens      => 'Spacevars.simple_lns',
-        incl      => '/etc/redis/redis.conf',
-        changes   => [
-          'set port 6379',
-          "set requirepass ${redis_password}",
-          'set appendonly yes',
-          'rm save',
-        ],
-        show_diff => false,
-        require   => File['/etc/redis/redis.conf'],
-        notify    => Service['redis-server'];
+      lens      => 'Spacevars.simple_lns',
+      incl      => '/etc/redis/redis.conf',
+      changes   => [
+        'set port 6379',
+        "set requirepass ${redis_password}",
+        'set appendonly yes',
+        'rm save',
+      ],
+      show_diff => false,
+      require   => File['/etc/redis/redis.conf'],
+      notify    => Service['redis-server'];
     }
 
     # We already have an OCF member with the username "hitch", so dpkg

--- a/modules/ocf_decal/manifests/init.pp
+++ b/modules/ocf_decal/manifests/init.pp
@@ -17,15 +17,12 @@ class ocf_decal {
       require => User['ocfdecal'];
   }
 
-  if $::use_private_share {
-    file { '/etc/decal_mysql.conf':
-      source    => 'puppet:///private/mysql.conf',
-      owner     => ocfdecal,
-      group     => ocfstaff,
-      mode      => '0440',
-      show_diff => false,
-      require   => User['ocfdecal'];
-    }
+  ocf::privatefile { '/etc/decal_mysql.conf':
+    source  => 'puppet:///private/mysql.conf',
+    owner   => ocfdecal,
+    group   => ocfstaff,
+    mode    => '0440',
+    require => User['ocfdecal'];
   }
 
   vcsrepo { '/opt/share/decal-utils':

--- a/modules/ocf_decal/manifests/init.pp
+++ b/modules/ocf_decal/manifests/init.pp
@@ -15,13 +15,17 @@ class ocf_decal {
       owner   => ocfdecal,
       group   => ocfdecal,
       require => User['ocfdecal'];
-    '/etc/decal_mysql.conf':
+  }
+
+  if $::use_private_share {
+    file { '/etc/decal_mysql.conf':
       source    => 'puppet:///private/mysql.conf',
       owner     => ocfdecal,
       group     => ocfstaff,
       mode      => '0440',
       show_diff => false,
       require   => User['ocfdecal'];
+    }
   }
 
   vcsrepo { '/opt/share/decal-utils':

--- a/modules/ocf_hpc/manifests/init.pp
+++ b/modules/ocf_hpc/manifests/init.pp
@@ -5,7 +5,6 @@ class ocf_hpc {
 
   package { 'slurm-wlm': }
 
-  # TODO: Rename $::use_private_share to something more representative of what it does
   if str2bool($::puppetdb_running) {
     $slurm_nodes_facts_query = puppetdb_query('inventory[facts] { resources { type = "Class" and title = "Ocf_hpc::Compute" } }')
     # To avoid a circular dependency, fallback to empty values if no nodes match the query.
@@ -42,18 +41,13 @@ class ocf_hpc {
 
   # SLURM uses MUNGE for authentication. Each host needs to have
   # the same munge.key, and have synced clocks.
-  package { 'munge': }
-
-  if $::use_private_share {
-    file { '/etc/munge/munge.key':
-      source  => 'puppet:///private/munge.key',
-      mode    => '0400',
-      owner   => 'munge',
-      group   => 'munge',
-      require => Package['munge'],
-      notify  => Service['munge'],
-    }
-  }
+  package { 'munge': } ->
+  ocf::privatefile { '/etc/munge/munge.key':
+    source => 'puppet:///private/munge.key',
+    mode   => '0400',
+    owner  => 'munge',
+    group  => 'munge',
+  } ~>
   service { 'munge':
     ensure     => 'running',
     enable     => true,

--- a/modules/ocf_hpc/manifests/init.pp
+++ b/modules/ocf_hpc/manifests/init.pp
@@ -6,7 +6,7 @@ class ocf_hpc {
   package { 'slurm-wlm': }
 
   # TODO: Rename $::use_private_share to something more representative of what it does
-  if str2bool($::puppetdb_running) and $::use_private_share {
+  if str2bool($::puppetdb_running) {
     $slurm_nodes_facts_query = puppetdb_query('inventory[facts] { resources { type = "Class" and title = "Ocf_hpc::Compute" } }')
     # To avoid a circular dependency, fallback to empty values if no nodes match the query.
     $slurm_nodes_facts = $slurm_nodes_facts_query == undef ? {

--- a/modules/ocf_jenkins/manifests/init.pp
+++ b/modules/ocf_jenkins/manifests/init.pp
@@ -103,22 +103,18 @@ class ocf_jenkins {
       group   => root;
   }
 
-  if $::use_private_share {
-    file {
-      '/opt/jenkins/deploy/ocfdeploy.keytab':
-        source    => 'puppet:///private/ocfdeploy.keytab',
-        owner     => root,
-        group     => jenkins-deploy,
-        mode      => '0640',
-        show_diff => false;
+  ocf::privatefile {
+    '/opt/jenkins/deploy/ocfdeploy.keytab':
+      source => 'puppet:///private/ocfdeploy.keytab',
+      owner  => root,
+      group  => jenkins-deploy,
+      mode   => '0640';
 
-      '/opt/jenkins/deploy/ssh_cli':
-        source    => 'puppet:///private/ssh_cli',
-        owner     => jenkins-deploy,
-        group     => jenkins-deploy,
-        mode      => '0640',
-        show_diff => false;
-    }
+    '/opt/jenkins/deploy/ssh_cli':
+      source => 'puppet:///private/ssh_cli',
+      owner  => jenkins-deploy,
+      group  => jenkins-deploy,
+      mode   => '0640';
   }
 
   # We set up two separate jenkins users:

--- a/modules/ocf_jenkins/manifests/init.pp
+++ b/modules/ocf_jenkins/manifests/init.pp
@@ -73,13 +73,6 @@ class ocf_jenkins {
       owner  => jenkins-deploy,
       group  => jenkins-deploy;
 
-    '/opt/jenkins/deploy/ocfdeploy.keytab':
-      source    => 'puppet:///private/ocfdeploy.keytab',
-      owner     => root,
-      group     => jenkins-deploy,
-      mode      => '0640',
-      show_diff => false;
-
     '/opt/jenkins/deploy/.pypirc':
       content   => template('ocf_jenkins/pypirc'),
       owner     => root,
@@ -100,13 +93,6 @@ class ocf_jenkins {
       mode      => '0640',
       show_diff => false;
 
-    '/opt/jenkins/deploy/ssh_cli':
-      source    => 'puppet:///private/ssh_cli',
-      owner     => jenkins-deploy,
-      group     => jenkins-deploy,
-      mode      => '0640',
-      show_diff => false;
-
     '/opt/jenkins/update-plugins':
       source => 'puppet:///modules/ocf_jenkins/update-plugins',
       mode   => '0750';
@@ -115,6 +101,24 @@ class ocf_jenkins {
       content => "jenkins ALL=(jenkins-deploy) NOPASSWD: ALL\n",
       owner   => root,
       group   => root;
+  }
+
+  if $::use_private_share {
+    file {
+      '/opt/jenkins/deploy/ocfdeploy.keytab':
+        source    => 'puppet:///private/ocfdeploy.keytab',
+        owner     => root,
+        group     => jenkins-deploy,
+        mode      => '0640',
+        show_diff => false;
+
+      '/opt/jenkins/deploy/ssh_cli':
+        source    => 'puppet:///private/ssh_cli',
+        owner     => jenkins-deploy,
+        group     => jenkins-deploy,
+        mode      => '0640',
+        show_diff => false;
+    }
   }
 
   # We set up two separate jenkins users:

--- a/modules/ocf_kubernetes/manifests/worker/secrets.pp
+++ b/modules/ocf_kubernetes/manifests/worker/secrets.pp
@@ -24,14 +24,6 @@ class ocf_kubernetes::worker::secrets {
       ensure => directory,
       mode   => '0700';
 
-    '/opt/share/kubernetes/secrets':
-      mode      => '0644',
-      source    => 'puppet:///private-docker/',
-      recurse   => true,
-      purge     => true,
-      force     => true,
-      show_diff => false;
-
     # Create a couple scratch directories for sourcegraph to use for temporary
     # data storage
     #
@@ -41,5 +33,16 @@ class ocf_kubernetes::worker::secrets {
     ['/opt/share/docker/sourcegraph', '/opt/share/docker/sourcegraph/redis']:
       ensure => directory,
       mode   => '0700';
+  }
+
+  if $::use_private_share {
+    file { '/opt/share/kubernetes/secrets':
+      mode      => '0644',
+      source    => 'puppet:///private-docker/',
+      recurse   => true,
+      purge     => true,
+      force     => true,
+      show_diff => false;
+    }
   }
 }

--- a/modules/ocf_kubernetes/manifests/worker/secrets.pp
+++ b/modules/ocf_kubernetes/manifests/worker/secrets.pp
@@ -35,14 +35,11 @@ class ocf_kubernetes::worker::secrets {
       mode   => '0700';
   }
 
-  if $::use_private_share {
-    file { '/opt/share/kubernetes/secrets':
-      mode      => '0644',
-      source    => 'puppet:///private-docker/',
-      recurse   => true,
-      purge     => true,
-      force     => true,
-      show_diff => false;
-    }
+  ocf::privatefile { '/opt/share/kubernetes/secrets':
+    mode    => '0644',
+    source  => 'puppet:///private-docker/',
+    recurse => true,
+    purge   => true,
+    force   => true;
   }
 }

--- a/modules/ocf_kvm/manifests/init.pp
+++ b/modules/ocf_kvm/manifests/init.pp
@@ -47,13 +47,10 @@ class ocf_kvm($group = 'root') {
       ensure => directory;
   }
 
-  if $::use_private_share {
-    file {
-      '/opt/share/kvm/makevm-ssh-key':
-        content   => file('/opt/puppet/shares/private/makevm-ssh-key'),
-        mode      => '0400',
-        owner     => 'root',
-        show_diff => false;
-    }
+  ocf::privatefile {
+    '/opt/share/kvm/makevm-ssh-key':
+      content_path => '/opt/puppet/shares/private/makevm-ssh-key',
+      mode         => '0400',
+      owner        => 'root';
   }
 }

--- a/modules/ocf_kvm/manifests/init.pp
+++ b/modules/ocf_kvm/manifests/init.pp
@@ -45,11 +45,15 @@ class ocf_kvm($group = 'root') {
 
     '/opt/share/kvm':
       ensure => directory;
+  }
 
-    '/opt/share/kvm/makevm-ssh-key':
-      content   => file('/opt/puppet/shares/private/makevm-ssh-key'),
-      mode      => '0400',
-      owner     => 'root',
-      show_diff => false;
+  if $::use_private_share {
+    file {
+      '/opt/share/kvm/makevm-ssh-key':
+        content   => file('/opt/puppet/shares/private/makevm-ssh-key'),
+        mode      => '0400',
+        owner     => 'root',
+        show_diff => false;
+    }
   }
 }

--- a/modules/ocf_ldap/manifests/init.pp
+++ b/modules/ocf_ldap/manifests/init.pp
@@ -10,6 +10,7 @@ class ocf_ldap {
         '/etc/ldap/schema/puppet.schema',
         '/etc/ldap/sasl2/slapd.conf',
         '/etc/ldap/slapd.conf'],
+      Ocf::Privatefile['/etc/ldap/krb5.keytab'],
       Augeas['/etc/default/slapd'],
       Class['ocf::ssl::default'],
     ],
@@ -44,7 +45,6 @@ class ocf_ldap {
     group   => openldap,
     mode    => '0600',
     require => Package['slapd', 'heimdal-clients'],
-    notify  => Service['slapd'],
   }
 
   augeas { '/etc/default/slapd':
@@ -94,7 +94,8 @@ class ocf_ldap {
       '/var/backups/ldap/.git/hooks/post-commit':
         content => "git push -q git@github.com:ocf/ldap master\n",
         mode    => '0755',
-        require => Package['ldap-git-backup'];
+        require => [Package['ldap-git-backup'],
+                    Ocf::Privatefile['/root/.ssh/id_rsa']];
 
       '/root/.ssh':
         ensure => directory,
@@ -109,7 +110,6 @@ class ocf_ldap {
     ocf::privatefile { '/root/.ssh/id_rsa':
       source => 'puppet:///private/id_rsa',
       mode   => '0600',
-      before => File['/var/backups/ldap/.git/hooks/post-commit'];
     }
   }
 

--- a/modules/ocf_ldap/manifests/init.pp
+++ b/modules/ocf_ldap/manifests/init.pp
@@ -38,16 +38,13 @@ class ocf_ldap {
       require => Package['slapd', 'libsasl2-modules-gssapi-mit'];
   }
 
-  if $::use_private_share {
-    file { '/etc/ldap/krb5.keytab':
-      source    => 'puppet:///private/krb5-ldap.keytab',
-      owner     => openldap,
-      group     => openldap,
-      mode      => '0600',
-      show_diff => false,
-      require   => Package['slapd', 'heimdal-clients'],
-      notify    => Service['slapd'],
-    }
+  ocf::privatefile { '/etc/ldap/krb5.keytab':
+    source  => 'puppet:///private/krb5-ldap.keytab',
+    owner   => openldap,
+    group   => openldap,
+    mode    => '0600',
+    require => Package['slapd', 'heimdal-clients'],
+    notify  => Service['slapd'],
   }
 
   augeas { '/etc/default/slapd':
@@ -109,13 +106,10 @@ class ocf_ldap {
         source => 'puppet:///modules/ocf_ldap/github_known_hosts';
     }
 
-    if $::use_private_share {
-      file {  '/root/.ssh/id_rsa':
-        source    => 'puppet:///private/id_rsa',
-        mode      => '0600',
-        show_diff => false,
-        before    => File['/var/backups/ldap/.git/hooks/post-commit'];
-      }
+    ocf::privatefile { '/root/.ssh/id_rsa':
+      source => 'puppet:///private/id_rsa',
+      mode   => '0600',
+      before => File['/var/backups/ldap/.git/hooks/post-commit'];
     }
   }
 

--- a/modules/ocf_ldap/manifests/init.pp
+++ b/modules/ocf_ldap/manifests/init.pp
@@ -97,7 +97,7 @@ class ocf_ldap {
       '/var/backups/ldap/.git/hooks/post-commit':
         content => "git push -q git@github.com:ocf/ldap master\n",
         mode    => '0755',
-        require => [Package['ldap-git-backup'], File['/root/.ssh/id_rsa']];
+        require => Package['ldap-git-backup'];
 
       '/root/.ssh':
         ensure => directory,
@@ -113,7 +113,8 @@ class ocf_ldap {
       file {  '/root/.ssh/id_rsa':
         source    => 'puppet:///private/id_rsa',
         mode      => '0600',
-        show_diff => false;
+        show_diff => false,
+        before    => File['/var/backups/ldap/.git/hooks/post-commit'];
       }
     }
   }

--- a/modules/ocf_mail/manifests/site_ocf.pp
+++ b/modules/ocf_mail/manifests/site_ocf.pp
@@ -57,15 +57,13 @@ class ocf_mail::site_ocf {
       ];
   }
 
-  if $::use_private_share {
-    file { '/etc/postfix/ocf/smtp-krb5.keytab':
-      mode    => '0600',
-      owner   => root,
-      group   => root,
-      source  => 'puppet:///private/smtp-krb5.keytab',
-      require => Package['postfix'],
-      before  => Cron['update-cred-cache', 'update-cred-cache-reboot'],
-    }
+  ocf::privatefile { '/etc/postfix/ocf/smtp-krb5.keytab':
+    mode    => '0600',
+    owner   => root,
+    group   => root,
+    source  => 'puppet:///private/smtp-krb5.keytab',
+    require => Package['postfix'],
+    before  => Cron['update-cred-cache', 'update-cred-cache-reboot'],
   }
 
   file {

--- a/modules/ocf_mail/manifests/site_ocf.pp
+++ b/modules/ocf_mail/manifests/site_ocf.pp
@@ -44,6 +44,7 @@ class ocf_mail::site_ocf {
       special => 'hourly',
       require => [
         File['/usr/local/sbin/update-cred-cache'],
+        Ocf::Privatefile['/etc/postfix/ocf/smtp-krb5.keytab'],
         Service['postfix']
       ];
 
@@ -53,6 +54,7 @@ class ocf_mail::site_ocf {
       special => 'reboot',
       require => [
         File['/usr/local/sbin/update-cred-cache'],
+        Ocf::Privatefile['/etc/postfix/ocf/smtp-krb5.keytab'],
         Service['postfix']
       ];
   }
@@ -63,7 +65,6 @@ class ocf_mail::site_ocf {
     group   => root,
     source  => 'puppet:///private/smtp-krb5.keytab',
     require => Package['postfix'],
-    before  => Cron['update-cred-cache', 'update-cred-cache-reboot'],
   }
 
   file {

--- a/modules/ocf_mail/manifests/site_ocf.pp
+++ b/modules/ocf_mail/manifests/site_ocf.pp
@@ -44,7 +44,6 @@ class ocf_mail::site_ocf {
       special => 'hourly',
       require => [
         File['/usr/local/sbin/update-cred-cache'],
-        File['/etc/postfix/ocf/smtp-krb5.keytab'],
         Service['postfix']
       ];
 
@@ -54,19 +53,22 @@ class ocf_mail::site_ocf {
       special => 'reboot',
       require => [
         File['/usr/local/sbin/update-cred-cache'],
-        File['/etc/postfix/ocf/smtp-krb5.keytab'],
         Service['postfix']
       ];
   }
 
-  file {
-    '/etc/postfix/ocf/smtp-krb5.keytab':
+  if $::use_private_share {
+    file { '/etc/postfix/ocf/smtp-krb5.keytab':
       mode    => '0600',
       owner   => root,
       group   => root,
       source  => 'puppet:///private/smtp-krb5.keytab',
-      require => Package['postfix'];
+      require => Package['postfix'],
+      before  => Cron['update-cred-cache', 'update-cred-cache-reboot'],
+    }
+  }
 
+  file {
     '/etc/postfix/ldap-aliases.cf':
       mode    => '0644',
       source  => 'puppet:///modules/ocf_mail/site_ocf/postfix/ldap-aliases.cf',

--- a/modules/ocf_ocfweb/manifests/dev_config.pp
+++ b/modules/ocf_ocfweb/manifests/dev_config.pp
@@ -26,7 +26,8 @@ class ocf_ocfweb::dev_config($group = 'ocfstaff') {
     'octocatalog-diff':;
 
     # Newer puppetdb-termini versions (6.5.0-1stretch for instance) have an
-    # issue with CRLs
+    # issue with CRLs when used with octocatalog-diff, so pin this to 6.4.0 for
+    # now
     'puppetdb-termini':
       ensure => '6.4.0-1stretch';
   }

--- a/modules/ocf_ocfweb/manifests/dev_config.pp
+++ b/modules/ocf_ocfweb/manifests/dev_config.pp
@@ -29,12 +29,15 @@ class ocf_ocfweb::dev_config($group = 'ocfstaff') {
       group     => $group,
       mode      => '0640',
       show_diff => false;
+  }
 
-    '/etc/ocfweb/puppet-certs':
+  if $::use_private_share {
+    file { '/etc/ocfweb/puppet-certs':
       ensure    => 'directory',
       source    => 'puppet:///private-docker/ocfweb/puppet-certs',
       recurse   => true,
       purge     => true,
       show_diff => false;
+    }
   }
 }

--- a/modules/ocf_ocfweb/manifests/dev_config.pp
+++ b/modules/ocf_ocfweb/manifests/dev_config.pp
@@ -42,13 +42,10 @@ class ocf_ocfweb::dev_config($group = 'ocfstaff') {
       show_diff => false;
   }
 
-  if $::use_private_share {
-    file { '/etc/ocfweb/puppet-certs':
-      ensure    => 'directory',
-      source    => 'puppet:///private-docker/ocfweb/puppet-certs',
-      recurse   => true,
-      purge     => true,
-      show_diff => false;
-    }
+  ocf::privatefile { '/etc/ocfweb/puppet-certs':
+    ensure  => 'directory',
+    source  => 'puppet:///private-docker/ocfweb/puppet-certs',
+    recurse => true,
+    purge   => true;
   }
 }

--- a/modules/ocf_ocfweb/manifests/dev_config.pp
+++ b/modules/ocf_ocfweb/manifests/dev_config.pp
@@ -20,6 +20,17 @@ class ocf_ocfweb::dev_config($group = 'ocfstaff') {
   # ocf_admin along with this manifest (for supernova)
   ensure_packages(['libcrack2-dev'])
 
+  # Install some packages for generating puppet diffs
+  # TODO: Move this somewhere else alongside the puppet certs added below
+  package {
+    'octocatalog-diff':;
+
+    # Newer puppetdb-termini versions (6.5.0-1stretch for instance) have an
+    # issue with CRLs
+    'puppetdb-termini':
+      ensure => '6.4.0-1stretch';
+  }
+
   file {
     '/etc/ocfweb':
       ensure    => directory;

--- a/modules/ocf_puppet/files/ldap-enc
+++ b/modules/ocf_puppet/files/ldap-enc
@@ -40,17 +40,7 @@ def main():
     else:
         environment = 'production'
 
-    # The 'use_private_share' value is used for octocatalog-diff, which sets an
-    # enc override for this value to false. This means that nothing that
-    # touches the private share will be managed, since octocatalog-diff doesn't
-    # have access to the private share (and shouldn't have access to prevent
-    # leaking actual secrets)
-    output = {
-        'parameters': {
-            'use_private_share': True,
-        },
-        'environment': environment,
-    }
+    output = {'parameters': {}, 'environment': environment}
 
     for key, values in host.items():
         # Remove the value from its list only if it is a singular value

--- a/modules/ocf_puppet/files/ldap-enc
+++ b/modules/ocf_puppet/files/ldap-enc
@@ -40,7 +40,17 @@ def main():
     else:
         environment = 'production'
 
-    output = {'parameters': {}, 'environment': environment}
+    # The 'use_private_share' value is used for octocatalog-diff, which sets an
+    # enc override for this value to false. This means that nothing that
+    # touches the private share will be managed, since octocatalog-diff doesn't
+    # have access to the private share (and shouldn't have access to prevent
+    # leaking actual secrets)
+    output = {
+        'parameters': {
+            'use_private_share': True,
+        },
+        'environment': environment,
+    }
 
     for key, values in host.items():
         # Remove the value from its list only if it is a singular value

--- a/modules/ocf_www/manifests/lets_encrypt.pp
+++ b/modules/ocf_www/manifests/lets_encrypt.pp
@@ -6,12 +6,16 @@ class ocf_www::lets_encrypt {
       source  => 'puppet:///modules/ocf_www/lets-encrypt-update',
       mode    => '0755',
       require => File['/usr/local/bin/ocf-lets-encrypt'];
+  }
 
-    '/etc/ssl/lets-encrypt/le-vhost.key':
+  if $::use_private_share {
+    file { '/etc/ssl/lets-encrypt/le-vhost.key':
       source    => 'puppet:///private/lets-encrypt-vhost.key',
       owner     => ocfletsencrypt,
       show_diff => false,
-      mode      => '0400';
+      mode      => '0400',
+      before    => Cron['lets-encrypt-update'],
+    }
   }
 
   if $::host_env == 'prod' {
@@ -20,8 +24,7 @@ class ocf_www::lets_encrypt {
       user        => ocfletsencrypt,
       environment => ['MAILTO=root', 'PATH=/bin:/usr/bin:/usr/local/bin'],
       special     => hourly,
-      require     => File['/usr/local/bin/lets-encrypt-update',
-                          '/etc/ssl/lets-encrypt/le-vhost.key'],
+      require     => File['/usr/local/bin/lets-encrypt-update'],
     }
   }
 }

--- a/modules/ocf_www/manifests/lets_encrypt.pp
+++ b/modules/ocf_www/manifests/lets_encrypt.pp
@@ -12,7 +12,6 @@ class ocf_www::lets_encrypt {
     source => 'puppet:///private/lets-encrypt-vhost.key',
     owner  => ocfletsencrypt,
     mode   => '0400',
-    before => Cron['lets-encrypt-update'],
   }
 
   if $::host_env == 'prod' {
@@ -21,7 +20,8 @@ class ocf_www::lets_encrypt {
       user        => ocfletsencrypt,
       environment => ['MAILTO=root', 'PATH=/bin:/usr/bin:/usr/local/bin'],
       special     => hourly,
-      require     => File['/usr/local/bin/lets-encrypt-update'],
+      require     => [File['/usr/local/bin/lets-encrypt-update'],
+                      Ocf::Privatefile['/etc/ssl/lets-encrypt/le-vhost.key']],
     }
   }
 }

--- a/modules/ocf_www/manifests/lets_encrypt.pp
+++ b/modules/ocf_www/manifests/lets_encrypt.pp
@@ -8,14 +8,11 @@ class ocf_www::lets_encrypt {
       require => File['/usr/local/bin/ocf-lets-encrypt'];
   }
 
-  if $::use_private_share {
-    file { '/etc/ssl/lets-encrypt/le-vhost.key':
-      source    => 'puppet:///private/lets-encrypt-vhost.key',
-      owner     => ocfletsencrypt,
-      show_diff => false,
-      mode      => '0400',
-      before    => Cron['lets-encrypt-update'],
-    }
+  ocf::privatefile { '/etc/ssl/lets-encrypt/le-vhost.key':
+    source => 'puppet:///private/lets-encrypt-vhost.key',
+    owner  => ocfletsencrypt,
+    mode   => '0400',
+    before => Cron['lets-encrypt-update'],
   }
 
   if $::host_env == 'prod' {


### PR DESCRIPTION
This pull request adds [octocatalog-diff](https://github.com/github/octocatalog-diff) (forked at https://github.com/ocf/octocatalog-diff to add some patches for puppet 6.x) for creating a catalog on two different branches (one local, one pulled from a repo git repo) and calculating any differences between the two (or an error if the catalog doesn't even compile). This can be run by doing `make all_diffs` ([here's some sample output](https://i.fluffy.cc/NftRNPh8pl0tVdCQngPq5BbjXZr4N2bC.html), it fails for `singularity` currently because this branch isn't fully rebased), and my idea for it would be that it would run on any pull requests and maybe a version could run on master to just check if catalog compilation works or not.

Right now it's calculating against this branch (see https://github.com/jvperrin/puppet/blob/8c2a9dcf74b3307c0c6fc5d70f5fb01e5e5ee0d2/.octocatalog-diff.cfg.rb#L34-L36), but this should be switched to `origin/master` once this branch is merged.

This also introduces a new resource type, `ocf::privatefile`, that is essentially a wrapper around `file` that will set some parameters automatically (`show_diff` and `backup` set to `false` for instance) and works with `octocatalog-diff` to not use the actual secrets, since it does not have access to them.

There's also dummy secrets added in hiera to facilitate this, which is nice because it shows the structure of the secrets we have in a version-controlled way at least.

One thing I'd still like to do before merging is move [the stuff I added to this file](https://github.com/jvperrin/puppet/blob/8c2a9dcf74b3307c0c6fc5d70f5fb01e5e5ee0d2/modules/ocf_ocfweb/manifests/dev_config.pp#L23-L33) somewhere else, but I think in general this is ready to review, even without that change.

I've also spot-checked this on a few machines (my staff VM `fireball`, `dev-flood`, `supernova`), but to actually test it I need to replace the ENC used on `lightning` so that it returns the `use_private_share` parameter. Maybe that's a sign that I should flip the value the other way around so that by default it tries to use the secrets and otherwise doesn't? Anyway, another small thing I should probably change here.

~Probably also need to squash some commits, there's a bunch here that don't have great descriptions or have been rewritten/rebased.~