### PR TITLE
add prometheus pushgateway

### DIFF
--- a/modules/ocf_prometheus/manifests/init.pp
+++ b/modules/ocf_prometheus/manifests/init.pp
@@ -1,5 +1,6 @@
 class ocf_prometheus {
   include ocf_prometheus::alertmanager
   include ocf_prometheus::proxy
+  include ocf_prometheus::pushgateway
   include ocf_prometheus::server
 }

--- a/modules/ocf_prometheus/manifests/proxy.pp
+++ b/modules/ocf_prometheus/manifests/proxy.pp
@@ -44,6 +44,7 @@ class ocf_prometheus::proxy {
 
       rewrites            => [
         {rewrite_rule => '^/alertmanager(/.*)?$ http://127.0.0.1:9093/alertmanager$1 [P]'},
+        {rewrite_rule => '^/pushgateway(/.*)?$ http://127.0.0.1:9091$1 [P]'},
         {rewrite_rule => '^/(.*)$ http://127.0.0.1:9090/$1 [P]'},
       ],
       directories         => [{

--- a/modules/ocf_prometheus/manifests/pushgateway.pp
+++ b/modules/ocf_prometheus/manifests/pushgateway.pp
@@ -1,15 +1,5 @@
 class ocf_prometheus::pushgateway {
 
-  ocf::firewall::firewall46 {
-    '995 allow pushgateway to accept metrics':
-      opts => {
-        chain  => 'PUPPET-INPUT',
-        proto  => 'tcp',
-        dport  => 9091,
-        action => 'accept',
-      };
-  }
-
   class { '::prometheus::pushgateway':
     version       => '1.0.0',
     extra_options => "--web.route-prefix=/ --web.external-url=\"https://prometheus.ocf.berkeley.edu/pushgateway\"",

--- a/modules/ocf_prometheus/manifests/pushgateway.pp
+++ b/modules/ocf_prometheus/manifests/pushgateway.pp
@@ -1,0 +1,17 @@
+class ocf_prometheus::pushgateway {
+
+  ocf::firewall::firewall46 {
+    '995 allow pushgateway to accept metrics':
+      opts => {
+        chain  => 'PUPPET-INPUT',
+        proto  => 'tcp',
+        dport  => 9091,
+        action => 'accept',
+      };
+  }
+
+  class { '::prometheus::pushgateway':
+    version       => '1.0.0',
+    extra_options => "--web.route-prefix=/ --web.external-url=\"https://prometheus.ocf.berkeley.edu/pushgateway\"",
+  }
+}

--- a/modules/ocf_prometheus/manifests/server.pp
+++ b/modules/ocf_prometheus/manifests/server.pp
@@ -130,6 +130,12 @@ class ocf_prometheus::server {
 
         static_configs  => [{targets =>['smtp:9154']}],
       },
+      {
+        job_name       => 'pushgateway',
+        honor_labels   => true,
+
+        static_configs => [{targets =>['localhost:9091']}],
+      }
     ]
   }
 }


### PR DESCRIPTION
This allows us to push service-level metrics that might not belong to a specific node e.g. suffocation.

