### PR TITLE
remove node requirement from post action

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
       emailNotification()
     }
     always {
-      node(label: 'slave') {
+      {
         ircNotification()
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,9 +113,7 @@ pipeline {
       emailNotification()
     }
     always {
-      {
         ircNotification()
-      }
     }
   }
 }


### PR DESCRIPTION
This may fix the double executor problem

For anyone reading this in the future declaring `agent {label:'slave'}` at the top of the file allocates one executor on the `slave` and runs it there. `node` is a similar declaration, except `node` is a stage level declaration and `agent` is pipeline-level.

Unfortunately, it seems that every time you redeclare this, a new executor is allocated, and all our builds with this post {} block (all of them basically) actually require TWO executors, with one being allocated near the end to send us some IRC notifications.

<img width="314" alt="image" src="https://user-images.githubusercontent.com/2563849/88692602-1cda1880-d0b3-11ea-952a-b38a7cd296be.png">

This is a huge problem when we do lots of concurrent builds e.g. full org-wide Jenkins rebuilds since it leads to executor starvation no matter how many executors you allocate, as all of them will be waiting for another executor to be free.

Removing this requirement causes the post actions to stay on the same executor (as per `agent`).

<img width="267" alt="image" src="https://user-images.githubusercontent.com/2563849/88693097-befa0080-d0b3-11ea-8e5a-01788f601bd4.png">

Unfortunately this is going to be tricky since Jenkins uses the pipeline defined in each branch but we fix this moving forward and backfill into other branches at some point.
