### PR TITLE
update resource types when deploying puppet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ WORKSPACE ?= ${HOME}/.cache
 ENVIRONMENT := $(notdir $(realpath $(CURDIR)))
 
 .PHONY: all
-all: vendor install-hooks
+all: vendor .resource_types install-hooks
 
 .PHONY: venv
 venv: bin/venv-update Makefile
@@ -20,6 +20,9 @@ install-hooks: venv
 
 vendor: Puppetfile
 	r10k puppetfile install --verbose --color
+	@echo 'You may also want to run `make .resource_types`'
+
+.resource_types: vendor
 	puppet generate types --environment ${ENVIRONMENT} --force || (\
 		echo '\e[1;31mPlease run' && \
 		echo 'mkdir -p ~/.puppetlabs/etc/puppet/ && cp /etc/skel/.puppetlabs/etc/puppet/puppet.conf ~/.puppetlabs/etc/puppet/\e[0m' && \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 WORKSPACE ?= ${HOME}/.cache
+ENVIRONMENT := $(notdir $(realpath $(CURDIR)))
 
 .PHONY: all
 all: vendor install-hooks
@@ -19,6 +20,10 @@ install-hooks: venv
 
 vendor: Puppetfile
 	r10k puppetfile install --verbose --color
+	puppet generate types --environment ${ENVIRONMENT} --force || (\
+		echo '\e[1;31mPlease run' && \
+		echo 'mkdir -p ~/.puppetlabs/etc/puppet/ && cp /etc/skel/.puppetlabs/etc/puppet/puppet.conf ~/.puppetlabs/etc/puppet/\e[0m' && \
+		false )
 
 .PHONY: all_diffs
 all_diffs:

--- a/modules/ocf_puppet/files/update-prod
+++ b/modules/ocf_puppet/files/update-prod
@@ -17,7 +17,7 @@ else
 fi
 
 # update from remote
-git fetch origin
+git fetch origin master
 git reset --hard origin/master
 
 # Install third-party modules

--- a/modules/ocf_puppet/files/update-prod
+++ b/modules/ocf_puppet/files/update-prod
@@ -22,3 +22,4 @@ git reset --hard origin/master
 
 # Install third-party modules
 make vendor
+make .resource_types


### PR DESCRIPTION
Today, all puppet builds were failing because firewall_multi was updated and had new type definitions, but `puppet generate types` wasn't run. This will just run that every time we deploy.

See https://puppet.com/docs/puppet/latest/environment_isolation.html for more info. Note that it specifically mentions that we should use `--force` for every new deployment.