### PR TITLE
Revert "update jenkins apt repo key"

### DIFF
--- a/modules/ocf_jenkins/manifests/jenkins_apt.pp
+++ b/modules/ocf_jenkins/manifests/jenkins_apt.pp
@@ -1,6 +1,6 @@
 class ocf_jenkins::jenkins_apt {
   apt::key { 'jenkins':
-    id     => '62A9756BFD780C377CF24BA8FCEF32E745F2C3D5',
+    id     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
     source => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key';
   }
 


### PR DESCRIPTION
Reverts ocf/puppet#955

it's back

```
root@reaper:~# cat jenkins-ci.org.key.1 | gpg --import-options show-only --import
pub   dsa1024 2009-02-01 [SC]
      150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6
uid                      Kohsuke Kawaguchi <kk@kohsuke.org>
uid                      [jpeg image of size 3704]
uid                      Kohsuke Kawaguchi <kohsuke.kawaguchi@cloudbees.com>
uid                      Kohsuke Kawaguchi <kohsuke@cloudbees.com>
uid                      Kohsuke Kawaguchi <kkawaguchi@cloudbees.com>
sub   elg2048 2009-02-01 [E]
sub   rsa4096 2016-11-01 [S]

```