### PR TITLE
boot buster by default when using PXE

### DIFF
--- a/modules/ocf_dhcp/files/netboot/ocf-netboot
+++ b/modules/ocf_dhcp/files/netboot/ocf-netboot
@@ -13,7 +13,7 @@ set -euo pipefail
 # Whichever architecture and distribution is first in the arrays is the default,
 # and is (ab)used for the PXE boot menu.
 archs=(amd64)
-dists=(stretch buster bullseye)
+dists=(buster stretch bullseye)
 menu_arch="${archs[0]}"
 menu_dist="${dists[0]}"
 menu_path="debian-installer/$menu_arch"


### PR DESCRIPTION
As discussed before break. This will make life substantially less painful as we do the work of moving VMs over to buster.