### PR TITLE
make ssl restart postgres

### DIFF
--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -32,12 +32,6 @@ class ocf_postgres {
       };
   }
 
-  service { 'postgresql':
-    ensure  => 'running',
-    enable  => true,
-    require => Class['postgresql::server'],
-  }
-
   Class['Ocf::Ssl::Default'] ~> Class['Postgresql::Server']
   Class['Ocf::Ssl::Default'] ~> Service['postgresql']
 

--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -31,8 +31,15 @@ class ocf_postgres {
         action => 'accept',
       };
   }
+  
+  service { 'postgresql':
+    ensure  => 'running',
+    enable  => true,
+    require => Class['postgresql::server'],
+  }
 
   Class['Ocf::Ssl::Default'] ~> Class['Postgresql::Server']
+  Class['Ocf::Ssl::Default'] ~> Service['postgresql']
 
   file {
     # copies proper .pgpass file for ocfbackups to authenticate on backup

--- a/modules/ocf_postgres/manifests/init.pp
+++ b/modules/ocf_postgres/manifests/init.pp
@@ -31,7 +31,7 @@ class ocf_postgres {
         action => 'accept',
       };
   }
-  
+
   service { 'postgresql':
     ensure  => 'running',
     enable  => true,


### PR DESCRIPTION
Previously we were finding that new certs weren't being applied. Old postgres means we need to manually restart to apply them.

You'd get a run log like this:

```
Info: Class[Ocf::Ssl::Default]: Scheduling refresh of Class[Postgresql::Server]
Info: Class[Postgresql::Server]: Scheduling refresh of Anchor[postgresql::server::start]
Info: Class[Postgresql::Server]: Scheduling refresh of Anchor[postgresql::server::end]
Notice: /Stage[main]/Postgresql::Server/Anchor[postgresql::server::start]: Triggered 'refresh' from 1 event
Notice: /Stage[main]/Postgresql::Server/Anchor[postgresql::server::end]: Triggered 'refresh' from 1 event
```

but the service does not restart:

```
● postgresql.service - PostgreSQL RDBMS
   Loaded: loaded (/lib/systemd/system/postgresql.service; enabled; vendor preset: enabled)
   Active: active (exited) since Mon 2020-07-27 19:12:21 PDT; 5h 18min ago
```

push for octocatalog diff