### PR TITLE
actually include ocf_mail::logging

### DIFF
--- a/modules/ocf_mail/manifests/init.pp
+++ b/modules/ocf_mail/manifests/init.pp
@@ -1,6 +1,7 @@
 class ocf_mail {
   include ocf::ssl::default
 
+  include ocf_mail::logging
   include ocf_mail::spam
   include ocf_mail::site_ocf
   include ocf_mail::site_vhost


### PR DESCRIPTION
logging.pp was factored out of site_ocf.pp in c727262be2ba043c119453ccb864785e94557393, but never actually got properly included in init.pp. It hasn't been running for a long time, probably since the RAID failure in 2018.