### PR TITLE
Add Helm 3.0.3

### DIFF
--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -10,6 +10,7 @@ class ocf::packages {
   # special snowflake packages that require some config
   include ocf::packages::git
   include ocf::packages::grub
+  include ocf::packages::helm
   include ocf::packages::ldapvi
   include ocf::packages::ntp
   include ocf::packages::postfix

--- a/modules/ocf/manifests/packages/helm.pp
+++ b/modules/ocf/manifests/packages/helm.pp
@@ -1,0 +1,21 @@
+class ocf::packages::helm {
+
+  # This is not a package, but until Helm 3 is in the Debian
+  # repository we will have to download the binary manually.
+  $install_path        = '/usr/bin'
+  $package_name        = 'helm'
+  $package_ensure      = '3.0.3'
+  $repository_url      = 'https://get.helm.sh'
+  $archive_name        = "${package_name}-v${package_ensure}-linux-amd64.tar.gz"
+  $package_source      = "${repository_url}/${archive_name}"
+
+  archive { $archive_name:
+    path            => "/tmp/${archive_name}",
+    source          => $package_source,
+    extract         => true,
+    extract_path    => $install_path,
+    extract_command => 'tar xzf %s linux-amd64/helm --strip-components=1',
+    creates         => "${install_path}/${package_name}",
+    cleanup         => true,
+  }
+}


### PR DESCRIPTION
I've been playing with Helm 3 recently and it's actually been very useful. Unfortunately, it's also not packaged in the Debian apt repo and the Puppet module is for 2.x (which has Tiller). 

This might not be the best way to deploy it, so I'm open to comments.