### PR TITLE
Add a noop mirrors sync mode and key for dev-fallingrocks

### DIFF
--- a/hieradata/nodes/dev-fallingrocks.yaml
+++ b/hieradata/nodes/dev-fallingrocks.yaml
@@ -1,1 +1,3 @@
-ocf::networking::bond: true
+classes:
+    - ocf_apt
+    - ocf_mirrors

--- a/modules/ocf_apt/manifests/init.pp
+++ b/modules/ocf_apt/manifests/init.pp
@@ -10,6 +10,12 @@ class ocf_apt {
 
   package { 'reprepro':; }
 
+  if $::host_env == 'prod' {
+    $pkg_key = 'D72A0AF4'
+  } else {
+    $pkg_key = 'D0BA5B90'
+  }
+
   file {
     default:
       owner => ocfapt,
@@ -23,7 +29,7 @@ class ocf_apt {
       source => 'puppet:///modules/ocf_apt/README.html';
 
     '/opt/apt/etc/distributions':
-      source => 'puppet:///modules/ocf_apt/distributions';
+      content => template('ocf_apt/distributions.erb');
 
     '/opt/apt/bin':
       ensure  => directory,

--- a/modules/ocf_apt/templates/distributions.erb
+++ b/modules/ocf_apt/templates/distributions.erb
@@ -7,19 +7,19 @@
 Codename: stretch
 Architectures: amd64 i386 source
 Components: main
-SignWith: D72A0AF4
+SignWith: <%= @pkg_key %>
 
 Codename: stretch-backports
 Architectures: amd64 i386 source
 Components: main
-SignWith: D72A0AF4
+SignWith: <%= @pkg_key %>
 
 Codename: buster
 Architectures: amd64 i386 source
 Components: main
-SignWith: D72A0AF4
+SignWith: <%= @pkg_key %>
 
 Codename: buster-backports
 Architectures: amd64 i386 source
 Components: main
-SignWith: D72A0AF4
+SignWith: <%= @pkg_key %>

--- a/modules/ocf_mirrors/manifests/timer.pp
+++ b/modules/ocf_mirrors/manifests/timer.pp
@@ -12,6 +12,15 @@ define ocf_mirrors::timer(
   # Any meaningful second precision requires AccuracySec to be set
   $on_calendar = "${year}-${month}-${day} ${hour}:${minute}:00"
 
+  if $::host_env == 'dev' {
+    # Don't actually run the syncing commands when in dev since they will fill
+    # up the entire disk, so just print out what script would have been run to
+    # syslog
+    $exec = "logger -t ${title}_systemd_service: Would have run '${exec_start}' if in prod"
+  } else {
+    $exec = $exec_start
+  }
+
   ocf::systemd::timer { $title:
     service_content => template('ocf_mirrors/systemd/sync.service.erb'),
     timer_content   => template('ocf_mirrors/systemd/sync.timer.erb'),

--- a/modules/ocf_mirrors/templates/systemd/sync.service.erb
+++ b/modules/ocf_mirrors/templates/systemd/sync.service.erb
@@ -7,4 +7,4 @@ Type=simple
 <% @environments.each do |env, val| -%>
 Environment="<%= env %>=<%= val %>"
 <% end -%>
-ExecStart=<%= @exec_start %>
+ExecStart=<%= @exec %>


### PR DESCRIPTION
This adds a noop syncing mode for dev-fallingrocks mirrors where they just print to syslog that they would have tried to sync something, and adds a separate key to sign internal (`ocf_apt`) packages with, since I didn't feel comfortable using the production key with it given it can sign all internal packages if it is improperly released.

I mostly did this while investigating applying #838 on `dev-fallingrocks` and then finding it was out of disk space due to trying to sync a bunch of mirrors with only a 16 GB root drive.

CC @pxhanus as I believe you were working on this last?