### PR TITLE
Revert "log outbound request on death"

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -29,8 +29,6 @@ internal_zone_exceptions:
     - dev-death
 
 # IPv4 and IPv6 src ranges for types of servers
-ocf_ipv4_mask: 169.229.226.0/24
-ocf_ipv6_mask: 2607:f140:8801::/48
 internal_zone_range_4: 169.229.226.3-169.229.226.90
 desktop_src_range_4: 169.229.226.100-169.229.226.139
 staffvm_src_range_4: 169.229.226.200-169.229.226.252

--- a/modules/ocf_www/files/iptables-log.conf
+++ b/modules/ocf_www/files/iptables-log.conf
@@ -1,5 +1,0 @@
-# Send iptables logs to a separate file
-# Must come before others to prevent other rules from recording first
-:msg, contains, "[iptables-outbound] " /var/log/iptables.log
-# Prevent other rules from matching messages already recorded
-& ~

--- a/modules/ocf_www/files/iptables-logrotate
+++ b/modules/ocf_www/files/iptables-logrotate
@@ -1,8 +1,0 @@
-# Logrotate configuration for logging iptables
-/var/log/iptables-outbound.log {
-	weekly
-	missingok
-	rotate 5
-	compress
-	compresscmd gzip
-}

--- a/modules/ocf_www/manifests/logging.pp
+++ b/modules/ocf_www/manifests/logging.pp
@@ -7,25 +7,6 @@ class ocf_www::logging {
     require => Package['nfs-kernel-server'],
   }
 
-  $ocf_ipv4_mask = lookup('ocf_ipv4_mask')
-  $ocf_ipv6_mask = lookup('ocf_ipv6_mask')
-  # log outbound requests
-  firewall_multi {
-    default:
-        chain      => 'PUPPET-OUTPUT',
-        outiface   => '! lo',
-        jump       => 'LOG',
-        log_prefix => '[iptables-outbound] ',
-        log_level  => 7,
-        log_uid    => true;
-    '101 log outbound request on death (v4)':
-        provider    => 'iptables',
-        destination => "! ${ocf_ipv4_mask}";
-    '101 log outbound request on death (v6)':
-        provider    => 'ip6tables',
-        destination => "! ${ocf_ipv6_mask}";
-  }
-
   file {
     '/etc/exports':
       source  => 'puppet:///modules/ocf_www/exports',
@@ -36,12 +17,6 @@ class ocf_www::logging {
     '/var/log/apache2':
       mode    => '0755',
       require => Package['httpd'];
-
-    # Redirect iptables logs to different file
-    '/etc/rsyslog.d/iptables-log.conf':
-      source  => 'puppet:///modules/ocf_www/iptables-log.conf',
-      require => Package['rsyslog'],
-      notify  => Service['rsyslog'],
   }
 
   # logrotate config
@@ -55,10 +30,6 @@ class ocf_www::logging {
     ],
     require => Package['logrotate', 'httpd'],
     notify  => Exec['apache2-logrotate-once'],
-  }
-  file { '/etc/logrotate.d/iptables':
-    source  => 'puppet:///modules/ocf_www/iptables-logrotate',
-    require => Package['logrotate', 'rsyslog'],
   }
 
   # If we change the logrotate permissions, we should force a rotate once so


### PR DESCRIPTION
Reverts ocf/puppet#962

I'm reverting this for now since it filled up the disk on death in no time, and the syslog redirection doesn't seem to work as expected.