### PR TITLE
Add hieradata for quarantine

### DIFF
--- a/hieradata/nodes/quarantine.yaml
+++ b/hieradata/nodes/quarantine.yaml
@@ -1,0 +1,5 @@
+# Enable outside operator users to login
+ocf::auth::ulogin: [["%{lookup('owner')}", 'ALL']]
+
+# Temp owner to kmo
+owner: kmo


### PR DESCRIPTION
If the Minecraft builders are still interested in `quarantine`, we should add them as entires to `ocf::auth::ulogin`.