### PR TITLE
rsyncd performance improvements

### DIFF
--- a/modules/ocf_mirrors/files/rsyncd.conf
+++ b/modules/ocf_mirrors/files/rsyncd.conf
@@ -7,7 +7,7 @@ list = yes
 timeout = 60
 max connections = 100
 socket options = SO_KEEPALIVE
-dont compress = *.gz *.tgz *.zip *.z *.rpm *.deb *.iso *.bz2 *.tbz
+dont compress = *.gz *.tgz *.zip *.z *.rpm *.deb *.iso *.bz2 *.tbz *.zst *.xz
 
 [apache]
 	comment = apache project mirror

--- a/modules/ocf_mirrors/files/rsyncd.conf
+++ b/modules/ocf_mirrors/files/rsyncd.conf
@@ -8,6 +8,7 @@ timeout = 60
 max connections = 100
 socket options = SO_KEEPALIVE
 dont compress = *.gz *.tgz *.zip *.z *.rpm *.deb *.iso *.bz2 *.tbz *.zst *.xz
+reverse lookup = no
 
 [apache]
 	comment = apache project mirror


### PR DESCRIPTION
- By default rsyncd compresses files it serves. Skipping already-compressed files saves CPU and reduces latency.
- For a read-only rsync server, logging visitors' reverse DNS addresses is unnecessary.