### PR TITLE
Unpin puppetdb-termini (#956)

### DIFF
--- a/modules/ocf_ocfweb/manifests/dev_config.pp
+++ b/modules/ocf_ocfweb/manifests/dev_config.pp
@@ -22,15 +22,7 @@ class ocf_ocfweb::dev_config($group = 'ocfstaff') {
 
   # Install some packages for generating puppet diffs
   # TODO: Move this somewhere else alongside the puppet certs added below
-  package {
-    'octocatalog-diff':;
-
-    # Newer puppetdb-termini versions (6.5.0-1stretch for instance) have an
-    # issue with CRLs when used with octocatalog-diff, so pin this to 6.4.0 for
-    # now
-    'puppetdb-termini':
-      ensure => '6.4.0-1stretch';
-  }
+  package { ['octocatalog-diff', 'puppetdb-termini']:; }
 
   file {
     '/etc/ocfweb':


### PR DESCRIPTION
With https://github.com/ocf/octocatalog-diff/commit/65e4280fb683a8641f791eab91ef4cd2e9edd709 this should be fixed, and I've tested it on both stretch and buster and it seems to work fine with the newer `puppetdb-termini` packages.

This also should unblock moving staff VMs that include `ocf_ocfweb::dev_config` to buster, since puppet on them should be fixed after this (e.g. on `fireball` right now it's failing to run puppet due to this pin):

```
(/Stage[main]/Ocf_ocfweb::Dev_config/Package[puppetdb-termini]/ensure) change from '6.10.0-1buster' to '6.4.0-1stretch' failed: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold --force-yes install puppetdb-termini=6.4.0-1stretch' returned 100: Reading package lists...
(/Stage[main]/Ocf_ocfweb::Dev_config/Package[puppetdb-termini]/ensure) Building dependency tree...
(/Stage[main]/Ocf_ocfweb::Dev_config/Package[puppetdb-termini]/ensure) Reading state information...
(/Stage[main]/Ocf_ocfweb::Dev_config/Package[puppetdb-termini]/ensure) W: --force-yes is deprecated, use one of the options starting with --allow instead.
(/Stage[main]/Ocf_ocfweb::Dev_config/Package[puppetdb-termini]/ensure) E: Version '6.4.0-1stretch' for 'puppetdb-termini' was not found (corrective)
Applied catalog in 16.79 seconds
```