### PR TITLE
ocftv MPD configuration

### DIFF
--- a/modules/ocf_tv/files/lightdm.conf
+++ b/modules/ocf_tv/files/lightdm.conf
@@ -1,0 +1,7 @@
+[Seat:*]
+pam-service=lightdm
+pam-autologin-service=lightdm-autologin
+autologin-user=ocftv
+autologin-user-timeout=0
+session-wrapper=/etc/X11/Xsession
+greeter-session=lightdm-greeter

--- a/modules/ocf_tv/files/mpd.conf
+++ b/modules/ocf_tv/files/mpd.conf
@@ -11,13 +11,7 @@ bind_to_address     "any"
 input {
   plugin            "curl"
 }
-decoder {
-  plugin            "hybrid_dsd"
-  enabled           "no"
-}
 audio_output {
-	type              "pulse"
-	name              "Sink #1"
+  type              "pulse"
+  name              "Sink #1"
 }
-filesystem_charset  "UTF-8"
-

--- a/modules/ocf_tv/files/mpd.conf
+++ b/modules/ocf_tv/files/mpd.conf
@@ -1,0 +1,23 @@
+music_directory     "/var/lib/mpd/music"
+playlist_directory  "/var/lib/mpd/playlists"
+db_file			        "/var/lib/mpd/tag_cache"
+log_file            "/var/log/mpd/mpd.log"
+pid_file            "/run/mpd/pid"
+state_file          "/var/lib/mpd/state"
+sticker_file        "/var/lib/mpd/sticker.sql"
+user				        "mpd"
+bind_to_address		  "any"
+
+input {
+  plugin            "curl"
+}
+decoder {
+  plugin            "hybrid_dsd"
+  enabled           "no"
+}
+audio_output {
+	type		          "pulse"
+	name		          "Sink #1"
+}
+filesystem_charset	"UTF-8"
+

--- a/modules/ocf_tv/files/mpd.conf
+++ b/modules/ocf_tv/files/mpd.conf
@@ -1,12 +1,12 @@
 music_directory     "/var/lib/mpd/music"
 playlist_directory  "/var/lib/mpd/playlists"
-db_file			        "/var/lib/mpd/tag_cache"
+db_file             "/var/lib/mpd/tag_cache"
 log_file            "/var/log/mpd/mpd.log"
 pid_file            "/run/mpd/pid"
 state_file          "/var/lib/mpd/state"
 sticker_file        "/var/lib/mpd/sticker.sql"
-user				        "mpd"
-bind_to_address		  "any"
+user                "mpd"
+bind_to_address     "any"
 
 input {
   plugin            "curl"
@@ -16,8 +16,8 @@ decoder {
   enabled           "no"
 }
 audio_output {
-	type		          "pulse"
-	name		          "Sink #1"
+	type              "pulse"
+	name              "Sink #1"
 }
-filesystem_charset	"UTF-8"
+filesystem_charset  "UTF-8"
 

--- a/modules/ocf_tv/files/pulseaudio.service
+++ b/modules/ocf_tv/files/pulseaudio.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=PulseAudio service
 Requires=network-online.target
-After=nodm.service
+After=lightdm.service
 
 [Service]
 User=ocftv

--- a/modules/ocf_tv/files/x11vnc.service
+++ b/modules/ocf_tv/files/x11vnc.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=X11 VNC service
 Requires=network-online.target
-After=nodm.service
+After=lightdm.service
 
 [Service]
 User=ocftv

--- a/modules/ocf_tv/manifests/init.pp
+++ b/modules/ocf_tv/manifests/init.pp
@@ -18,7 +18,9 @@ class ocf_tv {
       'ffmpeg',
       'feh',
       'i3',
-      'nodm',
+      'lightdm'
+      'mpc',
+      'mpd',
       'python3-usb',
       'vlc',
       'x11vnc',
@@ -40,6 +42,9 @@ class ocf_tv {
       owner   => ocftv,
       group   => ocftv,
       require => User['ocftv'];
+    
+    '/etc/mpd.conf':
+      source => 'puppet:///modules/ocf_tv/mpd.conf';
 
     '/etc/X11/xorg.conf':
       source => 'puppet:///modules/ocf_tv/X11/xorg.conf';
@@ -60,7 +65,7 @@ class ocf_tv {
   ocf::systemd::service { 'x11vnc':
     source  => 'puppet:///modules/ocf_tv/x11vnc.service',
     require => [
-      Package['x11vnc', 'nodm'],
+      Package['x11vnc', 'lightdm'],
       User['ocftv'],
     ],
   }

--- a/modules/ocf_tv/manifests/init.pp
+++ b/modules/ocf_tv/manifests/init.pp
@@ -28,10 +28,14 @@ class ocf_tv {
     ]:;
   }
 
+  group { 'autologin':
+    system  => true;
+  }
+
   user { 'ocftv':
     comment => 'TV NUC',
     home    => '/opt/tv',
-    groups  => ['sys', 'audio'],
+    groups  => ['sys', 'audio', 'autologin'],
     shell   => '/bin/bash';
   }
 

--- a/modules/ocf_tv/manifests/init.pp
+++ b/modules/ocf_tv/manifests/init.pp
@@ -46,6 +46,9 @@ class ocf_tv {
     '/etc/mpd.conf':
       source => 'puppet:///modules/ocf_tv/mpd.conf';
 
+    '/etc/lightdm/lightdm.conf':
+      source => 'puppet:///modules/ocf_tv/lightdm.conf';
+
     '/etc/X11/xorg.conf':
       source => 'puppet:///modules/ocf_tv/X11/xorg.conf';
 

--- a/modules/ocf_tv/manifests/init.pp
+++ b/modules/ocf_tv/manifests/init.pp
@@ -42,7 +42,7 @@ class ocf_tv {
       owner   => ocftv,
       group   => ocftv,
       require => User['ocftv'];
-    
+
     '/etc/mpd.conf':
       source => 'puppet:///modules/ocf_tv/mpd.conf';
 

--- a/modules/ocf_tv/manifests/init.pp
+++ b/modules/ocf_tv/manifests/init.pp
@@ -44,10 +44,12 @@ class ocf_tv {
       require => User['ocftv'];
 
     '/etc/mpd.conf':
-      source => 'puppet:///modules/ocf_tv/mpd.conf';
+      source  => 'puppet:///modules/ocf_tv/mpd.conf',
+      require => Package['mpd'];
 
     '/etc/lightdm/lightdm.conf':
-      source => 'puppet:///modules/ocf_tv/lightdm.conf';
+      source  => 'puppet:///modules/ocf_tv/lightdm.conf',
+      require => Package['lightdm'];
 
     '/etc/X11/xorg.conf':
       source => 'puppet:///modules/ocf_tv/X11/xorg.conf';

--- a/modules/ocf_tv/manifests/init.pp
+++ b/modules/ocf_tv/manifests/init.pp
@@ -18,7 +18,7 @@ class ocf_tv {
       'ffmpeg',
       'feh',
       'i3',
-      'lightdm'
+      'lightdm',
       'mpc',
       'mpd',
       'python3-usb',


### PR DESCRIPTION
Should fix #887. However, I don't know if these changes don't cover all the things @encadyma mentions in the issue (yet). Could use some advice with:
*  create group name autologin, add ocftv to group (how should I go about doing this)
*  change ocf-tv script to remove hardcoded sink value (where is this and what is the alternative - since the sink value is also hardcoded in `mpd.conf`)

Also, will the systemd require make sure lightdm starts before X11?