### PR TITLE
Allow installed extensions by default in firefox

### DIFF
--- a/modules/ocf/templates/firefox/prefs.js.erb
+++ b/modules/ocf/templates/firefox/prefs.js.erb
@@ -8,6 +8,7 @@ pref("browser.privatebrowsing.autostart", true);
 pref("browser.search.geoSpecificDefaults", false);
 pref("browser.shell.checkDefaultBrowser", false);
 pref("browser.showQuitWarning", true);
+pref("extensions.allowPrivateBrowsingByDefault", true)
 pref("network.negotiate-auth.trusted-uris", "https://auth.ocf.berkeley.edu");
 pref("pdfjs.disabled", true);
 pref("signon.rememberSignons", false);


### PR DESCRIPTION
This should allow extensions installed in Firefox to work without needing to individually activating them. 