### PR TITLE
Fix paper-genmon in Debian 10

### DIFF
--- a/modules/ocf_desktop/files/skel/config/xfce4/panel/genmon-4.rc
+++ b/modules/ocf_desktop/files/skel/config/xfce4/panel/genmon-4.rc
@@ -2,4 +2,4 @@ Command=/usr/local/bin/paper-genmon
 UseLabel=0
 Text=(genmon)
 UpdatePeriod=60000
-Font=(default)
+Font=Sans 10

--- a/modules/ocf_desktop/files/xsession/paper-genmon
+++ b/modules/ocf_desktop/files/xsession/paper-genmon
@@ -25,7 +25,7 @@ def main(argv=None):
 
     print('<img>{}</img>'.format(IMAGE_PATH))
 
-    PANEL_TEXT = '<txt> {} {} left today | {} {} left this semester </txt>'
+    PANEL_TEXT = '<txt><span fgcolor="#bac3cf"> {} {} left today | {} {} left this semester </span></txt>'
     print(PANEL_TEXT.format(daily_quota, 'page' if daily_quota == 1 else 'pages',
                             semester_quota, 'page' if semester_quota == 1 else 'pages'
                             ))


### PR DESCRIPTION
On Debian 10 devices the generic monitor on the top xfce panel that displays the user's printer quota currently fails to display.
This appears to be because setting the panel item's font to `(default)` is no longer supported. Setting a specific font (`Sans 10`) fixes this.