### PR TITLE
add genfile resource definition

### DIFF
--- a/modules/ocf/manifests/exec_and_cron.pp
+++ b/modules/ocf/manifests/exec_and_cron.pp
@@ -1,0 +1,14 @@
+define ocf::exec_and_cron(
+    $command,
+    $creates,
+    $cron_options = {},
+) {
+  exec { "${title}-initial":
+    command => $command,
+    creates => $creates,
+  } ->
+  cron { $title:
+    command => $command,
+    *       => $cron_options;
+  }
+}

--- a/modules/ocf_munin/manifests/init.pp
+++ b/modules/ocf_munin/manifests/init.pp
@@ -33,12 +33,15 @@ class ocf_munin {
 
   # Generate munin nodes on the 3rd minute of every hour to avoid conflicting
   # with periodic Munin checks every 5 minutes (rt#4712)
-  cron { 'gen-munin-nodes':
-    command => '/usr/local/bin/gen-munin-nodes > /etc/munin/munin-conf.d/nodes',
-    user    => 'root',
-    minute  => '03',
-    notify  => Service['munin'],
-    require => File['/usr/local/bin/gen-munin-nodes'];
+  ocf::exec_and_cron { 'gen-munin-nodes':
+    command      => '/usr/local/bin/gen-munin-nodes > /etc/munin/munin-conf.d/nodes',
+    creates      => '/etc/munin/munin-conf.d/nodes',
+    cron_options =>  {
+      user    => 'root',
+      minute  => '03',
+      notify  => Service['munin'],
+      require => File['/usr/local/bin/gen-munin-nodes'],
+    },
   }
 
   include apache::mod::fcgid

--- a/modules/ocf_printhost/manifests/monitor.pp
+++ b/modules/ocf_printhost/manifests/monitor.pp
@@ -6,13 +6,10 @@ class ocf_printhost::monitor {
       source => 'puppet:///modules/ocf_printhost/monitor-cups',
       mode   => '0755';
   } ->
-  exec { 'monitor-cups-initial':
+  ocf::exec_and_cron { 'monitor-cups':
     command => '/usr/local/bin/monitor-cups /srv/prometheus/cups.prom',
     creates => '/srv/prometheus/cups.prom',
     require => File['/srv/prometheus'],
-  } ->
-  cron { 'monitor-cups':
-    command => '/usr/local/bin/monitor-cups /srv/prometheus/cups.prom',
     # Run every minute
   }
 }

--- a/modules/ocf_prometheus/manifests/server.pp
+++ b/modules/ocf_prometheus/manifests/server.pp
@@ -7,13 +7,10 @@ class ocf_prometheus::server {
       source => 'puppet:///modules/ocf_prometheus/gen-prometheus-nodes',
       mode   => '0755';
   } ->
-  exec { 'gen-promethues-nodes-initial':
-    command => '/usr/local/bin/gen-prometheus-nodes /var/local/prometheus-nodes.json',
-    creates => '/var/local/prometheus-nodes.json',
-  } ->
-  cron { 'gen-prometheus-nodes':
-    command => '/usr/local/bin/gen-prometheus-nodes /var/local/prometheus-nodes.json',
-    minute  => '0',
+  ocf::exec_and_cron { 'gen-prometheus-nodes':
+    command      => '/usr/local/bin/gen-prometheus-nodes /var/local/prometheus-nodes.json',
+    creates      => '/var/local/prometheus-nodes.json',
+    cron_options => { minute=>'0'},
   }
 
   file {
@@ -21,13 +18,10 @@ class ocf_prometheus::server {
       source => 'puppet:///modules/ocf_prometheus/gen-prometheus-printers',
       mode   => '0755';
   } ->
-  exec { 'gen-prometheus-printers-initial':
-    command => '/usr/local/bin/gen-prometheus-printers /var/local/prometheus-printers.json',
-    creates => '/var/local/prometheus-printers.json',
-  } ->
-  cron { 'gen-prometheus-printers':
-    command => '/usr/local/bin/gen-prometheus-printers /var/local/prometheus-printers.json',
-    minute  => '0',
+  ocf::exec_and_cron { 'gen-prometheus-printers':
+    command      => '/usr/local/bin/gen-prometheus-printers /var/local/prometheus-printers.json',
+    creates      => '/var/local/prometheus-printers.json',
+    cron_options => { minute=>'0'},
   }
 
   file {


### PR DESCRIPTION
`ocf::genfile` codifies a somewhat common in the codebase where we run a command to generate a file and thereafter add a cron rule to continuously run this command. This commit adds ocf::genfile and uses it in the necessary manifests.

I promised to do this a year ago in https://github.com/ocf/puppet/pull/386#discussion_r225031819 and am finally following through on the promise. Happy Hacktoberfest :P

This is tested to work everywhere it's used, it's essentially a no-op for the actual resource tree.