### PR TITLE
add authentication to prometheus.ocf.berkeley.edu

### DIFF
--- a/modules/ocf_prometheus/files/proxy_pam
+++ b/modules/ocf_prometheus/files/proxy_pam
@@ -1,0 +1,10 @@
+# Restrict access to prometheus.ocf.berkeley.edu to ocfstaff only, since it
+# includes configuration access to alertmanager, among other things.
+
+@include common-auth
+@include common-account
+@include common-password
+@include common-session
+
+# Must be in the ocfstaff group to access
+auth    required    pam_listfile.so onerr=fail item=group sense=allow file=/etc/prometheus/allowed-groups


### PR DESCRIPTION
This requires authentication as ocfstaff, or via an htpasswd file, to access prometheus.ocf.berkeley.edu. This properly restricts access to Alertmanager. The htpasswd file is used for allowing access via external applications such as Grafana.

This depends on ocf/grafana#10 to be merged first, otherwise Grafana will break.