### PR TITLE
Restore indicator panel on Debian 10 lock screen

### DIFF
--- a/modules/ocf_desktop/files/xsession/lightdm/lightdm-gtk-greeter.conf
+++ b/modules/ocf_desktop/files/xsession/lightdm/lightdm-gtk-greeter.conf
@@ -5,6 +5,6 @@ theme-name=Arc
 xft-antialias=true
 xft-hintstyle=hintslight
 xft-rgba=rgb
-show-indicators=~session;~power
+indicators=~host;~spacer;~clock;~spacer;~session;~language;~a11y;~power
 show-clock=true
 #clock-format=


### PR DESCRIPTION
Debian 10 breaks the indicator bar on the greeter/lock screen, this should fix that. This works on Debian 10, but I have not tested it on Debian 9. 