### PR TITLE
Remove uses of deprecated is_staff/list_staff functions

### DIFF
--- a/modules/ocf_desktop/files/xsession/auto-lock
+++ b/modules/ocf_desktop/files/xsession/auto-lock
@@ -6,20 +6,19 @@ import time
 from gi.repository import Gdk
 from gi.repository import GLib
 from gi.repository import Notify
-from ocflib.account.utils import is_staff
+from ocflib.account.utils import is_in_group
 from ocflib.misc.whoami import current_user
 
 # Time in seconds we wait for the user to move mouse/press keyboard
 WAIT_TIME = 180
 
 # Global variables. Just listing them out here.
-is_staffer = None
 pointer = None
 keyboard = None
 time_left = WAIT_TIME
 notification = None
 user = current_user()
-is_staffer = is_staff(user) or is_staff(user, group='opstaff')
+is_staffer = is_in_group(user, 'ocfstaff') or is_in_group(user, 'opstaff')
 
 
 def set_event_handler():

--- a/modules/ocf_desktop/files/xsession/lab-close-notify
+++ b/modules/ocf_desktop/files/xsession/lab-close-notify
@@ -4,7 +4,7 @@ import sched
 import time
 
 from gi.repository import Notify
-from ocflib.account.utils import is_staff
+from ocflib.account.utils import is_in_group
 from ocflib.lab.hours import read_hours_listing
 from ocflib.misc.whoami import current_user
 
@@ -26,7 +26,7 @@ def notify_user(seconds_left, staff):
 
 
 def main():
-    staff = is_staff(current_user())
+    staff = is_in_group(current_user(), 'ocfstaff')
     if staff:
         # 0 minutes, 15 minutes
         warning_durations = [0, 900]

--- a/modules/ocf_desktop/files/xsession/notify
+++ b/modules/ocf_desktop/files/xsession/notify
@@ -3,7 +3,7 @@ import pwd
 from datetime import datetime
 
 from gi.repository import Notify
-from ocflib.account.utils import is_staff
+from ocflib.account.utils import is_in_group
 from ocflib.lab.stats import staff_in_lab
 from ocflib.misc.whoami import current_user
 from ocflib.printing.quota import get_connection
@@ -18,7 +18,7 @@ def main():
     staff = {
         pwd.getpwnam(session.user).pw_gecos
         for session in staff_in_lab()
-        if not is_staff(session.user, 'opstaff')
+        if not is_in_group(session.user, 'opstaff')
     }
 
     # List staff in lab

--- a/modules/ocf_labstats/files/bin/update-groups
+++ b/modules/ocf_labstats/files/bin/update-groups
@@ -2,7 +2,7 @@
 
 import sys
 
-from ocflib.account.utils import list_staff
+from ocflib.account.utils import list_group
 from ocflib.lab.stats import get_connection
 
 
@@ -31,8 +31,8 @@ def main():
     with open('/opt/stats/ocfstats-password') as f:
         ocfstats_password = f.read().rstrip()
 
-    update_group(ocfstats_password, 'staff', list_staff())
-    update_group(ocfstats_password, 'opstaff', list_staff('opstaff'))
+    update_group(ocfstats_password, 'staff', list_group('ocfstaff'))
+    update_group(ocfstats_password, 'opstaff', list_group('opstaff'))
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/modules/ocf_mail/files/spam/logging/examine-mail-log
+++ b/modules/ocf_mail/files/spam/logging/examine-mail-log
@@ -6,7 +6,7 @@ import sys
 from collections import Counter
 from collections import defaultdict
 
-from ocflib.account.utils import is_staff
+from ocflib.account.utils import is_in_group
 
 
 # number of messages a single account can send per day without being flagged
@@ -71,7 +71,7 @@ def examine_mail(mail):
 
             if from_user:
                 if from_user != user and from_user not in USER_EXCEPTIONS:
-                    if not is_staff(user) or from_user != 'help':
+                    if not is_in_group(user, 'ocfstaff') or from_user != 'help':
                         yield ("From @ocf but user doesn't match",
                                'from {}, should be {} (uid {})'.format(from_user, user, uid))
             else:


### PR DESCRIPTION
[These functions](https://github.com/ocf/ocflib/blob/ae7e3bbbfd877e7ec51225b1b09ccf6a95d14341/ocflib/account/utils.py#L67-L84) have been deprecated in ocflib for a while (since https://github.com/ocf/ocflib/pull/129), so this changes all the usages of them to use the newer replacements.

Once this is merged, the functions should be able to be stripped out of ocflib, since I don't see [any other uses of these in sourcegraph](https://sourcegraph.ocf.berkeley.edu/search?q=%28is_staff%7Clist_staff%29).