### PR TITLE
Irc sasl

### DIFF
--- a/modules/ocf_irc/files/anope.service
+++ b/modules/ocf_irc/files/anope.service
@@ -6,10 +6,9 @@ After=network-online.target inspircd.service
 User=irc
 Group=irc
 Restart=always
-# Run ExecStartPre with root permissions to be able to create pid directory
-PermissionsStartOnly=true
-ExecStartPre=/usr/bin/install -o irc -g irc -d /var/run/anope
-# Run anope with regular permissions (irc:irc)
+RuntimeDirectory=anope
+PIDFile=/run/anope/anope.pid
+ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/sbin/anope --debug --nofork --confdir=/etc/anope --dbdir=/var/lib/anope/db --logdir=/var/log/anope --modulesdir=/usr/lib/anope --localedir=/usr/share/anope/locale
 
 [Install]

--- a/modules/ocf_irc/templates/inspircd.conf.erb
+++ b/modules/ocf_irc/templates/inspircd.conf.erb
@@ -13,6 +13,7 @@
 <module name="m_sha256.so">
 <module name="m_sqloper.so">
 <module name="m_ssl_gnutls.so">
+<module name="m_cap.so">
 
 # Required/Recommended modules for anope
 <module name="m_alias.so">
@@ -23,6 +24,9 @@
 <module name="m_spanningtree.so">
 <module name="m_svshold.so">
 
+# Add SASL authentication (provided by Anope)
+<module name="m_sasl.so">
+<sasl target="services.irc.ocf.berkeley.edu">
 
 <server name="irc.ocf.berkeley.edu"
         description="Open Computing Facility IRC Server"

--- a/modules/ocf_irc/templates/services.conf.erb
+++ b/modules/ocf_irc/templates/services.conf.erb
@@ -21,7 +21,7 @@ serverinfo {
     name = "services.irc.ocf.berkeley.edu"
     description = "OCF IRC Services"
 
-    pid = "/var/run/anope/anope.pid"
+    pid = "/run/anope/anope.pid"
     motd = "/etc/anope/services.motd"
 }
 

--- a/modules/ocf_irc/templates/services.conf.erb
+++ b/modules/ocf_irc/templates/services.conf.erb
@@ -179,6 +179,10 @@ module {
     }
 }
 
+# Add "SASL" authentication. Supported mechanisms are:
+# PLAIN, EXTERNAL.
+module { name = "m_sasl" }
+
 # Load the SHA256 module for NickServ password encryption
 module { name = "enc_sha256" }
 


### PR DESCRIPTION
We deliberately do not support the dh_aes (or its predecessor dh_blowfish)
mechanisms. These mechanisms are for users that want to send their
username and passwords encrypted to the server over an insecure
connection. Since the OCF only supports connecting over TLS there is no
point.