### PR TITLE
kubectl in style with new and innovative COOPERCTL

### DIFF
--- a/modules/ocf/files/shell/bash.bashrc
+++ b/modules/ocf/files/shell/bash.bashrc
@@ -38,6 +38,7 @@ shopt -s checkwinsize
 alias ls='ls -Fh'
 alias quota='/usr/bin/quota -Qs'
 alias rm='rm -I'
+alias cooperctl='kubectl'
 
 # Color terminal
 if [ "$TERM" != dumb ]; then

--- a/modules/ocf/files/shell/config.fish
+++ b/modules/ocf/files/shell/config.fish
@@ -36,6 +36,7 @@ alias quota "quota -Qs"
 alias rm "rm -I"
 alias leetfish "set -gx FISH swim"
 alias noobfish "set -gx FISH noob"
+alias cooperctl "kubectl"
 
 # Logout
 function on_exit --on-process %self

--- a/modules/ocf/files/shell/csh.cshrc
+++ b/modules/ocf/files/shell/csh.cshrc
@@ -16,6 +16,7 @@ mesg n
 alias ls ls -F
 alias quota quota -Qs
 alias rm rm -I
+alias cooperctl kubectl
 
 set prompt = "%m[%c]"
 

--- a/modules/ocf/files/shell/zshrc
+++ b/modules/ocf/files/shell/zshrc
@@ -76,3 +76,4 @@ mesg n
 
 alias ls="ls --color"
 alias grep="grep --color"
+alias cooperctl="kubectl"


### PR DESCRIPTION
Tired of typing kube? Tired of thinking about cooperc and then needing to quickly delete it before he notices you? Well fret not with cooperctl, you can type cooperc and pretend to be working! Cooperctl comes with a total of 2 extra characters for no extra charge.