### PR TITLE
make xfce4 panel span multiple monitors

### DIFF
--- a/modules/ocf_desktop/files/xsession/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+++ b/modules/ocf_desktop/files/xsession/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
@@ -29,6 +29,7 @@
         <value type="int" value="18"/>
       </property>
       <property name="autohide" type="bool" value="false"/>
+      <property name="span-monitors" type="bool" value="true"/>
     </property>
     <property name="panel-1" type="empty">
       <property name="position" type="string" value="p=8;x=96;y=1177"/>

--- a/modules/ocf_desktop/files/xsession/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+++ b/modules/ocf_desktop/files/xsession/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
@@ -40,6 +40,7 @@
       <property name="plugin-ids" type="array">
         <value type="int" value="3"/>
       </property>
+      <property name="span-monitors" type="bool" value="true"/>
     </property>
   </property>
   <property name="plugins" type="empty">


### PR DESCRIPTION
Currently, the xfce4 panel only stays on one monitor, which means it only displays on the left half on eruption with it's Picture By Picture mode. On other multi-monitor desktops, this is less important but still the panel isn't shown across both monitors. The default should be spanned in my opinion (and appealing to convention, is the default on macOS and Windows) and if users want old behavior they can toggle it in panel settings.

This PR sets the spanned option by default. Tested on cyclone.