### PR TITLE
install molly-guard everywhere

### DIFF
--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -95,6 +95,7 @@ class ocf::packages {
       'jq',
       'lsof',
       'man-db',
+      'molly-guard',
       'moreutils',
       'mtr',
       'ncdu',


### PR DESCRIPTION
rebooting isn't too common, this intercepts `reboot` and `shutdown` when executed over ssh and asks you to type the hostname to confirm

prevents accidental reboots of the hypervisors, which take a while