### PR TITLE
log outbound requests on death (v2)

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -29,6 +29,8 @@ internal_zone_exceptions:
     - dev-death
 
 # IPv4 and IPv6 src ranges for types of servers
+ocf_ipv4_mask: 169.229.226.0/24
+ocf_ipv6_mask: 2607:f140:8801::/48
 internal_zone_range_4: 169.229.226.3-169.229.226.90
 desktop_src_range_4: 169.229.226.100-169.229.226.139
 staffvm_src_range_4: 169.229.226.200-169.229.226.252

--- a/modules/ocf_www/files/iptables-log.conf
+++ b/modules/ocf_www/files/iptables-log.conf
@@ -1,0 +1,4 @@
+# Send iptables logs to a separate file
+# Must come before others to prevent other rules from recording first
+:msg,contains,"[iptables] " /var/log/iptables.log
+& ~

--- a/modules/ocf_www/files/iptables-log.conf
+++ b/modules/ocf_www/files/iptables-log.conf
@@ -1,5 +1,5 @@
 # Send iptables logs to a separate file
 # Must come before others to prevent other rules from recording first
 :msg, contains, "[iptables-outbound] " /var/log/iptables.log
-# Clear all messages already recorded
+# Prevent other rules from matching messages already recorded
 & ~

--- a/modules/ocf_www/files/iptables-log.conf
+++ b/modules/ocf_www/files/iptables-log.conf
@@ -2,4 +2,4 @@
 # Must come before others to prevent other rules from recording first
 :msg, contains, "[iptables-outbound] " /var/log/iptables.log
 # Prevent other rules from matching messages already recorded
-& ~
+& stop

--- a/modules/ocf_www/files/iptables-log.conf
+++ b/modules/ocf_www/files/iptables-log.conf
@@ -1,4 +1,5 @@
 # Send iptables logs to a separate file
 # Must come before others to prevent other rules from recording first
-:msg,contains,"[iptables] " /var/log/iptables.log
+:msg, contains, "[iptables-outbound] " /var/log/iptables.log
+# Clear all messages already recorded
 & ~

--- a/modules/ocf_www/files/iptables-logrotate
+++ b/modules/ocf_www/files/iptables-logrotate
@@ -4,5 +4,5 @@
 	missingok
 	rotate 5
 	compress
-	compresscmd xz
+	compresscmd gzip
 }

--- a/modules/ocf_www/files/iptables-logrotate
+++ b/modules/ocf_www/files/iptables-logrotate
@@ -1,0 +1,8 @@
+# Logrotate configuration for logging iptables
+/var/log/iptables-outbound.log {
+	weekly
+	missingok
+	rotate 5
+	compress
+	compresscmd xz
+}

--- a/modules/ocf_www/files/iptables-logrotate
+++ b/modules/ocf_www/files/iptables-logrotate
@@ -1,8 +1,8 @@
 # Logrotate configuration for logging iptables
-/var/log/iptables-outbound.log {
-	weekly
+/var/log/iptables.log {
+	daily
 	missingok
-	rotate 5
+	rotate 30
 	compress
 	compresscmd gzip
 }

--- a/modules/ocf_www/manifests/logging.pp
+++ b/modules/ocf_www/manifests/logging.pp
@@ -7,6 +7,29 @@ class ocf_www::logging {
     require => Package['nfs-kernel-server'],
   }
 
+  # log outbound requests
+  firewall_multi {
+    '101 log outbound request on death (v4)':
+        provider    => 'iptables',
+        chain       => 'PUPPET-OUTPUT',
+        outiface    => '! lo',
+        jump        => 'LOG',
+        destination => '! 169.229.226.0/24',
+        log_prefix  => '[iptables] ',
+        log_level   => 7,
+        log_uid     => true;
+
+    '101 log outbound request on death (v6)':
+        provider    => 'ip6tables',
+        chain       => 'PUPPET-OUTPUT',
+        outiface    => '! lo',
+        jump        => 'LOG',
+        destination => '! 2607:f140:8801::/48',
+        log_prefix  => '[iptables] ',
+        log_level   => 7,
+        log_uid     => true;
+  }
+
   file {
     '/etc/exports':
       source  => 'puppet:///modules/ocf_www/exports',
@@ -17,6 +40,12 @@ class ocf_www::logging {
     '/var/log/apache2':
       mode    => '0755',
       require => Package['httpd'];
+
+    # Redirect iptables logs to different file
+    '/etc/rsyslog.d/iptables-log.conf':
+      source  => 'puppet:///modules/ocf_www/iptables-log.conf',
+      require => Package['rsyslog'],
+      notify  => Service['rsyslog'],
   }
 
   # logrotate config

--- a/modules/ocf_www/manifests/logging.pp
+++ b/modules/ocf_www/manifests/logging.pp
@@ -15,7 +15,7 @@ class ocf_www::logging {
         outiface    => '! lo',
         jump        => 'LOG',
         destination => '! 169.229.226.0/24',
-        log_prefix  => '[iptables] ',
+        log_prefix  => '[iptables-outbound] ',
         log_level   => 7,
         log_uid     => true;
 
@@ -25,7 +25,7 @@ class ocf_www::logging {
         outiface    => '! lo',
         jump        => 'LOG',
         destination => '! 2607:f140:8801::/48',
-        log_prefix  => '[iptables] ',
+        log_prefix  => '[iptables-outbound] ',
         log_level   => 7,
         log_uid     => true;
   }

--- a/modules/ocf_www/manifests/logging.pp
+++ b/modules/ocf_www/manifests/logging.pp
@@ -14,6 +14,7 @@ class ocf_www::logging {
     default:
         chain      => 'PUPPET-OUTPUT',
         outiface   => '! lo',
+        state      => ['NEW'],
         jump       => 'LOG',
         log_prefix => '[iptables-outbound] ',
         log_level  => 7,


### PR DESCRIPTION
following from #962  and #970 

mostly changes were made to rotate more frequently and only keep track of new connections

I tested this on death and it seems to not blow up

