### PR TITLE
Store ED25519 SSH host keys in Puppet

### DIFF
--- a/modules/ocf/manifests/hostkeys.pp
+++ b/modules/ocf/manifests/hostkeys.pp
@@ -18,5 +18,11 @@ class ocf::hostkeys {
     '/etc/ssh/ssh_host_ecdsa_key.pub':
       mode   => '0644',
       source => 'puppet:///private/hostkeys/ssh_host_ecdsa_key.pub';
+    '/etc/ssh/ssh_host_ed25519_key':
+      mode   => '0600',
+      source => 'puppet:///private/hostkeys/ssh_host_ed25519_key';
+    '/etc/ssh/ssh_host_ed25519_key.pub':
+      mode   => '0644',
+      source => 'puppet:///private/hostkeys/ssh_host_ed25519_key.pub';
   }
 }


### PR DESCRIPTION
Right now, ED25519 keys are generated when sshd is installed, but they are not stored in Puppet, so when the host is rebuilt, the ED25519 keys might change, causing host verification failed warnings for clients which chose to use that key.
Store the keys in Puppet to prevent these kinds of problems.