### PR TITLE
Change ubuntu upstream to official us.archive.ubuntu.

### DIFF
--- a/modules/ocf_mirrors/manifests/projects/ubuntu.pp
+++ b/modules/ocf_mirrors/manifests/projects/ubuntu.pp
@@ -1,6 +1,6 @@
 class ocf_mirrors::projects::ubuntu {
   ocf_mirrors::ftpsync { 'ubuntu':
-    rsync_host  => 'mirror.enzu.com',
+    rsync_host  => 'us.archive.ubuntu.com',
     cron_minute => '50';
   }
 


### PR DESCRIPTION
Our previous upstream went out of date; the official US upstream seems to have good enough bandwidth.

Tested--fallingrocks is on my env right now.