### PR TITLE
ocf-netboot: use fqdn for tftp

### DIFF
--- a/modules/ocf_dhcp/files/netboot/ocf-netboot
+++ b/modules/ocf_dhcp/files/netboot/ocf-netboot
@@ -96,6 +96,9 @@ for dist in "${dists[@]}"; do
         # Add OCF install options, set as default if menu dist and arch
         # The first item overwrites the existing install menu option, as we do
         # not want it (would like to use our own instead)
+        #
+        # TODO: Figure out why domain is set wrong in /etc/resolv.conf during
+        # installation, hence the FQDN for dhcp.
         if [ "$dist" == "$menu_dist" ] && [ "$arch" == "$menu_arch" ]; then
             echo "label ocf-$label
                 menu label OCF Automated Install ($label)

--- a/modules/ocf_dhcp/files/netboot/ocf-netboot
+++ b/modules/ocf_dhcp/files/netboot/ocf-netboot
@@ -101,12 +101,12 @@ for dist in "${dists[@]}"; do
                 menu label OCF Automated Install ($label)
                 menu default
                 kernel debian-installer/$arch/linux
-                append auto=true priority=critical locale=en_US keymap=us vga=788 initrd=debian-installer/$arch/initrd.gz url=tftp://dhcp/preseed/$dist -- quiet" > $txt_cfg
+                append auto=true priority=critical locale=en_US keymap=us vga=788 initrd=debian-installer/$arch/initrd.gz url=tftp://dhcp.ocf.berkeley.edu/preseed/$dist -- quiet" > $txt_cfg
         else
             echo "label ocf-$label
                 menu label OCF Automated Install ($label)
                 kernel $da_dir/debian-installer/$arch/linux
-                append auto=true priority=critical locale=en_US keymap=us vga=788 initrd=$da_dir/debian-installer/$arch/initrd.gz url=tftp://dhcp/preseed/$dist -- quiet" >> $txt_cfg
+                append auto=true priority=critical locale=en_US keymap=us vga=788 initrd=$da_dir/debian-installer/$arch/initrd.gz url=tftp://dhcp.ocf.berkeley.edu/preseed/$dist -- quiet" >> $txt_cfg
         fi
     done
 done


### PR DESCRIPTION
Somehow domain in resolv.conf is being set wrong during installation, causing the installation to try fetching from `dhcp.berkeley.edu` instead. I'd like to try and figure out why, but the cause is eluding me so far. 