### PR TITLE
bump websocket timeouts in k8s lb

### DIFF
--- a/modules/ocf_kubernetes/templates/master/loadbalancer/haproxy.cfg.erb
+++ b/modules/ocf_kubernetes/templates/master/loadbalancer/haproxy.cfg.erb
@@ -12,6 +12,7 @@ defaults
   timeout connect 10s
   timeout client 30s
   timeout server 30s
+  timeout tunnel 60s
   option httplog
   log global
   option redispatch


### PR DESCRIPTION
I still need to test this, but this should keep the mastodon websocket from timing out.