### PR TITLE
Increase CPU limits for ssh

### DIFF
--- a/modules/ocf/files/limits.conf
+++ b/modules/ocf/files/limits.conf
@@ -1,7 +1,8 @@
 # <domain> <type> <item> <value>
 @ocf hard as 10000000
 @ocf hard core 0
-@ocf hard cpu 30
+@ocf soft cpu 60
+@ocf hard cpu 1440
 @ocf hard nproc 250
 @ocf hard stack 4096
 


### PR DESCRIPTION
This would let users run more long-running jobs on tsunami, while still hopefully preventing accidental runaway resource hogs. 