### PR TITLE
ocf_irc: Improve the inspircd service file

### DIFF
--- a/modules/ocf_irc/files/inspircd.service.d/override.conf
+++ b/modules/ocf_irc/files/inspircd.service.d/override.conf
@@ -1,0 +1,7 @@
+[Unit]
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Group=irc
+Restart=always

--- a/modules/ocf_irc/manifests/ircd.pp
+++ b/modules/ocf_irc/manifests/ircd.pp
@@ -56,4 +56,9 @@ class ocf_irc::ircd {
       mode      => '0640',
       show_diff => false;
   }
+
+  ocf::systemd::override { 'inspircd-group-restart':
+    unit   => 'inspircd.service',
+    source => 'puppet:///modules/ocf_irc/inspircd.service.d/override.conf';
+  }
 }


### PR DESCRIPTION
The service file provided by Debian is really dated. Add overrides with
some options that upstream has added. I decided this was worthwhile when
the IRC server on dev-flood went down for a couple days due to a SIGSEV,
and was never brought back automatically since Restart= was not set.

https://github.com/inspircd/inspircd/blob/insp3/make/template/inspircd.service