### PR TITLE
prometheus: increase switch scrape interval

### DIFF
--- a/modules/ocf_prometheus/manifests/server.pp
+++ b/modules/ocf_prometheus/manifests/server.pp
@@ -116,8 +116,8 @@ class ocf_prometheus::server {
       },
       {
         job_name        => 'switch',
-        scrape_interval => '30s',
-        scrape_timeout  => '20s',
+        scrape_interval => '60s',
+        scrape_timeout  => '30s',
 
         file_sd_configs => [
           {


### PR DESCRIPTION
The 30s interval was overloading the switches' SNMP servers, causing 40s scrape durations.

This is tested, and it brings scrape durations down to under 10s (even with dev-dementors still scraping at 30s).