### PR TITLE
Rename devuan to devuan-cd

### DIFF
--- a/modules/ocf_mirrors/files/project/devuan-cd/sync-archive
+++ b/modules/ocf_mirrors/files/project/devuan-cd/sync-archive
@@ -1,3 +1,3 @@
 #!/bin/sh -eu
 /usr/local/bin/rsync-no-vanished --delete -raX \
-	files.devuan.org::devuan /opt/mirrors/ftp/devuan
+	files.devuan.org::devuan /opt/mirrors/ftp/devuan-cd

--- a/modules/ocf_mirrors/files/rsyncd.conf
+++ b/modules/ocf_mirrors/files/rsyncd.conf
@@ -61,10 +61,10 @@ reverse lookup = no
 	path = /opt/mirrors/ftp/debian-cd
 	log file = /var/log/rsync/debian-cd.log
 
-[devuan]
-	comment = devuan mirror
-	path = /opt/mirrors/ftp/devuan
-	log file = /var/log/rsync/devuan.log
+[devuan-cd]
+	comment = devuan-cd mirror
+	path = /opt/mirrors/ftp/devuan-cd
+	log file = /var/log/rsync/devuan-cd.log
 
 [finnix]
 	comment = finnix releases mirror

--- a/modules/ocf_mirrors/manifests/projects/devuan.pp
+++ b/modules/ocf_mirrors/manifests/projects/devuan.pp
@@ -1,20 +1,18 @@
 class ocf_mirrors::projects::devuan {
   file {
-    '/opt/mirrors/project/devuan':
+    '/opt/mirrors/project/devuan-cd':
       ensure  => directory,
-      source  => 'puppet:///modules/ocf_mirrors/project/devuan',
+      source  => 'puppet:///modules/ocf_mirrors/project/devuan-cd',
       owner   => mirrors,
       group   => mirrors,
       mode    => '0755',
       recurse => true;
   }
 
-# Looks like devuan doesn't have a timestamp file, so omitted ocf_mirrors::monitoring
-
-  ocf_mirrors::timer { 'devuan':
-    exec_start => '/opt/mirrors/project/devuan/sync-archive',
+  ocf_mirrors::timer { 'devuan-cd':
+    exec_start => '/opt/mirrors/project/devuan-cd/sync-archive',
     hour       => '0/6',
     minute     => '57',
-    require    => File['/opt/mirrors/project/devuan'];
+    require    => File['/opt/mirrors/project/devuan-cd'];
   }
 }


### PR DESCRIPTION
I talked to the devuan maintainers and it seems we'd be really useful as a package mirror, so that's definitely a todo for the future.