### PR TITLE
mirrors: Restart on failure only

### DIFF
--- a/modules/ocf_mirrors/templates/systemd/monitor.service.erb
+++ b/modules/ocf_mirrors/templates/systemd/monitor.service.erb
@@ -1,7 +1,5 @@
 [Unit]
 Description=Healthcheck service for <%= @title %>
-StartLimitInterval=70
-StartLimitBurst=5
 
 [Service]
 User=<%= @exec_user %>
@@ -11,5 +9,3 @@ Environment="<%= env %>=<%= val %>"
 <% end -%>
 ExecStart=<%= @exec_start %>
 RuntimeMaxSec=10
-Restart=always
-RestartSec=5

--- a/modules/ocf_mirrors/templates/systemd/monitor.service.erb
+++ b/modules/ocf_mirrors/templates/systemd/monitor.service.erb
@@ -1,5 +1,7 @@
 [Unit]
 Description=Healthcheck service for <%= @title %>
+StartLimitInterval=70
+StartLimitBurst=5
 
 [Service]
 User=<%= @exec_user %>
@@ -9,3 +11,5 @@ Environment="<%= env %>=<%= val %>"
 <% end -%>
 ExecStart=<%= @exec_start %>
 RuntimeMaxSec=10
+Restart=on-failure
+RestartSec=5


### PR DESCRIPTION
This was causing all the healthchecks to restart even on success. Now they should only restart on failure which is the intended behavior.