### PR TITLE
remove hozer-73 and hozer-74 as kubernetes workers

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -71,8 +71,6 @@ kubernetes::nginx_version: '0.21.0'
 kubernetes::worker_nodes:
     - pandemic
     - riptide
-    - hozer-73
-    - hozer-74
     - bedbugs
 kubernetes::master_nodes:
     - coup


### PR DESCRIPTION
they've been defunct for a while