### PR TITLE
add ripgrep to extrapackages

### DIFF
--- a/modules/ocf/manifests/extrapackages.pp
+++ b/modules/ocf/manifests/extrapackages.pp
@@ -190,6 +190,7 @@ class ocf::extrapackages {
     'r10k',
     'rails',
     'rbenv',
+    'ripgrep',
     'ruby-build',
     'ruby-dev',
     'ruby-fcgi',


### PR DESCRIPTION
I made this bar graph to illustrate why we need ripgrep:

![IMG_0022](https://user-images.githubusercontent.com/2773700/80152576-cbc8fe80-8570-11ea-8fd3-366dcf7f7836.jpg)

As we can see, the bar for rg is bigger, so we need it.