### PR TITLE
mirrors: move ocfstats db password to a file

### DIFF
--- a/modules/ocf_mirrors/files/collect-mirrors-stats
+++ b/modules/ocf_mirrors/files/collect-mirrors-stats
@@ -15,7 +15,7 @@ from pathlib import Path
 from ocflib.lab.stats import get_connection
 from ocflib.lab.stats import humanize_bytes
 
-OCFSTATS_PWD = os.environ.get('OCFSTATS_PWD', None)
+OCFSTATS_PWD = open(os.environ.get('OCFSTATS_PWD__FILE')).read().strip()
 MIRRORS_DATA_PATH = Path('/opt/mirrors/ftp')
 APACHE_LOG_PATH = Path('/var/log/apache2')
 APACHE_LOG_FILES = [

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -182,15 +182,23 @@ class ocf_mirrors {
     mode   => '0755',
   }
 
-  file { '/usr/local/sbin/collect-mirrors-stats':
-    source => 'puppet:///modules/ocf_mirrors/collect-mirrors-stats',
-    mode   => '0755',
+  file {
+    '/opt/ocfstats-password':
+      content   => lookup('ocfstats::mysql::password'),
+      mode      => '0600',
+      owner     => 'root',
+      group     => 'root',
+      show_diff => false;
+
+    '/usr/local/sbin/collect-mirrors-stats':
+      source => 'puppet:///modules/ocf_mirrors/collect-mirrors-stats',
+      mode   => '0755';
   } ->
   cron { 'mirrors-stats':
     command     => '/usr/local/sbin/collect-mirrors-stats --quiet --no-dry-run',
     minute      => 0,
     hour        => 0,
-    environment => ["OCFSTATS_PWD=${ocfstats_password}"];
+    environment => ['OCFSTATS_PWD__FILE=/opt/ocfstats-password'];
   }
 
   package { ['python3-prometheus-client']: }


### PR DESCRIPTION
`OCFSTATS_PWD` was showing up in fallingrocks' root crontab as an environment variable and got leaked on stream. This change moves it to a file which protects it from these kinds of leaks. The `__FILE` suffix for environment variables is borrowed from Grafana's convention.

Tested and working on fallingrocks.