### PR TITLE
Add prometheus-kube

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,15 +60,12 @@ pipeline {
 ', 4)[0..2].join('
 ')
               def url = createGist('octocatalog-diff-results.md', output, env.BUILD_URL)
-              output = summary + '
-**WARNING: Output is too long for a comment, posted to a gist instead**: ' + url
+              output = summary + '**WARNING: Output is too long for a comment, posted to a gist instead**: ' + url
             }
 
             // Add a link to Jenkins in the comment so it's easy to get back to
             // the full build and it's clear which build a comment goes with
-            pullRequestComment = output + "
-
-[Jenkins](${env.BUILD_URL})"
+            pullRequestComment = output + "[Jenkins](${env.BUILD_URL})"
             pullRequest.comment(pullRequestComment)
 
             if (status != 0) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,14 +56,19 @@ pipeline {
             if (output.length() > 65536) {
               // Get the first 3 lines from the output and still include them
               // in the comment as a kind of summary
-              def summary = output.split('\n', 4)[0..2].join('\n')
+              def summary = output.split('
+', 4)[0..2].join('
+')
               def url = createGist('octocatalog-diff-results.md', output, env.BUILD_URL)
-              output = summary + '\n**WARNING: Output is too long for a comment, posted to a gist instead**: ' + url
+              output = summary + '
+**WARNING: Output is too long for a comment, posted to a gist instead**: ' + url
             }
 
             // Add a link to Jenkins in the comment so it's easy to get back to
             // the full build and it's clear which build a comment goes with
-            pullRequestComment = output + "\n\n[Jenkins](${env.BUILD_URL})"
+            pullRequestComment = output + "
+
+[Jenkins](${env.BUILD_URL})"
             pullRequest.comment(pullRequestComment)
 
             if (status != 0) {
@@ -113,9 +118,7 @@ pipeline {
       emailNotification()
     }
     always {
-      node(label: 'slave') {
         ircNotification()
-      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,16 +56,14 @@ pipeline {
             if (output.length() > 65536) {
               // Get the first 3 lines from the output and still include them
               // in the comment as a kind of summary
-              def summary = output.split('
-', 4)[0..2].join('
-')
+              def summary = output.split('\n', 4)[0..2].join('\n')
               def url = createGist('octocatalog-diff-results.md', output, env.BUILD_URL)
-              output = summary + '**WARNING: Output is too long for a comment, posted to a gist instead**: ' + url
+              output = summary + '\n**WARNING: Output is too long for a comment, posted to a gist instead**: ' + url
             }
 
             // Add a link to Jenkins in the comment so it's easy to get back to
             // the full build and it's clear which build a comment goes with
-            pullRequestComment = output + "[Jenkins](${env.BUILD_URL})"
+            pullRequestComment = output + "\n\n[Jenkins](${env.BUILD_URL})"
             pullRequest.comment(pullRequestComment)
 
             if (status != 0) {

--- a/modules/ocf_kubernetes/manifests/master/loadbalancer.pp
+++ b/modules/ocf_kubernetes/manifests/master/loadbalancer.pp
@@ -27,6 +27,7 @@ class ocf_kubernetes::master::loadbalancer {
     'new',
     'pma',
     'printlist',
+    'prometheus-kube',
     'rt',
     'sourcegraph',
     'static',


### PR DESCRIPTION
This prometheus instance will run on Kubernetes so we get the benefit of stuff like service discovery. It's already running at prometheus.dev-kubernetes.ocf.berkeley.edu (query for `probe_success`). Maybe people have opinions about the name?