### PR TITLE
ocf_mirrors: Fix GNU upstream

### DIFF
--- a/modules/ocf_mirrors/files/project/gnu/sync-archive
+++ b/modules/ocf_mirrors/files/project/gnu/sync-archive
@@ -1,3 +1,3 @@
 #!/bin/sh -eu
 /usr/local/bin/rsync-no-vanished -rltpHS --delete-excluded \
-	rsync://mirror.keystealth.org/gnu/ /opt/mirrors/ftp/gnu
+	rsync://mirrors.tripadvisor.com/gnu/ /opt/mirrors/ftp/gnu


### PR DESCRIPTION
mirror.keystealth.org has a low connection_limit in their rsyncd.conf,
and deny all of our incoming connections. Temporarily switch upstreams
until GNU gets back to us with an official mirror.