### PR TITLE
enable EFI netbooting

### DIFF
--- a/modules/ocf_dhcp/files/dhcpd.conf
+++ b/modules/ocf_dhcp/files/dhcpd.conf
@@ -20,7 +20,14 @@ subnet 169.229.226.0 netmask 255.255.255.0 {
   option domain-search "ocf.berkeley.edu";
   option domain-name-servers ns.ocf.berkeley.edu, ns1.berkeley.edu, ns2.berkeley.edu;
   option ntp-servers ntp1.ocf.berkeley.edu, ntp2.ocf.berkeley.edu, ntp1.berkeley.edu;
-  filename "pxelinux.0";
+
+  if substring(option vendor-class-identifier, 0, 20) = "PXEClient:Arch:00000" {
+    # BIOS PXE
+    filename "pxelinux.0";
+  } else {
+    filename "debian-installer/amd64/bootnetx64.efi";
+  }
+
   next-server 169.229.226.22; # pxe booting server
 
   # pool for general use

--- a/modules/ocf_dhcp/files/netboot/ocf-netboot
+++ b/modules/ocf_dhcp/files/netboot/ocf-netboot
@@ -99,6 +99,8 @@ for dist in "${dists[@]}"; do
         #
         # TODO: Figure out why domain is set wrong in /etc/resolv.conf during
         # installation, hence the FQDN for dhcp.
+        # TODO: Add these options to GRUB as well, so they're accessible
+        # on EFI boots.
         if [ "$dist" == "$menu_dist" ] && [ "$arch" == "$menu_arch" ]; then
             echo "label ocf-$label
                 menu label OCF Automated Install ($label)


### PR DESCRIPTION
This should allow us to install Debian on EFI over the network. The OCF-specific options are not added in yet.