### PR TITLE
Enable ptrace protection for browser sandbox

### DIFF
--- a/modules/ocf/manifests/browser_sandbox.pp
+++ b/modules/ocf/manifests/browser_sandbox.pp
@@ -1,0 +1,22 @@
+class ocf::browser_sandbox {
+  # Change kernel settings for the sandbox used by Brave, Chrome, and Firefox.
+  # Verify sandbox status at brave://sandbox, chrome://sandbox, about:support,
+  # respectively.
+  sysctl {
+    # Distributions like Debian currently disable unprivileged user namespaces
+    # by default to decrease the kernel attack surface for local privilege
+    # escalation. See Debian bug #898446. If kept disabled, Brave 1.2+ and
+    # Chrome will still enforce namespace sandboxing via their setuid-root
+    # helper executable. See brave/brave-browser#3420 and
+    # brave/brave-browser#6247. Firefox does not include a setuid-root binary,
+    # however, so unprivileged user namespaces are useful to have for
+    # defense in depth, but not critical. See
+    # <https://www.morbo.org/2018/05/linux-sandboxing-improvements-in_10.html>.
+    'kernel.unprivileged_userns_clone':
+      value => '1';
+    # Enable ptrace protection. Only allow ptrace from a parent process to its
+    # children or via CAP_SYS_PTRACE.
+    'kernel.yama.ptrace_scope':
+      value => '1';
+  }
+}

--- a/modules/ocf/manifests/packages/brave.pp
+++ b/modules/ocf/manifests/packages/brave.pp
@@ -1,5 +1,5 @@
 class ocf::packages::brave {
-  include ocf::userns
+  include ocf::browser_sandbox
 
   $browser_homepage = lookup('browser_homepage')
 

--- a/modules/ocf/manifests/packages/chrome.pp
+++ b/modules/ocf/manifests/packages/chrome.pp
@@ -1,5 +1,5 @@
 class ocf::packages::chrome {
-  include ocf::userns
+  include ocf::browser_sandbox
 
   $browser_homepage = lookup('browser_homepage')
 

--- a/modules/ocf/manifests/packages/firefox.pp
+++ b/modules/ocf/manifests/packages/firefox.pp
@@ -1,4 +1,6 @@
 class ocf::packages::firefox {
+  include ocf::browser_sandbox
+
   $browser_homepage = lookup('browser_homepage')
 
   package { 'firefox-esr':; }

--- a/modules/ocf/manifests/userns.pp
+++ b/modules/ocf/manifests/userns.pp
@@ -1,9 +1,0 @@
-class ocf::userns {
-  # On Debian userns is compiled-in but disabled by deafult.
-  # This is the recommended way to run Brave (and Chrome-based
-  # browsers) in sandboxed mode. Not running the browser as
-  # a sandbox is strongly discouraged as the user is at much
-  # greater risk.
-  # See more here: https://chromium.googlesource.com/chromium/src/+/lkcr/docs/linux_sandboxing.md#User-namespaces-sandbox
-  sysctl { 'kernel.unprivileged_userns_clone': value =>  '1' }
-}


### PR DESCRIPTION
Only allow ptrace from a parent process to its children or via
CAP_SYS_PTRACE.

To verify sandbox status for Brave, Chrome, Firefox see
brave://sandbox, chrome://sandbox, about:support, respectively.

Also describe disadvantages of enabling unprivileged user namespaces.
Distributions like Debian currently disable unprivileged user namespaces
by default to decrease the kernel attack surface for local privilege
escalation. See [Debian bug #898446][898446]. If kept disabled, Brave 1.2+ and
Chrome will still enforce namespace sandboxing via their setuid-root
helper executable. See brave/brave-browser#3420 and
brave/brave-browser#6247. Firefox does not include a setuid-root binary,
however, so unprivileged user namespaces are useful to have for
defence-in-depth, but not critical. See
<https://www.morbo.org/2018/05/linux-sandboxing-improvements-in_10.html>.

[898446]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=898446