### PR TITLE
Change manjaro mirror upstream to official rsync upstream in UK.

### DIFF
--- a/modules/ocf_mirrors/files/project/manjaro/sync-archive
+++ b/modules/ocf_mirrors/files/project/manjaro/sync-archive
@@ -1,3 +1,3 @@
 #!/bin/sh -eu
 /usr/local/bin/rsync-no-vanished -rtlH --delete-after --delay-updates --safe-links \
-	rsync://manjaro.mirrors.uk2.net/manjaro/ /opt/mirrors/ftp/manjaro
+	rsync://mirrorservice.org/repo.manjaro.org/repos/ /opt/mirrors/ftp/manjaro


### PR DESCRIPTION
The old upstream was failing sync and we were like 2 weeks out of date.

Tested.