### PR TITLE
Automatic security updates

### DIFF
--- a/modules/ocf/files/apt/02periodic
+++ b/modules/ocf/files/apt/02periodic
@@ -1,0 +1,5 @@
+APT::Periodic::Enable "1";
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Download-Upgradeable-Packages "1";
+APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::AutocleanInterval "21";

--- a/modules/ocf/files/apt/02periodic
+++ b/modules/ocf/files/apt/02periodic
@@ -1,5 +1,4 @@
 APT::Periodic::Enable "1";
 APT::Periodic::Update-Package-Lists "1";
-APT::Periodic::Download-Upgradeable-Packages "1";
 APT::Periodic::Unattended-Upgrade "1";
 APT::Periodic::AutocleanInterval "21";

--- a/modules/ocf/files/apt/50unattended-upgrades
+++ b/modules/ocf/files/apt/50unattended-upgrades
@@ -1,0 +1,5 @@
+Unattended-Upgrade::Origins-Pattern {
+        "origin=Debian,codename=${distro_codename},label=Debian-Security";
+};
+
+Unattended-Upgrade::Mail "root";

--- a/modules/ocf/manifests/apt.pp
+++ b/modules/ocf/manifests/apt.pp
@@ -1,5 +1,5 @@
 class ocf::apt($stage = 'first') {
-  package { ['aptitude', 'imvirt', 'apt-transport-https', 'lsb-release', 'ethtool']:; }
+  package { ['aptitude', 'imvirt', 'apt-transport-https', 'lsb-release', 'ethtool', 'unattended-upgrades']:; }
 
   class { '::apt':
     purge => {
@@ -104,10 +104,13 @@ class ocf::apt($stage = 'first') {
     source => 'https://apt.ocf.berkeley.edu/pubkey.gpg';
   }
 
-  # rt#4960: This cronjob was broken for several years and wasn't actually
-  # doing anything, so it's just been removed. Once this is gone off all hosts
-  # then this snippet can be removed too.
-  file { '/etc/cron.daily/ocf-apt':
-    ensure => 'absent',
+  # Configure automatic security upgrades
+  file {
+    '/etc/apt/apt.conf.d/50unattended-upgrades':
+      source  => 'puppet:///modules/ocf/apt/50unattended-upgrades';
+
+    '/etc/apt/apt.conf.d/02periodic':
+      source  => 'puppet:///modules/ocf/apt/02periodic';
   }
+
 }


### PR DESCRIPTION
Nice: running apt dater everytime a DSA comes out at 3am
Nicer: magic cron man updates them for us

EDIT: I didn't see #548 but this closes that