### PR TITLE
add default puppet config for non-root

### DIFF
--- a/modules/ocf_puppet/manifests/environments.pp
+++ b/modules/ocf_puppet/manifests/environments.pp
@@ -29,4 +29,19 @@ class ocf_puppet::environments {
       }
     }
   }
+
+  # Add some basic config for puppet run as non-root
+  # This allows staff to run `puppet generate types --environment <username>`
+  # to generate resource types for their own environment.
+  file {
+    [
+      '/etc/skel/.puppetlabs/',
+      '/etc/skel/.puppetlabs/etc/',
+      '/etc/skel/.puppetlabs/etc/puppet/',
+    ]:
+      ensure => directory;
+
+    '/etc/skel/.puppetlabs/etc/puppet/puppet.conf':
+      content => "codedir = /etc/puppetlabs/code\n";
+  }
 }


### PR DESCRIPTION
This allows users to generate resource types for their own environments, which is useful when testing vendor updates.