### PR TITLE
move debian-security mirror upstream to rsync.security.debian.org

### DIFF
--- a/modules/ocf_mirrors/manifests/projects/debian.pp
+++ b/modules/ocf_mirrors/manifests/projects/debian.pp
@@ -5,7 +5,7 @@ class ocf_mirrors::projects::debian {
       cron_minute => '10';
 
     'debian-security':
-      rsync_host  => 'security.debian.org',
+      rsync_host  => 'rsync.security.debian.org',
       cron_minute => '20';
 
     'debian-cd':


### PR DESCRIPTION
Debian will be decommissioning rsync on the main debian-security server, so we have to use this one instead now.