### PR TITLE
Fix octocatalog-diff on master with a couple dummy secrets

### DIFF
--- a/hieradata/dummy_secrets.yaml
+++ b/hieradata/dummy_secrets.yaml
@@ -112,5 +112,7 @@ kubernetes::etcdpeer_crt: dummycert
 kubernetes::etcdpeer_key: dummykey
 kubernetes::kubernetes_ca_crt: dummycert
 kubernetes::kubernetes_ca_key: dummykey
+kubernetes::kubernetes_front_proxy_ca_crt: dummycert
+kubernetes::kubernetes_front_proxy_ca_key: dummykey
 kubernetes::sa_pub: dummykey
 kubernetes::sa_key: dummykey


### PR DESCRIPTION
These were missing (but added in the private share on 2019-11-04) and cause `octocatalog-diff` to error on kubernetes hosts (`autocrat`, `bedbugs`, `coup`, `deadlock`, `hozer-73`, `hozer-74`, `pandemic`, and `riptide`).