### PR TITLE
Change OpenBSD upstream to ftp4

### DIFF
--- a/modules/ocf_mirrors/files/project/openbsd/sync-archive
+++ b/modules/ocf_mirrors/files/project/openbsd/sync-archive
@@ -1,3 +1,3 @@
 #!/bin/sh -eu
 /usr/local/bin/rsync-no-vanished -azH --safe-links --delete-after --delay-updates --no-motd \
- rsync://ftp3.usa.openbsd.org/ftp /opt/mirrors/ftp/openbsd
+ rsync://ftp4.usa.openbsd.org/ftp /opt/mirrors/ftp/openbsd


### PR DESCRIPTION
ftp3 is very slow and ftp4 is not. This is the one on the website anyway: https://www.openbsd.org/ftp.html