### PR TITLE
Post octocatalog-diff results as pull request comments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('shared-ocf-pipeline@add-create-gist') _
+
 pipeline {
   agent {
     label 'slave'
@@ -49,13 +51,13 @@ pipeline {
             // https://issues.jenkins-ci.org/browse/JENKINS-44930), so the
             // output is saved to a file and then used soon after
             def status = sh returnStatus: true, script: 'make all_diffs > all_diffs_output.log'
-            // GitHub has a max comment length of 65536, so truncate and leave
-            // a warning about it at the top if necessary
+            // GitHub has a max comment length of 65536, so create a gist and
+            // link to that if necessary
             def output = readFile('all_diffs_output.log').trim()
             def charLimit = 65536
             if (output.length() > charLimit) {
-              def warning = "**WARNING: Output has been truncated due to comment limit, see Jenkins for full output**\n"
-              pullRequest.comment(warning + output.take(charLimit - warning.length()))
+              def url = createGist(output)
+              pullRequest.comment('**WARNING: Test output is too long for a GitHub comment, posted to a gist instead**: ' + url)
             } else {
               pullRequest.comment(output)
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,10 +50,10 @@ pipeline {
             // saved at the same time (thanks jenkins, see
             // https://issues.jenkins-ci.org/browse/JENKINS-44930), so the
             // output is saved to a file and then used soon after
-            def status = sh returnStatus: true, script: 'make all_diffs > all_diffs_output.log'
+            def status = sh returnStatus: true, script: './bin/octocatalog-diff > all_diffs_output.md'
             // GitHub has a max comment length of 65536, so create a gist and
             // link to that if necessary
-            def output = readFile('all_diffs_output.log').trim()
+            def output = readFile('all_diffs_output.md').trim()
             def charLimit = 65536
             if (output.length() > charLimit) {
               def url = createGist('octocatalog-diff-results.md', output)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
             def output = readFile('all_diffs_output.log').trim()
             def charLimit = 65536
             if (output.length() > charLimit) {
-              def url = createGist('octocatalog-diff-results.log', output)
+              def url = createGist('octocatalog-diff-results.md', output)
               pullRequest.comment('**WARNING: Test output is too long for a GitHub comment, posted to a gist instead**: ' + url)
             } else {
               pullRequest.comment(output)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
             def output = readFile('all_diffs_output.log').trim()
             def charLimit = 65536
             if (output.length() > charLimit) {
-              def url = createGist(output)
+              def url = createGist('octocatalog-diff-results.log', output)
               pullRequest.comment('**WARNING: Test output is too long for a GitHub comment, posted to a gist instead**: ' + url)
             } else {
               pullRequest.comment(output)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,8 +47,8 @@ pipeline {
             // Don't fail the whole build if octocatalog-diff fails, since it's new
             // and needs some fixing before it's relied on
             try {
-              //sh 'make all_diffs'
-              pullRequest.comment('Test comment from jenkins')
+              def output = sh returnStdout: true, script: 'make all_diffs'
+              pullRequest.comment(output)
             } catch (err) {
               echo 'make all_diffs failed, but it is being ignored for now'
               mail to: 'jvperrin@ocf.berkeley.edu',

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ vendor: Puppetfile
 
 .PHONY: all_diffs
 all_diffs:
-	@./bin/octocatalog-diff
+	./bin/octocatalog-diff

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ vendor: Puppetfile
 
 .PHONY: all_diffs
 all_diffs:
-	./bin/octocatalog-diff
+	@./bin/octocatalog-diff

--- a/bin/octocatalog-diff
+++ b/bin/octocatalog-diff
@@ -120,7 +120,7 @@ def diff(host):
         # This means the puppet run has failed in some way (a return code of 1
         # is pretty usual for that), so we return an error code and the output
         # to post in the review
-        return (host, 1, GITHUB_COLLAPSE_CODE.format('**error** for {}'.format(host), 'text', stderr))
+        return (host, 1, GITHUB_COLLAPSE_CODE.format('error for {}'.format(host), 'text', stderr))
 
 
 def process_output(empty_diffs, diffs, errors, return_code, output):

--- a/bin/octocatalog-diff
+++ b/bin/octocatalog-diff
@@ -138,10 +138,10 @@ def process_output(empty_diffs, diffs, errors, return_code, output):
     return empty_diffs, diffs, errors, return_code
 
 
-def report_output(title, count, contents):
+def collapsible_report(title, contents):
     print(
         GITHUB_COLLAPSE_CONTAINER.format(
-            '{} ({})'.format(title, count),
+            title,
             contents,
         ),
     )
@@ -178,14 +178,20 @@ def all_diffs():
             empty_diffs, diffs, errors, return_code, output,
         )
 
+    # Gather and print the number of hosts in each category as a summary
+    num_changed = sum([len(hosts) for hosts in diffs.values()])
+    print('#### Errored hosts ({})'.format(len(errors)))
+    print('#### Changed hosts ({})'.format(num_changed))
+    print('#### Unaffected hosts ({})'.format(len(empty_diffs)))
+    print('<hr>')
+
     # Report any hosts that had errors (catalog compilation failed)
     if errors:
-        report_output('Errored hosts', len(errors), '\n'.join(errors))
+        collapsible_report('Errored hosts', '\n'.join(errors))
 
     # For any diffs, print them grouped by diff so it's not too verbose and
     # it's easier to see which hosts are affected
     if diffs:
-        num_hosts = sum([len(hosts) for hosts in diffs.values()])
         text = []
         for diff_text, hosts in diffs.items():
             text.append(
@@ -196,14 +202,13 @@ def all_diffs():
                 ),
             )
 
-        report_output('Changed hosts', num_hosts, '\n'.join(text))
+        collapsible_report('Changed hosts', '\n'.join(text))
 
     # Unaffected hosts just have their hostnames printed, but there's nothing
     # else to really show about them since nothing of note happened
     if empty_diffs:
-        report_output(
+        collapsible_report(
             'Unaffected hosts',
-            len(empty_diffs),
             '```\n{}\n```'.format('\n'.join(empty_diffs)),
         )
 

--- a/bin/octocatalog-diff
+++ b/bin/octocatalog-diff
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -u
+#!/usr/bin/python3
 # Note that this does not use the /usr/bin/env python3 shebang because it wants
 # to use the system-installed requests and ocflib which are not in the puppet
 # python virtualenv
@@ -133,16 +133,16 @@ def process_output(empty_diffs, diffs, errors, return_code, output):
         output_without_host = cmd_output.split('\n', 1)[1]
         diffs[output_without_host] = diffs.get(output_without_host, []) + [host]
     else:
-        empty_diffs.append('`{}`\n'.format(host))
+        empty_diffs.append(host)
 
     return empty_diffs, diffs, errors, return_code
 
 
-def report_output(title, count, items):
+def report_output(title, count, contents):
     print(
         GITHUB_COLLAPSE_CONTAINER.format(
             '{} ({})'.format(title, count),
-            '\n'.join(items),
+            contents,
         ),
     )
 
@@ -180,7 +180,7 @@ def all_diffs():
 
     # Report any hosts that had errors (catalog compilation failed)
     if errors:
-        report_output('Errored hosts', len(errors), errors)
+        report_output('Errored hosts', len(errors), '\n'.join(errors))
 
     # For any diffs, print them grouped by diff so it's not too verbose and
     # it's easier to see which hosts are affected
@@ -196,12 +196,16 @@ def all_diffs():
                 ),
             )
 
-        report_output('Changed hosts', num_hosts, text)
+        report_output('Changed hosts', num_hosts, '\n'.join(text))
 
     # Unaffected hosts just have their hostnames printed, but there's nothing
     # else to really show about them since nothing of note happened
     if empty_diffs:
-        report_output('Unaffected hosts', len(empty_diffs), empty_diffs)
+        report_output(
+            'Unaffected hosts',
+            len(empty_diffs),
+            '```\n{}\n```'.format('\n'.join(empty_diffs)),
+        )
 
     return return_code
 

--- a/bin/octocatalog-diff
+++ b/bin/octocatalog-diff
@@ -64,6 +64,9 @@ def diff(host):
             '-n', host,
             '--enc-override',
             'environment=production,parameters::dummy_secrets=true',
+            # Unfortunately color codes are not handled well by github, so we
+            # turn those off here
+            '--no-color',
             '--display-detail-add',
             # Ignore changes to puppetserver settings, since these are
             # dependent on the path that octocatalog-diff sets and thus always
@@ -84,7 +87,7 @@ def diff(host):
     diff_or_error = process.stdout.decode('utf-8').rstrip()
     if process.returncode == 0:
         # This is a clean run, puppet did not error and there was no diff
-        return (0, '{}: no change'.format(host))
+        return (0, None)
     elif process.returncode == 2:
         # This means the puppet run has found some diff from master, so we
         # return this and report it back in the review but do not fail the run
@@ -121,7 +124,8 @@ def all_diffs():
     returncode = 0
     for output in run_output:
         returncode = max(returncode, output[0])
-        print(output[1])
+        if output[1]:
+            print(output[1])
 
     return returncode
 

--- a/bin/octocatalog-diff
+++ b/bin/octocatalog-diff
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python3 -u
 # Note that this does not use the /usr/bin/env python3 shebang because it wants
 # to use the system-installed requests and ocflib which are not in the puppet
 # python virtualenv
@@ -15,6 +15,15 @@ CACHE_DIR_NAME = '.octocatalog-diff-cache'
 PUPPETDB_NODES_URL = 'https://puppetdb:8081/pdb/query/v4/nodes'
 # TODO: Change this to not piggyback off the ocfweb certs
 PUPPET_CERT_DIR = '/etc/ocfweb/puppet-certs'
+
+GITHUB_COLLAPSE_MARKDOWN = '''
+<details>
+  <summary>{}</summary>
+
+```diff
+{}
+```
+</details>'''
 
 
 def setup_cache():
@@ -72,21 +81,19 @@ def diff(host):
         stdout=subprocess.PIPE,
     )
 
+    diff_or_error = process.stdout.decode('utf-8').rstrip()
     if process.returncode == 0:
         # This is a clean run, puppet did not error and there was no diff
-        print('run for {}: clean'.format(host))
-        return 0
+        return (0, '{}: no change'.format(host))
     elif process.returncode == 2:
         # This means the puppet run has found some diff from master, so we
-        # should keep this and report it back in the review
-        print(process.stdout.decode('utf-8').rstrip())
-        return 0
+        # return this and report it back in the review but do not fail the run
+        return (0, GITHUB_COLLAPSE_MARKDOWN.format('diff for {}'.format(host), diff_or_error))
     else:
         # This means the puppet run has failed in some way (a return code of 1
-        # is pretty usualfor that), so the whole command should error out
-        print('run for {} errored:'.format(host))
-        print(process.stderr.decode('utf-8').rstrip())
-        return 1
+        # is pretty usual for that), so we return an error code and the output
+        # to post in the review
+        return (1, GITHUB_COLLAPSE_MARKDOWN.format('**error** for {}'.format(host), diff_or_error))
 
 
 def all_diffs():
@@ -95,16 +102,27 @@ def all_diffs():
     TODO: Make this faster by just selecting a single node from each class we
     care about (not selecting all desktops/hozers for example)
     """
-    print('Setting up cache...')
+    print('Setting up cache...', file=sys.stderr)
     setup_cache()
-    print('Getting hosts from puppetdb...')
+
+    print('Getting hosts from puppetdb...', file=sys.stderr)
     hosts = get_hosts_from_puppetdb()
+
     # Get number of cores to parallelize across and create a worker pool of that size
     pool = Pool(os.cpu_count())
 
-    print('Running octocatalog-diff across all hosts...')
-    # Find any status codes that are non-zero (errors encountered in puppet runs)
-    returncode = max([ret for ret in pool.imap(diff, hosts)])
+    print('Running octocatalog-diff across all hosts...', file=sys.stderr)
+    run_output = pool.imap(diff, hosts)
+
+    # Print out information to be posted in a comment on the review
+    #
+    # Also find any status codes that are non-zero (errors encountered in
+    # puppet runs), and use that as the return code to report
+    returncode = 0
+    for output in run_output:
+        returncode = max(returncode, output[0])
+        print(output[1])
+
     return returncode
 
 

--- a/bin/octocatalog-diff
+++ b/bin/octocatalog-diff
@@ -16,14 +16,25 @@ PUPPETDB_NODES_URL = 'https://puppetdb:8081/pdb/query/v4/nodes'
 # TODO: Change this to not piggyback off the ocfweb certs
 PUPPET_CERT_DIR = '/etc/ocfweb/puppet-certs'
 
-GITHUB_COLLAPSE_MARKDOWN = '''
+GITHUB_COLLAPSE_CODE = '''
 <details>
   <summary>{}</summary>
 
-```diff
+```{}
 {}
 ```
 </details>'''
+
+GITHUB_COLLAPSE_CONTAINER = '''
+<details>
+  <summary>{}</summary>
+
+{}
+</details>'''
+
+
+def info(output):
+    print(output, file=sys.stderr)
 
 
 def setup_cache():
@@ -56,47 +67,84 @@ def get_hosts_from_puppetdb():
 
 
 def diff(host):
-    """Run octocatalog-diff for a particular hostname"""
+    """Run octocatalog-diff for a particular hostname, and return whether the
+    run succeeded or failed and any output"""
     process = subprocess.run(
-        (
-            'octocatalog-diff',
-            # Add a --debug flag to get much more verbose output
-            '-n', host,
-            '--enc-override',
-            'environment=production,parameters::dummy_secrets=true',
-            # Unfortunately color codes are not handled well by github, so we
-            # turn those off here
-            '--no-color',
-            '--display-detail-add',
-            # Ignore changes to puppetserver settings, since these are
-            # dependent on the path that octocatalog-diff sets and thus always
-            # differ
-            '--ignore', "'Ini_setting[puppet.conf/master/storeconfigs]'",
-            '--ignore', "'Ini_setting[puppet.conf/master/storeconfigs_backend]'",
-            '--ignore', "'Ini_setting[puppetdbserver_urls]'",
-            '--ignore', "'Ini_setting[soft_write_failure]'",
-            '--ignore', "'File[/tmp/*/routes.yaml]'",
-            # Ignore changes to SSH keys, since these change when any machines
-            # are reprovisioned, etc. and change frequently
-            '--ignore', "'Sshkey[*]'",
+        ' '.join(
+            (
+                'octocatalog-diff',
+                # Add a --debug flag to get much more verbose output
+                '-n', host,
+                '--enc-override',
+                'environment=production,parameters::dummy_secrets=true',
+                # Unfortunately color codes are not handled well by github, so
+                # we turn those off here
+                '--no-color',
+                '--display-detail-add',
+                # Ignore changes to puppetserver settings, since these are
+                # dependent on the path that octocatalog-diff sets and thus
+                # always differ
+                "--ignore 'Ini_setting[puppet.conf/master/storeconfigs]'",
+                "--ignore 'Ini_setting[puppet.conf/master/storeconfigs_backend]'",
+                "--ignore 'Ini_setting[puppetdbserver_urls]'",
+                "--ignore 'Ini_setting[soft_write_failure]'",
+                "--ignore 'File[/tmp/*/routes.yaml]'",
+                # Ignore changes to SSH keys, since these change when any
+                # machines are reprovisioned, etc. and change frequently
+                "--ignore 'Sshkey[*]'",
+            ),
         ),
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
+        # We need shell=True here for the diffs to calculate correctly on the
+        # puppetmaster, otherwise the ignore settings above do not take effect.
+        # This should be safe enough as we aren't accepting user-defined input
+        shell=True,
     )
 
-    diff_or_error = process.stdout.decode('utf-8').rstrip()
+    stdout = process.stdout.decode('utf-8').rstrip()
+    stderr = process.stderr.decode('utf-8').rstrip()
+    info('stdout for {}'.format(host))
+    info(stdout)
+    info('stderr for {}'.format(host))
+    info(stderr)
+
     if process.returncode == 0:
         # This is a clean run, puppet did not error and there was no diff
-        return (0, None)
+        return (host, 0, None)
     elif process.returncode == 2:
         # This means the puppet run has found some diff from master, so we
         # return this and report it back in the review but do not fail the run
-        return (0, GITHUB_COLLAPSE_MARKDOWN.format('diff for {}'.format(host), diff_or_error))
+        return (host, 0, stdout)
     else:
         # This means the puppet run has failed in some way (a return code of 1
         # is pretty usual for that), so we return an error code and the output
         # to post in the review
-        return (1, GITHUB_COLLAPSE_MARKDOWN.format('**error** for {}'.format(host), diff_or_error))
+        return (host, 1, GITHUB_COLLAPSE_CODE.format('**error** for {}'.format(host), 'text', stderr))
+
+
+def process_output(empty_diffs, diffs, errors, return_code, output):
+    host, status, cmd_output = output
+    return_code = max(return_code, status)
+
+    if status and cmd_output:
+        errors.append(cmd_output)
+    elif cmd_output:
+        output_without_host = cmd_output.split('\n', 1)[1]
+        diffs[output_without_host] = diffs.get(output_without_host, []) + [host]
+    else:
+        empty_diffs.append('`{}`\n'.format(host))
+
+    return empty_diffs, diffs, errors, return_code
+
+
+def report_output(title, count, items):
+    print(
+        GITHUB_COLLAPSE_CONTAINER.format(
+            '{} ({})'.format(title, count),
+            '\n'.join(items),
+        ),
+    )
 
 
 def all_diffs():
@@ -105,29 +153,57 @@ def all_diffs():
     TODO: Make this faster by just selecting a single node from each class we
     care about (not selecting all desktops/hozers for example)
     """
-    print('Setting up cache...', file=sys.stderr)
+    info('Setting up cache...')
     setup_cache()
 
-    print('Getting hosts from puppetdb...', file=sys.stderr)
+    info('Getting hosts from puppetdb...')
     hosts = get_hosts_from_puppetdb()
 
     # Get number of cores to parallelize across and create a worker pool of that size
     pool = Pool(os.cpu_count())
 
-    print('Running octocatalog-diff across all hosts...', file=sys.stderr)
+    info('Running octocatalog-diff across all hosts...')
     run_output = pool.imap(diff, hosts)
 
     # Print out information to be posted in a comment on the review
     #
     # Also find any status codes that are non-zero (errors encountered in
     # puppet runs), and use that as the return code to report
-    returncode = 0
+    empty_diffs = []
+    diffs = {}
+    errors = []
+    return_code = 0
     for output in run_output:
-        returncode = max(returncode, output[0])
-        if output[1]:
-            print(output[1])
+        empty_diffs, diffs, errors, return_code = process_output(
+            empty_diffs, diffs, errors, return_code, output,
+        )
 
-    return returncode
+    # Report any hosts that had errors (catalog compilation failed)
+    if errors:
+        report_output('Errored hosts', len(errors), errors)
+
+    # For any diffs, print them grouped by diff so it's not too verbose and
+    # it's easier to see which hosts are affected
+    if diffs:
+        num_hosts = sum([len(hosts) for hosts in diffs.values()])
+        text = []
+        for diff_text, hosts in diffs.items():
+            text.append(
+                GITHUB_COLLAPSE_CODE.format(
+                    'diff for {}'.format(', '.join(sorted(hosts))),
+                    'diff',
+                    diff_text,
+                ),
+            )
+
+        report_output('Changed hosts', num_hosts, text)
+
+    # Unaffected hosts just have their hostnames printed, but there's nothing
+    # else to really show about them since nothing of note happened
+    if empty_diffs:
+        report_output('Unaffected hosts', len(empty_diffs), empty_diffs)
+
+    return return_code
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This sets octocatalog-diff to run on pull requests and post the results as comments back to the review about what hosts are unaffected, which have diffs, and which errored in the catalog compilation stage. It also groups diffs that are the same together so that it's less verbose than listing every host in the output, but doesn't do the same with errors (after all, they should all be fixed anyway before proceeding). A few examples are shown below in this review