### PR TITLE
add ip6HostAddress to LDAP host schema

### DIFF
--- a/modules/ocf_ldap/files/ldap-lint
+++ b/modules/ocf_ldap/files/ldap-lint
@@ -10,6 +10,9 @@ Currently checks the Hosts OU for:
     * Host not in DNS or mismatched IP
     * Unrecognized puppetVar (often typos)
     * Reverse DNS for IP exists and matches hostname
+    * IP is not an OCF address
+    * IPv6 does not match IPv4
+    * Does not have an IPv6 address
 
 It also does some checks around users and kerberos principals:
     * All users with a /root principal should also have a /admin principal
@@ -22,9 +25,14 @@ from ipaddress import ip_address
 from operator import itemgetter
 
 import dns
+from ocflib.infra.hosts import HOST_TYPES_WITH_IPV6
 from ocflib.infra.ldap import ldap_connection
 from ocflib.infra.ldap import OCF_LDAP_GROUP
 from ocflib.infra.ldap import OCF_LDAP_HOSTS
+from ocflib.infra.net import ipv4_to_ipv6
+from ocflib.infra.net import ipv6_to_ipv4
+from ocflib.infra.net import is_ocf_ip
+from ocflib.infra.net import OCF_SUBNET_V6_COMPAT
 from ocflib.misc.shell import bold
 from ocflib.misc.shell import red
 
@@ -60,7 +68,7 @@ def check_hosts(c, complain):
     c.search(
         OCF_LDAP_HOSTS,
         '(cn=*)',
-        attributes=['cn', 'type', 'macAddress', 'ipHostNumber', 'puppetVar', 'puppetClass'],
+        attributes=['cn', 'type', 'macAddress', 'ipHostNumber', 'ip6HostNumber', 'puppetVar', 'puppetClass'],
     )
     for attrs in map(itemgetter('attributes'), c.response):
         cn = attrs['cn'][0]
@@ -88,6 +96,16 @@ def check_hosts(c, complain):
             complain(cn, 'is a staff VM, but not in staffvm IP range')
         elif type_ != 'staffvm' and in_staffvm_range:
             complain(cn, 'is in staffvm IP range, but not a staffvm')
+        if not is_ocf_ip(ip):
+            complain(cn, 'has the IP address {}, which is not an OCF IP'.format(ip))
+        ip6s = [ip_address(ip6) for ip6 in attrs['ip6HostNumber']]
+        for ip6 in ip6s:
+            if not is_ocf_ip(ip6):
+                complain(cn, 'has the IP address {}, which is not an OCF IP'.format(ip6))
+            if ip6 in OCF_SUBNET_V6_COMPAT and ipv6_to_ipv4(ip6) != ip:
+                complain(cn, 'has the IPv6 address {}, which does not match its IPv4 address'.format(ip6))
+        if (len(ip6s) > 0 or type_ in HOST_TYPES_WITH_IPV6) and ipv4_to_ipv6(ip) not in ip6s:
+            complain(cn, 'does not have an ip6HostNumber attribute matching its ipHostNumber')
 
         ip = attrs['ipHostNumber'][0]
         dns_ip = lookup_dns(cn + '.ocf.berkeley.edu')

--- a/modules/ocf_ldap/files/ocf.schema
+++ b/modules/ocf_ldap/files/ocf.schema
@@ -81,5 +81,5 @@ objectclass ( 1.3.6.1.4.1.41759.2.1.1
         DESC 'Attributes for OCF hosts'
         SUP ( ipHost $ ieee802Device $ puppetClient )
         AUXILIARY
-        MUST ( cn $ ipHostNumber $ type )
+        MUST ( cn $ type )
         MAY ( environment $ dnsCname $ dnsA ) )

--- a/modules/ocf_ldap/files/ocf.schema
+++ b/modules/ocf_ldap/files/ocf.schema
@@ -76,10 +76,26 @@ attributetype ( 1.3.6.1.4.1.41759.2.2.3
         SUBSTR caseIgnoreSubstringsMatch
         SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
+# based on ipHostNumber, 1.3.6.1.1.1.1.19
+attributetype ( 1.3.6.1.4.1.41759.2.2.4
+        NAME 'ip6HostNumber'
+        DESC 'IPv6 address, as represented by RFC1884 section 2.2.2'
+        EQUALITY caseIgnoreIA5Match
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128} )
+
+# based on ipHost, 1.3.6.1.1.1.2.6
+objectclass ( 1.3.6.1.4.1.41759.2.1.2
+        NAME 'ip6Host'
+        DESC 'Host optionally supporting IPv6'
+        SUP top
+        AUXILIARY
+        MUST ( cn )
+        MAY ( ip6HostNumber $ manager $ description $ l ) )
+
 objectclass ( 1.3.6.1.4.1.41759.2.1.1
         NAME 'ocfDevice'
         DESC 'Attributes for OCF hosts'
-        SUP ( ipHost $ ieee802Device $ puppetClient )
+        SUP ( ipHost $ ip6Host $ ieee802Device $ puppetClient )
         AUXILIARY
         MUST ( cn $ type )
         MAY ( environment $ dnsCname $ dnsA ) )

--- a/modules/ocf_ldap/manifests/init.pp
+++ b/modules/ocf_ldap/manifests/init.pp
@@ -5,6 +5,7 @@ class ocf_ldap {
   # ldif files in /etc/ldap/slapd.d, slapd is the ldap server
   package { ['slapd', 'ocf-ldap-overlay', 'libarchive-zip-perl']:; }
   service { 'slapd':
+    enable    => true,
     subscribe => [
       File['/etc/ldap/schema/ocf.schema',
         '/etc/ldap/schema/puppet.schema',


### PR DESCRIPTION
As discussed on IRC: https://irclogs.ocf.berkeley.edu/rebuild/2020-03-14#1584221913-1584225880;

This will give us more flexibility moving forward with IP address, and will avoid nasty hacks in Puppet and elsewhere.

I will use [this script](https://i.fluffy.cc/DSTM0wWNmFVbMDCTDlLHpwhxP0k5sP23.html) to update existing records once this is merged. (Note that this depends on ocf/ocflib#206 to not break, but I've tested it with that change on dev-firestorm and it does work.)