### PR TITLE
inspircd cert reload fixes

### DIFF
--- a/modules/ocf_irc/files/reload-ssl.sh
+++ b/modules/ocf_irc/files/reload-ssl.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-# Log into the IRC server and reload the SSL cert.
+# Send a signal to the server to make it reload certs
 
-# Use a random nick to ensure no collisions with users on the server
-nick=$(pwgen --secure --no-numerals 16 1)
-oper_pass=$(<"$1")
-
-(
-echo NICK $nick
-echo USER ocf-cert-reload 0 0 :Lets Encrypt cert reloading script
-sleep 2
-echo OPER ocf-cert-reload "$oper_pass"
-sleep 2
-echo REHASH -ssl
-echo QUIT
-) | nc 127.0.0.1 6667
+pid=`pgrep inspircd`
+echo "Reloading certs for inspircd pid: $pid"
+kill -SIGUSR1 $pid

--- a/modules/ocf_irc/templates/inspircd.conf.erb
+++ b/modules/ocf_irc/templates/inspircd.conf.erb
@@ -15,6 +15,7 @@
 #<module name="sqloper">
 <module name="ssl_gnutls">
 <module name="cap">
+<module name="sslrehashsignal">
 
 # Required/Recommended modules for anope
 <module name="alias">


### PR DESCRIPTION
See [here](https://irclogs.ocf.berkeley.edu/rebuild/2020-08-02#862506) for context

installing the module:
```
jaw@dev-flood:~$ sudo !!
sudo kill -SIGUSR1 27442
jaw@dev-flood:~$ sudo systemctl status inspircd
● inspircd.service - InspIRCd - Internet Relay Chat Daemon
   Loaded: loaded (/lib/systemd/system/inspircd.service; enabled; vendor preset: enabled)
  Drop-In: /etc/systemd/system/inspircd.service.d
           └─inspircd-group-restart.conf
   Active: active (running) since Sun 2020-08-02 22:52:06 PDT; 29min ago
     Docs: man:inspircd(8)
  Process: 27441 ExecStart=/usr/lib/inspircd/inspircd start (code=exited, status=0/SUCCESS)
  Process: 30821 ExecReload=/usr/lib/inspircd/inspircd rehash (code=exited, status=0/SUCCESS)
 Main PID: 27442 (inspircd)
    Tasks: 2 (limit: 2355)
   Memory: 2.7M
   CGroup: /system.slice/inspircd.service
           └─27442 /usr/sbin/inspircd --config=/etc/inspircd/inspircd.conf

Aug 02 22:52:06 dev-flood inspircd[27441]: [*] Loading module:        m_hidechans.so
Aug 02 22:52:06 dev-flood inspircd[27441]: [*] Loading module:        m_services_account.so
Aug 02 22:52:06 dev-flood inspircd[27441]: [*] Loading module:        m_spanningtree.so
Aug 02 22:52:06 dev-flood inspircd[27441]: [*] Loading module:        m_svshold.so
Aug 02 22:52:06 dev-flood inspircd[27441]: [*] Loading module:        m_sasl.so
Aug 02 22:52:06 dev-flood inspircd[27441]: InspIRCd is now running as 'irc.ocf.berkeley.edu'[531] with 524288 max open sockets
Aug 02 22:52:06 dev-flood systemd[1]: Started InspIRCd - Internet Relay Chat Daemon.
Aug 02 23:20:51 dev-flood systemd[1]: Reloading InspIRCd - Internet Relay Chat Daemon.
Aug 02 23:20:51 dev-flood inspircd[30821]: InspIRCd rehashed (pid: 27442).
Aug 02 23:20:51 dev-flood systemd[1]: Reloaded InspIRCd - Internet Relay Chat Daemon.
```

the new script:
```
jaw@dev-flood:~$ sudo /usr/local/bin/reload-ssl.sh
Reloading certs for inspircd pid: 27442
jaw@dev-flood:~$ sudo systemctl status inspircd   
● inspircd.service - InspIRCd - Internet Relay Chat Daemon
   Loaded: loaded (/lib/systemd/system/inspircd.service; enabled; vendor preset: enabled)
  Drop-In: /etc/systemd/system/inspircd.service.d
           └─inspircd-group-restart.conf
   Active: active (running) since Sun 2020-08-02 22:52:06 PDT; 41min ago
     Docs: man:inspircd(8)
  Process: 27441 ExecStart=/usr/lib/inspircd/inspircd start (code=exited, status=0/SUCCESS)
  Process: 434 ExecReload=/usr/lib/inspircd/inspircd rehash (code=exited, status=0/SUCCESS)
 Main PID: 27442 (inspircd)
    Tasks: 2 (limit: 2355)
   Memory: 2.9M
   CGroup: /system.slice/inspircd.service
           └─27442 /usr/sbin/inspircd --config=/etc/inspircd/inspircd.conf

Aug 02 22:52:06 dev-flood systemd[1]: Started InspIRCd - Internet Relay Chat Daemon.
Aug 02 23:20:51 dev-flood systemd[1]: Reloading InspIRCd - Internet Relay Chat Daemon.
Aug 02 23:20:51 dev-flood inspircd[30821]: InspIRCd rehashed (pid: 27442).
Aug 02 23:20:51 dev-flood systemd[1]: Reloaded InspIRCd - Internet Relay Chat Daemon.
Aug 02 23:28:52 dev-flood systemd[1]: Reloading InspIRCd - Internet Relay Chat Daemon.
Aug 02 23:28:52 dev-flood inspircd[31850]: InspIRCd rehashed (pid: 27442).
Aug 02 23:28:52 dev-flood systemd[1]: Reloaded InspIRCd - Internet Relay Chat Daemon.
Aug 02 23:32:19 dev-flood systemd[1]: Reloading InspIRCd - Internet Relay Chat Daemon.
Aug 02 23:32:19 dev-flood inspircd[434]: InspIRCd rehashed (pid: 27442).
```