### PR TITLE
don't backport dehydrated

### DIFF
--- a/modules/ocf/manifests/ssl/lets_encrypt/dns_common.pp
+++ b/modules/ocf/manifests/ssl/lets_encrypt/dns_common.pp
@@ -1,9 +1,6 @@
 class ocf::ssl::lets_encrypt::dns_common {
-  ocf::repackage { 'dehydrated':
-    backport_on => ['stretch'],
-  }
-  package { 'dehydrated-hook-ddns-tsig':
-    require => Package['dehydrated'],
+  package {
+    ['dehydrated', 'dehydrated-hook-ddns-tsig']:;
   }
 
   $letsencrypt_ddns_key = assert_type(Stdlib::Base64, lookup('letsencrypt::ddns::key'))


### PR DESCRIPTION
The version in stretch-backports and stretch is the same. This was causing puppetspam due to how ocf::repackage works.