### PR TITLE
node_exporter: enable the systemd collector

### DIFF
--- a/modules/ocf/manifests/node_exporter.pp
+++ b/modules/ocf/manifests/node_exporter.pp
@@ -8,6 +8,9 @@ class ocf::node_exporter {
   }
 
   if $::lsbdistid != 'Raspbian' {
-    include prometheus::node_exporter
+    class { 'prometheus::node_exporter':
+      collectors_enable => ['systemd'],
+      extra_options     => '--collector.systemd.unit-whitelist ".+\.(service|timer)"',
+    }
   }
 }


### PR DESCRIPTION
Lets us tie in services status to prometheus