### PR TITLE
Revert "ocf-netboot: use fqdn for tftp"

### DIFF
--- a/modules/ocf_dhcp/files/netboot/ocf-netboot
+++ b/modules/ocf_dhcp/files/netboot/ocf-netboot
@@ -96,20 +96,17 @@ for dist in "${dists[@]}"; do
         # Add OCF install options, set as default if menu dist and arch
         # The first item overwrites the existing install menu option, as we do
         # not want it (would like to use our own instead)
-        #
-        # TODO: Figure out why domain is set wrong in /etc/resolv.conf during
-        # installation, hence the FQDN for dhcp.
         if [ "$dist" == "$menu_dist" ] && [ "$arch" == "$menu_arch" ]; then
             echo "label ocf-$label
                 menu label OCF Automated Install ($label)
                 menu default
                 kernel debian-installer/$arch/linux
-                append auto=true priority=critical locale=en_US keymap=us vga=788 initrd=debian-installer/$arch/initrd.gz url=tftp://dhcp.ocf.berkeley.edu/preseed/$dist -- quiet" > $txt_cfg
+                append auto=true priority=critical locale=en_US keymap=us vga=788 initrd=debian-installer/$arch/initrd.gz url=tftp://dhcp/preseed/$dist -- quiet" > $txt_cfg
         else
             echo "label ocf-$label
                 menu label OCF Automated Install ($label)
                 kernel $da_dir/debian-installer/$arch/linux
-                append auto=true priority=critical locale=en_US keymap=us vga=788 initrd=$da_dir/debian-installer/$arch/initrd.gz url=tftp://dhcp.ocf.berkeley.edu/preseed/$dist -- quiet" >> $txt_cfg
+                append auto=true priority=critical locale=en_US keymap=us vga=788 initrd=$da_dir/debian-installer/$arch/initrd.gz url=tftp://dhcp/preseed/$dist -- quiet" >> $txt_cfg
         fi
     done
 done


### PR DESCRIPTION
Reverts ocf/puppet#916.

This should be fixed now that we have blocked incoming router advertisements at the switch level. I tested this and it seems good.