### PR TITLE
ocf_kubernetes: only `kubectl apply` when there are new changes

### DIFF
--- a/modules/ocf_kubernetes/manifests/apply.pp
+++ b/modules/ocf_kubernetes/manifests/apply.pp
@@ -6,6 +6,8 @@ define ocf_kubernetes::apply(
   exec { "kubectl-apply-${title}":
     environment => ["KUBECONFIG=${config}"],
     command     => "kubectl apply -f ${target}",
+    # only apply if there are actually new changes, to avoid spam
+    unless      => "kubectl diff -f ${target}",
     require     => Package['kubectl'],
   }
 }


### PR DESCRIPTION
This avoids the masters reporting changes on every single puppet run.