### PR TITLE
Fix example used in check-pass-strength

### DIFF
--- a/modules/ocf_kerberos/files/check-pass-strength
+++ b/modules/ocf_kerberos/files/check-pass-strength
@@ -9,7 +9,7 @@ Details on interface Heimdal uses:
 http://www.h5l.org/manual/HEAD/info/heimdal/Password-changing.html
 
 Example usage:
-$ echo -n "principal: ckuehl@OCF.BERKELEY.EDU\nnew-password: hello" | ./check-pass-strength
+$ echo -e "principal: ckuehl@OCF.BERKELEY.EDU\nnew-password: hello" | ./check-pass-strength
 """
 import sys
 


### PR DESCRIPTION
Trying it with `-n` as shown gives this output:
```bash
jvperrin@firestorm:/etc/heimdal-kdc$ echo -n "principal: ckuehl@OCF.BERKELEY.EDU\nnew-password: hello" | ./check-pass-strength
Traceback (most recent call last):
  File "./check-pass-strength", line 28, in <module>
    assert len(line) == 2, 'Could not parse input: ' + str(line)
AssertionError: Could not parse input: ['principal', ' ckuehl@OCF.BERKELEY.EDU\\nnew-password', ' hello']
```

Compared to trying with `-e`:
```bash
jvperrin@firestorm:/etc/heimdal-kdc$ echo -e "principal: ckuehl@OCF.BERKELEY.EDU\nnew-password: hello" | ./check-pass-strength
Password must be at least 8 characters.
```