### PR TITLE
Change mirror to RuntimeMaxSec instead

### DIFF
--- a/modules/ocf_mirrors/templates/systemd/sync.service.erb
+++ b/modules/ocf_mirrors/templates/systemd/sync.service.erb
@@ -9,4 +9,4 @@ Environment="<%= env %>=<%= val %>"
 <% end -%>
 ExecStart=<%= @exec_start %>
 # one day should be good enough for anyone
-TimeoutStartSec=86400
+RuntimeMaxSec=86400


### PR DESCRIPTION
not tested yet~

I think this is the behavior we want? Since it's actually that the script runs but hangs forever.

This might affect initial syncs though since those can take a while, so it might be good to separate the healthchecks and sync service files.