### PR TITLE
add current Google mailing lists/aliases to postfix aliases

### DIFF
--- a/modules/ocf_mail/files/site_ocf/aliases
+++ b/modules/ocf_mail/files/site_ocf/aliases
@@ -19,21 +19,46 @@ nomail: /var/mail/nomail/nomail
 
 # bureaucracy
 officers: officers@g.ocf.berkeley.edu
-alums: alums@g.ocf.berkeley.edu
-decal: decal@g.ocf.berkeley.edu
-opstaff: opstaff@g.ocf.berkeley.edu
+
+manager: officers
+managers: manager
 
 gm: officers
 general-manager: gm
+general-managers: gm
 owner-gm: officers
 
 sm: officers
 site-manager: sm
+site-managers: sm
 owner-sm: officers
 
 staff: staff-current
 wheel: staff-current
 owner-staff: root
+
+decal: decal@g.ocf.berkeley.edu
+
+# decal announcement lists
+decal-announce: decal-announce@g.ocf.berkeley.edu
+decal-beginner-announce: decal-beginner-announce@g.ocf.berkeley.edu
+decal-announce-beginner: decal-beginner-announce
+decal-basic-announce: decal-beginner-announce
+decal-advanced-announce: decal-advanced-announce@g.ocf.berkeley.edu
+decal-announce-advanced: decal-advanced-announce
+
+alums: alums@g.ocf.berkeley.edu
+alumnus: alums
+
+opstaff: opstaff@g.ocf.berkeley.edu
+
+extcomm: extcomm@g.ocf.berkeley.edu
+mirrors: extcomm
+sks: extcomm
+
+abuse: abuse@g.ocf.berkeley.edu
+
+joinstaff: joinstaff@g.ocf.berkeley.edu
 
 # request tracker
 bod: "|/usr/bin/rt-mailgate --queue 'bod' --action correspond --url https://rt.ocf.berkeley.edu"


### PR DESCRIPTION
This brings the current mailing lists and aliases on Google's side into sync with `/etc/aliases`. See #780. I didn't make one for alumnidinner-sp19@ since that seems like a one-off. Also, I deleted the alumni@ alias from Google since that was concealing an actual user, and I didn't include dca-admin@ because I don't think it's relevant now that we're using letsencrypt.