### PR TITLE
Run lets-encrypt-update after the hour so it gets build-vhosts updates

### DIFF
--- a/modules/ocf_www/manifests/lets_encrypt.pp
+++ b/modules/ocf_www/manifests/lets_encrypt.pp
@@ -19,7 +19,10 @@ class ocf_www::lets_encrypt {
       command     => 'chronic /usr/local/bin/lets-encrypt-update -v web',
       user        => ocfletsencrypt,
       environment => ['MAILTO=root', 'PATH=/bin:/usr/bin:/usr/local/bin'],
-      special     => hourly,
+      # Run 5 minutes past the hour to allow for build-vhosts to be run so as
+      # to minimize the time between a vhost being configured and getting HTTPS
+      # enabled
+      minute      => 5,
       require     => [File['/usr/local/bin/lets-encrypt-update'],
                       Ocf::Privatefile['/etc/ssl/lets-encrypt/le-vhost.key']],
     }


### PR DESCRIPTION
I noticed when looking into the process of adding new vhosts that they get added and then have to wait for around an hour to get HTTPS enabled. By shifting this cronjob to be 5 minutes after the hour instead of on the hour it should allow for `build-vhosts` to finish (~ 1.5 minutes when I ran it manually) before `lets-encrypt-update` is run, meaning that vhosts get HTTPS much earlier. Also, given they aren't available over plain HTTP any more (since https://github.com/ocf/puppet/pull/496 was merged), this means that this should make new vhosts actually available more quickly.

We could also maybe run `build-vhosts` more frequently than once an hour, but I'm not sure we'd want to run `lets-encrypt-update` too frequently as we probably have some API limits with Let's Encrypt that we don't want to go over.