### PR TITLE
Added New Redis Printer Channel & Changed Print Notification Channel

### DIFF
--- a/modules/ocf_desktop/files/xsession/print-notify-handler
+++ b/modules/ocf_desktop/files/xsession/print-notify-handler
@@ -50,7 +50,7 @@ def main():
     p = poll()
     p.register(sys.stdout.fileno(), POLLERR | POLLHUP)
 
-    s = subscribe(host, password, username)
+    s = subscribe(host, password, 'user-' + username)
     while True:
         message = s.get_message()
         if message and 'data' in message:

--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -180,7 +180,7 @@ def prehook(c, r, job):
             msg = NOTIFY_PROBLEMATIC_FILE_SOURCE.format(
                 file_source=file_source,
             )
-            r.publish(job.user, msg)
+            r.publish('user-' + job.user, msg)
             sys.exit(255)
 
     if job.pages > quo.daily:
@@ -189,7 +189,7 @@ def prehook(c, r, job):
             pages=job.pages,
             quota=quo.daily,
         )
-        r.publish(job.user, msg)
+        r.publish('user-' + job.user, msg)
         sys.exit(255)
 
 
@@ -205,7 +205,7 @@ def posthook(c, r, job, success):
         quo = quota.get_quota(c, job.user)
         msg = NOTIFY_JOB_ERROR.format(document=job.doc_name)
         send_printer_mail(PRINTER_ERROR_MESSAGE, job, quo)
-    r.publish(job.user, msg)
+    r.publish('user-' + job.user, msg)
 
 
 def main(argv):

--- a/modules/ocf_printhost/files/enforcer
+++ b/modules/ocf_printhost/files/enforcer
@@ -197,10 +197,12 @@ def posthook(c, r, job, success):
     msg = ''
     if success:
         quota.add_job(c, job)
+        printer_name = job.printer.split('-')[0]
         msg = NOTIFY_JOB_ACCEPTED.format(
             document=job.doc_name,
-            printer=job.printer.split('-')[0],
+            printer=printer_name,
         )
+        r.publish('printer-' + printer_name, job.user)
     else:
         quo = quota.get_quota(c, job.user)
         msg = NOTIFY_JOB_ERROR.format(document=job.doc_name)


### PR DESCRIPTION
I added a new channel to redis for each of the printers. Each printer channel would contain a list of users who used that printer. This would allow me to subscribe to these channels from a raspberry pi which would be connected to a monitor. The monitor would be placed above the printer area of OCF and would allow members to see which printer printed their job. I also changed the current job.user channel to prevent conflicts between the printer name and user name.