### PR TITLE
Use puppetlabs and backports apt repos for buster

### DIFF
--- a/hieradata/os/buster.yaml
+++ b/hieradata/os/buster.yaml
@@ -1,2 +1,0 @@
-# TODO: Remove this once puppetlabs releases packages for buster
-puppet_agent: false

--- a/modules/ocf/manifests/apt.pp
+++ b/modules/ocf/manifests/apt.pp
@@ -60,12 +60,10 @@ class ocf::apt($stage = 'first') {
       codename => "${::lsbdistcodename}-backports",
     }
 
-    if $::lsbdistcodename != 'buster' {
-      # TODO: Submit patch to puppetlabs-apt to enable having includes for
-      # apt::backports (so that we can include the source too)
-      class { 'apt::backports':
-        location => 'http://mirrors/debian/';
-      }
+    # TODO: Submit patch to puppetlabs-apt to enable having includes for
+    # apt::backports (so that we can include the source too)
+    class { 'apt::backports':
+      location => 'http://mirrors/debian/';
     }
 
   } elsif $::lsbdistid == 'Raspbian' {
@@ -88,20 +86,17 @@ class ocf::apt($stage = 'first') {
     }
   }
 
-  # TODO: Add the puppetlabs repo to buster when it is available
-  if $::lsbdistcodename == 'stretch' {
-    apt::source {
-      'puppetlabs':
-        location => 'http://mirrors/puppetlabs/apt/',
-        release  => $::lsbdistcodename,
-        repos    => 'puppet',
-    }
+  apt::source {
+    'puppetlabs':
+      location => 'http://mirrors/puppetlabs/apt/',
+      release  => $::lsbdistcodename,
+      repos    => 'puppet',
+  }
 
-    # Add the puppetlabs apt repo key
-    apt::key { 'puppet gpg key':
-      id     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
-      source => 'https://mirrors.ocf.berkeley.edu/puppetlabs/apt/pubkey.gpg';
-    }
+  # Add the puppetlabs apt repo key
+  apt::key { 'puppet gpg key':
+    id     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
+    source => 'https://mirrors.ocf.berkeley.edu/puppetlabs/apt/pubkey.gpg';
   }
 
   apt::key { 'ocf':


### PR DESCRIPTION
[Puppetlabs now has an apt distribution for buster](http://mirrors.ocf.berkeley.edu/puppetlabs/apt/dists/buster/), and [debian has buster-backports](http://mirrors.ocf.berkeley.edu/debian/dists/buster-backports/), so let's enable both of those and make things a bit more standard when on buster.

Note: This still needs testing on a machine running buster to see how it'll do with the switch in puppet versions. I think it should be fine, but it's worth an actual live test to make sure.