### PR TITLE
Shuffle around includes for the base ocf_hpc class

### DIFF
--- a/modules/ocf_hpc/manifests/compute.pp
+++ b/modules/ocf_hpc/manifests/compute.pp
@@ -1,6 +1,11 @@
 class ocf_hpc::compute {
   require ocf_hpc
 
+  include ocf::ipmi
+  include ocf::firewall::allow_ssh
+
+  include ocf_hpc::singularity
+
   # install proprietary nvidia drivers and CUDA.
   ocf::repackage { ['nvidia-driver', 'nvidia-settings', 'nvidia-cuda-toolkit', 'nvidia-persistenced']:
       backport_on => stretch;

--- a/modules/ocf_hpc/manifests/controller.pp
+++ b/modules/ocf_hpc/manifests/controller.pp
@@ -1,6 +1,9 @@
 class ocf_hpc::controller {
   require ocf_hpc
 
+  include ocf::firewall::allow_ssh
+  include ocf_hpc::singularity
+
   $slurmdbd_mysql_password = lookup('hpc::controller::slurmdbd_mysql_password')
 
   package { 'slurmdbd': } -> file { '/etc/slurm-llnl/slurmdbd.conf':

--- a/modules/ocf_hpc/manifests/init.pp
+++ b/modules/ocf_hpc/manifests/init.pp
@@ -1,7 +1,4 @@
 class ocf_hpc {
-  include ocf::firewall::allow_ssh
-  include ocf::ipmi
-  include ocf_hpc::singularity
 
   package { 'slurm-wlm': }
 


### PR DESCRIPTION
Shouldn't change anything right now, but will help in case we ever want to put just the ocf_hpc class on a node so it can issue slurm commands, but not be a compute or control node. 