### PR TITLE
Change to using puppetlabs repo for puppet-agent

### DIFF
--- a/modules/ocf_dhcp/files/preseed/buster
+++ b/modules/ocf_dhcp/files/preseed/buster
@@ -81,14 +81,23 @@ d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 
+# Additional apt repositories, local[0-9] are available
+d-i apt-setup/local0/repository string \
+       http://mirrors/puppetlabs/apt/ buster puppet
+d-i apt-setup/local0/comment string puppetlabs
+# Enable deb-src lines
+d-i apt-setup/local0/source boolean true
+# URL to the public key of the local repository; you must provide a key or
+# apt will complain about the unauthenticated repository and so the
+# sources.list line will be left commented out
+d-i apt-setup/local0/key string \
+	https://mirrors.ocf.berkeley.edu/puppetlabs/apt/pubkey.gpg
+
 # Package selection
 tasksel tasksel/first multiselect standard
 
 # Individual additional packages to install
-#
-# TODO: Change to using puppet-agent (and use their mirrored repo) when
-# puppetlabs releases it for buster
-d-i pkgsel/include string openssh-server build-essential puppet ethtool
+d-i pkgsel/include string openssh-server build-essential puppet-agent ethtool
 
 # Whether to upgrade packages after debootstrap.
 d-i pkgsel/upgrade select full-upgrade


### PR DESCRIPTION
Not tested but it's in the repo now and that's the only change from stretch