### PR TITLE
fixed tab-autocomplete with username

### DIFF
--- a/modules/ocf/files/shell/bash.bashrc
+++ b/modules/ocf/files/shell/bash.bashrc
@@ -18,6 +18,11 @@ mesg n
 # Set up bash-completion
 [ -r /etc/bash_completion ] && source /etc/bash_completion
 
+# reset _usergroup() to prevent autocomplete lag
+_usergroup() {
+    return
+}
+
 # No duplicate lines in shell history
 HISTCONTROL=ignoreboth
 HISTTIMEFORMAT="%F %T "

--- a/modules/ocf/files/shell/zshrc
+++ b/modules/ocf/files/shell/zshrc
@@ -56,6 +56,11 @@ autoload -U compinit promptinit
 compinit
 promptinit
 
+# reset _users to null to prevent autocomplete lag
+unset _users
+_users () {}
+compdef _users
+
 if [[ $EUID -ne 0 ]]; then
 	PROMPT_COLOR=green
 	PROMPT_SYMBOL="$"


### PR DESCRIPTION
prevents bash/zsh to load up 60k+ user entries when doing tab-autocomplete