### PR TITLE
Hw monitor controls

### DIFF
--- a/modules/ocf_desktop/manifests/displaycontrol.pp
+++ b/modules/ocf_desktop/manifests/displaycontrol.pp
@@ -1,0 +1,16 @@
+class ocf_desktop::displaycontrol {
+
+  file {
+    '/etc/modules-load.d/i2c.conf':
+      mode    => '0644',
+      content => 'i2c_dev\n',
+  }
+
+  exec { 'load-modules':
+    command     => '/lib/systemd/systemd-modules-load',
+    subscribe   => File['/etc/modules-load.d/i2c.conf'],
+    refreshonly => true,
+  }
+
+  package { [ 'i2c-tools', 'ddcutil' ]: }
+}

--- a/modules/ocf_desktop/manifests/displaycontrol.pp
+++ b/modules/ocf_desktop/manifests/displaycontrol.pp
@@ -3,7 +3,7 @@ class ocf_desktop::displaycontrol {
   file {
     '/etc/modules-load.d/i2c.conf':
       mode    => '0644',
-      content => 'i2c_dev\n',
+      content => 'i2c_dev',
   }
 
   exec { 'load-modules':

--- a/modules/ocf_desktop/manifests/init.pp
+++ b/modules/ocf_desktop/manifests/init.pp
@@ -8,6 +8,7 @@ class ocf_desktop {
   include ocf::packages::vscode
   include ocf_desktop::crondeny
   include ocf_desktop::defaults
+  include ocf_desktop::displaycontrol
   include ocf_desktop::drivers
   include ocf_desktop::firewall_output
   include ocf_desktop::grub


### PR DESCRIPTION
Monitor status reporting and controls of hardware.

Some i2c commands can brick monitors, so this functionality should be limited to root for now.