### PR TITLE
fix dehydrated permissions problems on lethe

### DIFF
--- a/modules/ocf/files/ssl/dehydrated-config
+++ b/modules/ocf/files/ssl/dehydrated-config
@@ -3,8 +3,6 @@ BASEDIR="/var/lib/lets-encrypt"
 HOOK="/usr/share/dehydrated-hook-ddns-tsig/dehydrated-hook-ddns-tsig.py"
 CHALLENGETYPE="dns-01"
 
-DEHYDRATED_USER="ocfletsencrypt"
-
 # if you update this, run
 # dehydrated --privkey /etc/ssl/lets-encrypt/le-account.key --account
 # with the new config in place to update LE's records

--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -32,20 +32,6 @@ class ocf_postgres {
       };
   }
 
-  # Postgres expects the letsencrypt certs to be owned by root
-  # The renewal script expects the letsencrypt certs to be owned by ocfletsencrypt
-  # We change the owner to ocfletsencrypt before the renewal script runs
-  # Then we change the owner back to root after it runs
-  exec { 'chown-letsencrypt':
-    command => 'chown -R ocfletsencrypt:ssl-cert /var/lib/lets-encrypt/certs',
-    before  => Class['Ocf::Ssl::Default'],
-  }
-
-  exec { 'chown-root':
-    command => 'chown -R root:ssl-cert /var/lib/lets-encrypt/certs',
-    require => Class['Ocf::Ssl::Default'],
-  }
-
   Class['Ocf::Ssl::Default'] ~> Class['Postgresql::Server']
 
   file {


### PR DESCRIPTION
This resolves the issues with #669. Apparently the issue was just that we had specified `DEHYDRATED_USER` in the dehydrated config, so if dehydrated was run as root it would just sudo to that user. This removes that config and leaves the specification the the user running dehydrated to puppet. This allows us to revert #669 and remove the lethe puppet spam.