### PR TITLE
Bump puppetfile

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,27 +6,26 @@ moduledir 'vendor'
 # too, since r10k does not manage dependencies and you will be confused as to
 # why they are not working properly.
 
-mod 'alexharvey/firewall_multi',           '1.10.0'
+mod 'alexharvey-firewall_multi',           '1.12.0'
 mod 'camptocamp-kmod',                     '2.3.1' # Dependency of puppetlabs-kubernetes
-mod 'camptocamp-systemd',                  '2.1.0' # Dependency of puppet-prometheus
+mod 'camptocamp-systemd',                  '2.2.0' # Dependency of puppet-prometheus
 mod 'herculesteam-augeasproviders_core',   '2.5.0' # Dependency of puppetlabs-kubernetes
 mod 'herculesteam-augeasproviders_sysctl', '2.3.1' # Dependency of puppetlabs-kubernetes
+mod 'puppet-archive',                      '3.2.1' # Dependency of puppet-prometheus
 mod 'puppet-nginx',                        '0.16.0'
-mod 'puppet-archive',                      '3.2.0' # Dependency of puppet-prometheus
-mod 'puppet-prometheus',                   '6.2.0'
-mod 'puppetlabs-apache',                   '3.1.0'
+mod 'puppet-prometheus',                   '6.4.0'
+mod 'puppetlabs-apache',                   '4.0.0'
 mod 'puppetlabs-apt',                      '6.3.0'
-mod 'puppetlabs-concat',                   '4.2.1'
-mod 'puppetlabs-firewall',                 '1.12.0'
-mod 'puppetlabs-hocon',                    '1.0.0'
-mod 'puppetlabs-inifile',                  '2.2.2' # Dependency of puppetlabs-puppetdb
-mod 'puppetlabs-kubernetes',               '5.0.0'
-mod 'puppetlabs-haproxy',                  '2.2.0'
-mod 'puppetlabs-postgresql',               '5.4.0' # Dependency of puppetlabs-puppetdb
-mod 'puppetlabs-puppet_authorization',     '0.4.0'
-mod 'puppetlabs-puppetdb',                 '6.0.2'
-mod 'puppetlabs-stdlib',                   '4.25.1'
-mod 'puppetlabs-tagmail',                  '2.4.0'
-mod 'puppetlabs-vcsrepo',                  '2.3.0'
+mod 'puppetlabs-concat',                   '5.3.0'
+mod 'puppetlabs-firewall',                 '1.15.1'
+mod 'puppetlabs-hocon',                    '1.0.1' # Dependency of puppetlabs-puppet_authorization
+mod 'puppetlabs-inifile',                  '2.5.0' # Dependency of puppetlabs-puppetdb
+mod 'puppetlabs-kubernetes',               '3.2.2'
+mod 'puppetlabs-postgresql',               '5.12.1'
+mod 'puppetlabs-puppet_authorization',     '0.5.0'
+mod 'puppetlabs-puppetdb',                 '7.1.0'
+mod 'puppetlabs-stdlib',                   '5.2.0'
+mod 'puppetlabs-tagmail',                  '2.5.0'
+mod 'puppetlabs-vcsrepo',                  '2.4.0'
+mod 'puppetlabs-translate',                '2.0.0' # Dependency of puppetlabs-kubernetes
 mod 'thias-sysctl',                        '1.0.6'
-mod 'puppetlabs/translate',                '2.0.0' # Dependency of puppetlabs-kubernetes

--- a/Puppetfile
+++ b/Puppetfile
@@ -6,26 +6,26 @@ moduledir 'vendor'
 # too, since r10k does not manage dependencies and you will be confused as to
 # why they are not working properly.
 
-mod 'alexharvey-firewall_multi',           '1.12.0'
-mod 'camptocamp-kmod',                     '2.3.1' # Dependency of puppetlabs-kubernetes
-mod 'camptocamp-systemd',                  '2.2.0' # Dependency of puppet-prometheus
+mod 'alexharvey-firewall_multi',           '1.16.0'
+mod 'camptocamp-kmod',                     '2.4.0' # Dependency of puppetlabs-kubernetes
+mod 'camptocamp-systemd',                  '2.8.0' # Dependency of puppet-prometheus
 mod 'herculesteam-augeasproviders_core',   '2.5.0' # Dependency of puppetlabs-kubernetes
-mod 'herculesteam-augeasproviders_sysctl', '2.3.1' # Dependency of puppetlabs-kubernetes
-mod 'puppet-archive',                      '3.2.1' # Dependency of puppet-prometheus
-mod 'puppet-nginx',                        '0.16.0'
-mod 'puppet-prometheus',                   '6.4.0'
-mod 'puppetlabs-apache',                   '4.0.0'
-mod 'puppetlabs-apt',                      '6.3.0'
-mod 'puppetlabs-concat',                   '5.3.0'
-mod 'puppetlabs-firewall',                 '1.15.1'
-mod 'puppetlabs-hocon',                    '1.0.1' # Dependency of puppetlabs-puppet_authorization
-mod 'puppetlabs-inifile',                  '2.5.0' # Dependency of puppetlabs-puppetdb
-mod 'puppetlabs-kubernetes',               '3.2.2'
-mod 'puppetlabs-postgresql',               '5.12.1'
+mod 'herculesteam-augeasproviders_sysctl', '2.4.0' # Dependency of puppetlabs-kubernetes
+mod 'puppet-archive',                      '4.4.0' # Dependency of puppet-prometheus
+mod 'puppet-nginx',                        '1.1.0'
+mod 'puppet-prometheus',                   '8.2.1'
+mod 'puppetlabs-apache',                   '5.4.0'
+mod 'puppetlabs-apt',                      '7.3.0'
+mod 'puppetlabs-concat',                   '6.2.0'
+mod 'puppetlabs-firewall',                 '2.2.0'
+mod 'puppetlabs-hocon',                    '1.1.0' # Dependency of puppetlabs-puppet_authorization
+mod 'puppetlabs-inifile',                  '4.1.0' # Dependency of puppetlabs-puppetdb
+mod 'puppetlabs-kubernetes',               '5.0.0'
+mod 'puppetlabs-postgresql',               '6.3.0'
 mod 'puppetlabs-puppet_authorization',     '0.5.0'
-mod 'puppetlabs-puppetdb',                 '7.1.0'
-mod 'puppetlabs-stdlib',                   '5.2.0'
-mod 'puppetlabs-tagmail',                  '2.5.0'
-mod 'puppetlabs-vcsrepo',                  '2.4.0'
-mod 'puppetlabs-translate',                '2.0.0' # Dependency of puppetlabs-kubernetes
+mod 'puppetlabs-puppetdb',                 '7.4.0'
+mod 'puppetlabs-stdlib',                   '6.2.0'
+mod 'puppetlabs-tagmail',                  '3.2.0'
+mod 'puppetlabs-vcsrepo',                  '3.1.0'
+mod 'puppetlabs-translate',                '2.1.0' # Dependency of puppetlabs-kubernetes
 mod 'thias-sysctl',                        '1.0.6'

--- a/modules/ocf/manifests/apt.pp
+++ b/modules/ocf/manifests/apt.pp
@@ -1,5 +1,5 @@
 class ocf::apt($stage = 'first') {
-  package { ['aptitude', 'imvirt', 'apt-transport-https', 'lsb-release', 'ethtool']:; }
+  package { ['aptitude', 'imvirt', 'lsb-release', 'ethtool']:; }
 
   class { '::apt':
     purge => {

--- a/modules/ocf_ocfweb/manifests/dev_config.pp
+++ b/modules/ocf_ocfweb/manifests/dev_config.pp
@@ -18,7 +18,9 @@ class ocf_ocfweb::dev_config($group = 'ocfstaff') {
   # ocfweb depends on, but we can't just declare the package
   # because it conflicts with extrapackages, which is declared in
   # ocf_admin along with this manifest (for supernova)
-  ensure_packages(['libcrack2-dev'])
+  if !defined(Package['libcrack2-dev']) {
+    package { 'libcrack2-dev': }
+  }
 
   # Install some packages for generating puppet diffs
   # TODO: Move this somewhere else alongside the puppet certs added below


### PR DESCRIPTION
I'm curious to see what `octocatalog-diff` does with this one since I suspect there's going to be quite a few changes, and I'd like to see how it differs from what an actual puppet run does for instance (if at all).

Also wow does the diff look messed up on this, but I essentially just bumped all the modules to their latest versions. I suspect this'll break some things or that there might be missing dependencies, so that's why I'd like to see what `octocatalog-diff` has to say