### PR TITLE
Add Riot client (Matrix) to OCF desktops

### DIFF
--- a/modules/ocf/manifests/packages/riot.pp
+++ b/modules/ocf/manifests/packages/riot.pp
@@ -1,0 +1,7 @@
+class ocf::packages::riot {
+  class { 'ocf::packages::riot::apt':
+    stage => first,
+  }
+
+  package { 'riot-web':; }
+}

--- a/modules/ocf/manifests/packages/riot/apt.pp
+++ b/modules/ocf/manifests/packages/riot/apt.pp
@@ -2,7 +2,7 @@
 class ocf::packages::riot::apt {
   apt::key { 'riot':
     ensure => refreshed,
-    id     =>  '12D4CD600C2240A9F4A82071D7B0B66941D01538',
+    id     => '12D4CD600C2240A9F4A82071D7B0B66941D01538',
     source => 'https://packages.riot.im/debian/riot-im-archive-keyring.asc',
   }
 

--- a/modules/ocf/manifests/packages/riot/apt.pp
+++ b/modules/ocf/manifests/packages/riot/apt.pp
@@ -1,0 +1,16 @@
+# Include Riot apt repo.
+class ocf::packages::riot::apt {
+  apt::key { 'riot':
+    ensure => refreshed,
+    id     =>  '12D4CD600C2240A9F4A82071D7B0B66941D01538',
+    source => 'https://packages.riot.im/debian/riot-im-archive-keyring.asc',
+  }
+
+  apt::source { 'riot':
+    architecture => 'amd64',
+    location     => 'https://packages.riot.im/debian',
+    release      => $::lsbdistcodename,
+    repos        => 'main',
+    require      => Apt::Key['riot'],
+  }
+}

--- a/modules/ocf_desktop/manifests/init.pp
+++ b/modules/ocf_desktop/manifests/init.pp
@@ -5,6 +5,7 @@ class ocf_desktop {
   include ocf::packages::cups
   include ocf::packages::firefox
   include ocf::packages::pulse
+  include ocf::packages::riot
   include ocf::packages::vscode
   include ocf_desktop::crondeny
   include ocf_desktop::defaults


### PR DESCRIPTION
In anticipation for Matrix @ OCF, I have added the Riot client to the Puppet config for OCF desktops.

Tested on hurricane.