### PR TITLE
Disable network logging on tsunami

### DIFF
--- a/modules/ocf_ssh/manifests/init.pp
+++ b/modules/ocf_ssh/manifests/init.pp
@@ -3,7 +3,6 @@ class ocf_ssh {
   include ocf::extrapackages
   include ocf::hostkeys
   include ocf::limits
-  include ocf::netlog
   include ocf::firewall::allow_mosh
   include ocf::packages::cups
   include ocf::ssl::default


### PR DESCRIPTION
The investigation in rt#9297 has concluded

There's probably a bit of manual cleanup to do to stop it but this won't reapply it.