### PR TITLE
Change debian to sync once every 6 hours (debian bug #914540)

### DIFF
--- a/modules/ocf_mirrors/manifests/projects/debian.pp
+++ b/modules/ocf_mirrors/manifests/projects/debian.pp
@@ -2,7 +2,7 @@ class ocf_mirrors::projects::debian {
   ocf_mirrors::ftpsync {
     'debian':
       rsync_host  => 'mirrors.wikimedia.org',
-      cron_hour   => '*/6',
+      cron_hour   => '0/6',
       cron_minute => '10';
 
     'debian-security':

--- a/modules/ocf_mirrors/manifests/projects/debian.pp
+++ b/modules/ocf_mirrors/manifests/projects/debian.pp
@@ -2,6 +2,7 @@ class ocf_mirrors::projects::debian {
   ocf_mirrors::ftpsync {
     'debian':
       rsync_host  => 'mirrors.wikimedia.org',
+      cron_hour   => '*/6',
       cron_minute => '10';
 
     'debian-security':


### PR DESCRIPTION
As per https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=914540 we should only sync this every 6 hours instead of every hour since the archive only updates every 6 hours anyway.