### PR TITLE
Update python3-ldap3 with forced newer version

### DIFF
--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -147,6 +147,9 @@ class ocf::packages {
     backport_on => ['stretch'],
   }
 
+  ocf::repackage { 'python3-ldap3':
+    backport_on => ['stretch'],
+  }
 
   # Packages to only install on Debian (not on Raspbian for example)
   if $::lsbdistid == 'Debian' {


### PR DESCRIPTION
This is to resolve https://github.com/ocf/utils/issues/128 once, but probably not for all for sure; didn't test if version can be correctly fetched but hopefully