### PR TITLE
Upgrade pre-commit hooks and add shellcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,6 @@ repos:
     rev: v2.1.0
     hooks:
     -   id: puppet-validate
-        # TODO: Remove this version pinning. The problem here seems to be that
-        # the Debian-packaged versions of the semantic_puppet gem
-        # (ruby-semantic-puppet package) cause some kind of error with locale
-        # loading for puppet validation. A bug probably needs to be opened with
-        # the Debian package maintainers or with semantic_puppet depending on
-        # who is actually causing the error.
-        additional_dependencies: ['puppet:<5']
     -   id: erb-validate
     -   id: puppet-lint
         args:
@@ -24,7 +17,7 @@ repos:
     -   id: r10k-validate
     -   id: ruby-validate
 -   repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v2.2.1
+    rev: v3.2.0
     hooks:
     -   id: check-added-large-files
     -   id: check-docstring-first
@@ -44,16 +37,16 @@ repos:
     -   id: trailing-whitespace
         exclude: \.preseed$
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.4.4
+    rev: v1.5.4
     hooks:
     -   id: autopep8
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.7
+    rev: 3.8.3
     hooks:
     - id: flake8
       language_version: python3.5
 -   repo: https://github.com/asottile/reorder_python_imports.git
-    rev: v1.4.0
+    rev: v2.3.5
     hooks:
     -   id: reorder-python-imports
 -   repo: local
@@ -64,3 +57,8 @@ repos:
         entry: ^\s*[A-Z][A-Za-z0-9:]+\s*{
         types: [puppet]
         exclude: ^manifests/
+-   repo: https://github.com/detailyang/pre-commit-shell.git
+    rev: v1.0.6
+    hooks:
+    -   id: shell-lint
+        exclude: ^(.deactivate.sh)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,8 @@ repos:
     -   id: r10k-validate
     -   id: ruby-validate
 -   repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v3.2.0
+    # We need to be using python3.6 by default before this can be upgraded to 3.x+
+    rev: v2.5.0
     hooks:
     -   id: check-added-large-files
     -   id: check-docstring-first
@@ -46,7 +47,8 @@ repos:
     - id: flake8
       language_version: python3.5
 -   repo: https://github.com/asottile/reorder_python_imports.git
-    rev: v2.3.5
+    # We need to be using python3.6 by default before this can be upgraded to 2.x+
+    rev: v1.9.0
     hooks:
     -   id: reorder-python-imports
 -   repo: local

--- a/modules/ocf/facts.d/ifaces-linked
+++ b/modules/ocf/facts.d/ifaces-linked
@@ -5,13 +5,12 @@ set -euo pipefail
 # that looks like a ethernet-like interface
 
 active_ifaces=()
-ifaces=$(ls /sys/class/net/ | grep ^en)
 
 # Only do this check if ethtool is actually installed
 if [ -f /sbin/ethtool ]; then
-    for iface in $ifaces; do
-        if /sbin/ethtool $iface | grep -q "Link detected: yes"; then
-            active_ifaces+=($iface)
+    for iface in /sys/class/net/en*; do
+        if /sbin/ethtool "$iface" | grep -q "Link detected: yes"; then
+            active_ifaces+=("$iface")
         fi
     done
 fi
@@ -19,8 +18,8 @@ fi
 # If no interface has been found that looks suitable, fall back to a sensible
 # default (the first ethernet-like interface on the system)
 
-if [ "${#active_ifaces[@]}" -ne 0 ]; then
-    echo "ifaces_linked=${active_ifaces[@]}"
+if [ "${#active_ifaces[*]}" -ne 0 ]; then
+    echo "ifaces_linked=${active_ifaces[*]}"
 else
     echo "ifaces_linked=${active_ifaces[0]}"
 fi

--- a/modules/ocf/facts.d/ifaces-linked
+++ b/modules/ocf/facts.d/ifaces-linked
@@ -9,8 +9,9 @@ active_ifaces=()
 # Only do this check if ethtool is actually installed
 if [ -f /sbin/ethtool ]; then
     for iface in /sys/class/net/en*; do
-        if /sbin/ethtool "$iface" | grep -q "Link detected: yes"; then
-            active_ifaces+=("$iface")
+        iface_name="$(basename $iface)"
+        if /sbin/ethtool "$iface_name" | grep -q "Link detected: yes"; then
+            active_ifaces+=("$iface_name")
         fi
     done
 fi

--- a/modules/ocf/facts.d/ifaces-linked
+++ b/modules/ocf/facts.d/ifaces-linked
@@ -9,7 +9,7 @@ active_ifaces=()
 # Only do this check if ethtool is actually installed
 if [ -f /sbin/ethtool ]; then
     for iface in /sys/class/net/en*; do
-        iface_name="$(basename $iface)"
+        iface_name=$(basename "$iface")
         if /sbin/ethtool "$iface_name" | grep -q "Link detected: yes"; then
             active_ifaces+=("$iface_name")
         fi

--- a/modules/ocf/files/mdraid/mdraid-cron
+++ b/modules/ocf/files/mdraid/mdraid-cron
@@ -11,7 +11,7 @@ tmp=$(mktemp -p /var/lib mdraid.XXXXXXXXXX)
     echo '====== Array information: ======'
     mdadm --detail --scan |
             awk '{print $2}' |
-            while read device; do
+            while read -r device; do
         echo "=== Details for device '$device' ==="
 
         # Normalize the output a bit; some of these values change constantly,

--- a/modules/ocf/files/packages/rsync-no-vanished
+++ b/modules/ocf/files/packages/rsync-no-vanished
@@ -20,10 +20,10 @@ IGNOREOUT='^(file has vanished: |rsync warning: some files vanished before they 
 
 set -o pipefail
 
-(rsync "${@}" 3>&2 2>&1 1>&3 | (egrep -v "$IGNOREOUT" || true)) 3>&2 2>&1 1>&3
+(rsync "${@}" 3>&2 2>&1 1>&3 | (grep -vE "$IGNOREOUT" || true)) 3>&2 2>&1 1>&3
 ret=$?
 
-if [[ $ret == $IGNOREEXIT ]]; then
+if [[ "$ret" == "$IGNOREEXIT" ]]; then
     ret=0
 fi
 

--- a/modules/ocf/files/shell/bash.bash_logout
+++ b/modules/ocf/files/shell/bash.bash_logout
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 klist &> /dev/null
 if [ $? = 0 ]; then
   kdestroy

--- a/modules/ocf/files/shell/bash.bashrc
+++ b/modules/ocf/files/shell/bash.bashrc
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Quit if no prompt
 [ -z "$PS1" ] && return
 

--- a/modules/ocf/files/shell/config.fish
+++ b/modules/ocf/files/shell/config.fish
@@ -1,3 +1,5 @@
+#!/usr/bin/fish
+
 # Quit if not interactive
 if not status --is-interactive
     exit

--- a/modules/ocf/files/shell/csh.cshrc
+++ b/modules/ocf/files/shell/csh.cshrc
@@ -1,3 +1,5 @@
+#!/bin/csh
+
 # Quit if no prompt
 if(! $?prompt) exit
 

--- a/modules/ocf/files/shell/csh.logout
+++ b/modules/ocf/files/shell/csh.logout
@@ -1,2 +1,4 @@
+#!/bin/csh
+
 klist >& /dev/null
 if ($? == 0) kdestroy

--- a/modules/ocf/files/shell/how_completion.bash
+++ b/modules/ocf/files/shell/how_completion.bash
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 _how () {
     COMPREPLY=()
 

--- a/modules/ocf/files/shell/zlogout
+++ b/modules/ocf/files/shell/zlogout
@@ -1,3 +1,5 @@
+#!/bin/zsh
+
 klist &> /dev/null
 if [ $? = 0 ]; then
   kdestroy

--- a/modules/ocf/files/shell/zshenv
+++ b/modules/ocf/files/shell/zshenv
@@ -1,3 +1,5 @@
+#!/bin/zsh
+
 # /etc/zsh/zshenv: system-wide .zshenv file for zsh(1).
 #
 # This file is sourced on all invocations of the shell.

--- a/modules/ocf/files/shell/zshrc
+++ b/modules/ocf/files/shell/zshrc
@@ -1,3 +1,5 @@
+#!/bin/zsh
+
 # /etc/zsh/zshrc: system-wide .zshrc file for zsh(1).
 #
 # This file is sourced only for interactive shells. It

--- a/modules/ocf_apt/files/bin/include-changes-from-stdin
+++ b/modules/ocf_apt/files/bin/include-changes-from-stdin
@@ -21,9 +21,10 @@ unzip -d "$tmpdir" "$tmpfile"
 # re-run a Jenkins job)
 # Use globbing (and also assume that there's exactly one file which matches the
 # glob)
-for pkg in $(sed 's/^Binary: //; t; d' "$tmpdir"/archive/$changes); do
+# shellcheck disable=SC2013
+for pkg in $(sed 's/^Binary: //; t; d' "${tmpdir}/archive/$changes"); do
 	/opt/apt/bin/reprepro remove "$dist" "$pkg"
 done
 
 /opt/apt/bin/reprepro --ignore=wrongdistribution include "$dist" \
-    "$tmpdir"/archive/$changes
+    "${tmpdir}/archive/$changes"

--- a/modules/ocf_backups/files/backup-mysql
+++ b/modules/ocf_backups/files/backup-mysql
@@ -10,6 +10,7 @@ set -euo pipefail
 databases=$(mysql --defaults-file=/opt/share/backups/my.cnf -e "SHOW databases;" | \
 		   grep -Ev "(Database|information_schema|performance_schema)")
 
+# shellcheck disable=SC1004,SC2016
 parallel -i \
     sh -c 'mysqldump \
              --defaults-file=/opt/share/backups/my.cnf \
@@ -17,4 +18,4 @@ parallel -i \
              --triggers \
              --routines \
              --single-transaction \
-             --databases {} | pigz > "mysql-{}-$(date +%F).sql.gz"' -- $databases
+             --databases {} | pigz > "mysql-{}-$(date +%F).sql.gz"' -- "$databases"

--- a/modules/ocf_backups/files/backup-pgsql
+++ b/modules/ocf_backups/files/backup-pgsql
@@ -3,4 +3,4 @@ set -euo pipefail
 
 # Dumps the entire PostgreSQL instance to one .sql file.
 # Requires that a valid ~/.pgpass file be available on the PostgreSQL host
-ssh -K ocfbackups@postgres 'pg_dumpall -U postgres -h localhost | pigz' > pgsql-all-$(date +%F).sql.gz
+ssh -K ocfbackups@postgres 'pg_dumpall -U postgres -h localhost | pigz' > "pgsql-all-$(date +%F).sql.gz"

--- a/modules/ocf_desktop/files/xsession/fix-audio
+++ b/modules/ocf_desktop/files/xsession/fix-audio
@@ -8,6 +8,6 @@ SINK="$(pacmd list-sinks | grep -E '\s+name: <.+analog-stereo>' | cut -d ' ' -f2
 pacmd unload-module module-device-restore
 pacmd unload-module module-stream-restore
 pacmd unload-module module-card-restore
-pacmd set-sink-port ${SINK:1:-1} analog-output-headphones
-pacmd set-sink-volume ${SINK:1:-1} 20480
-pacmd set-sink-mute ${SINK:1:-1} 0
+pacmd set-sink-port "${SINK:1:-1}" analog-output-headphones
+pacmd set-sink-volume "${SINK:1:-1}" 20480
+pacmd set-sink-mute "${SINK:1:-1}" 0

--- a/modules/ocf_desktop/files/xsession/lightdm/session-cleanup
+++ b/modules/ocf_desktop/files/xsession/lightdm/session-cleanup
@@ -2,9 +2,9 @@
 
 if [ -n "$USER" ]; then
   # Send user processes SIGTERM, then SIGKILL
-  pkill -u $USER
+  pkill -u "$USER"
   sleep 1
-  pkill -9 -u $USER
+  pkill -9 -u "$USER"
 fi
 
 sudo -u ocfstats /opt/stats/update-delay.sh cleanup &

--- a/modules/ocf_desktop/files/xsession/pdf-open
+++ b/modules/ocf_desktop/files/xsession/pdf-open
@@ -14,7 +14,7 @@ ft="${ft,,}"
 
 if [ "$ft" == "pdf" ]; then
     len=$(pdftk "$1" dump_data | awk '/NumberOfPages/{print $2}')
-    [ -z "$len" -o "$len" -gt 75 ] && { echo 'Too long, trying evince...'; exec evince "$1"; }
+    [ -z "$len" ] || [ "$len" -gt 75 ] && { echo 'Too long, trying evince...'; exec evince "$1"; }
 fi
 
 filename=$(basename "$1")
@@ -26,7 +26,7 @@ trap 'rm -rf "$tmpdir"' EXIT
 (
     # Because Zenity ...
     function clean_up {
-        [ -n "$(jobs -pr)" ] && kill $(jobs -pr)
+        [ -n "$(jobs -pr)" ] && kill "$(jobs -pr)"
     }
 
     trap clean_up EXIT

--- a/modules/ocf_desktop/files/xsession/print-notify-listener
+++ b/modules/ocf_desktop/files/xsession/print-notify-listener
@@ -9,6 +9,7 @@ icon=/opt/share/xsession/images/ocf-color-256.png
 [[ -p "$pipe" ]] && rm -f "$pipe"
 mkfifo "$pipe"
 
+# shellcheck disable=SC2024
 sudo -u ocfbroker /opt/share/puppet/print-notify-handler > "$pipe" &
 
 # listener
@@ -17,7 +18,7 @@ while true; do
     if [[ ! -p "$pipe" ]]; then
         break
     fi
-    if read -u 3 msg < "$pipe"; then
+    if read -r -u 3 msg < "$pipe"; then
 	    notify-send -i "$icon" "Print Job Status" "$msg"
     fi
 done

--- a/modules/ocf_dhcp/files/netboot/ocf-netboot
+++ b/modules/ocf_dhcp/files/netboot/ocf-netboot
@@ -64,29 +64,29 @@ for dist in "${dists[@]}"; do
 
         # Download and extract netboot image
         echo "Downloading netboot.tar.gz for $dist ($arch)..."
-        cd $tftpdir
+        cd "$tftpdir"
         wget -q -O netboot.tar.gz "$netboot"
-        mkdir -p $da_dir
-        tar -zxf netboot.tar.gz -C $da_dir
+        mkdir -p "$da_dir"
+        tar -zxf netboot.tar.gz -C "$da_dir"
 
         # Add non-free firmware to initrd if set
         if [ -n "$fw" ]; then
             echo "Downloading non-free firmware..."
-            cd $fwdir
+            cd "$fwdir"
             mkdir -p firmware
             wget -q "$fw"
-            cd $fwdir/firmware
+            cd "$fwdir/firmware"
             tar -zxf ../firmware.tar.gz
-            cd $fwdir
+            cd "$fwdir"
 
             echo "Adding non-free firmware to initrd..."
             pax -x sv4cpio -s'%firmware%/firmware%' -w firmware | gzip -c > firmware.cpio.gz
 
-            cd $tftpdir/$da_dir/debian-installer/$arch
+            cd "$tftpdir/$da_dir/debian-installer/$arch"
             [ -f initrd.gz.orig ] || cp -p initrd.gz initrd.gz.orig
-            cat initrd.gz.orig $fwdir/firmware.cpio.gz > initrd.gz
+            cat initrd.gz.orig "$fwdir/firmware.cpio.gz" > initrd.gz
 
-            rm -rf $fwdir
+            rm -rf "$fwdir"
         fi
 
         echo "Adding OCF preseed file into installer menu..."
@@ -101,12 +101,12 @@ for dist in "${dists[@]}"; do
                 menu label OCF Automated Install ($label)
                 menu default
                 kernel debian-installer/$arch/linux
-                append auto=true priority=critical locale=en_US keymap=us vga=788 initrd=debian-installer/$arch/initrd.gz url=tftp://dhcp/preseed/$dist -- quiet" > $txt_cfg
+                append auto=true priority=critical locale=en_US keymap=us vga=788 initrd=debian-installer/$arch/initrd.gz url=tftp://dhcp/preseed/$dist -- quiet" > "$txt_cfg"
         else
             echo "label ocf-$label
                 menu label OCF Automated Install ($label)
                 kernel $da_dir/debian-installer/$arch/linux
-                append auto=true priority=critical locale=en_US keymap=us vga=788 initrd=$da_dir/debian-installer/$arch/initrd.gz url=tftp://dhcp/preseed/$dist -- quiet" >> $txt_cfg
+                append auto=true priority=critical locale=en_US keymap=us vga=788 initrd=$da_dir/debian-installer/$arch/initrd.gz url=tftp://dhcp/preseed/$dist -- quiet" >> "$txt_cfg"
         fi
     done
 done
@@ -127,7 +127,7 @@ echo "label dban
     menu label Darik's Boot and Nuke
     kernel dban/DBAN.BZI
     append load_ramdisk=1 root=/dev/ram0 nuke=\"dwipe --autonuke --method zero\"" \
->> $txt_cfg
+>> "$txt_cfg"
 
 
 # Download Memtest86+, add to menu
@@ -141,7 +141,7 @@ gunzip -c memtest/memtest.bin.gz > memtest/memtest
 echo "label memtest
     menu label Memtest86+
     kernel memtest/memtest" \
->> $txt_cfg
+>> "$txt_cfg"
 
 
 # Extract and add Finnix to menu
@@ -153,12 +153,12 @@ echo "label finnix
     menu label Finnix (requires 768 MB RAM)
     kernel finnix/boot/x86/linux64
     append initrd=finnix/boot/x86/initrd_net.xz vga=791 nomodeset" \
->> $txt_cfg
+>> "$txt_cfg"
 
 
 # Clean up
 echo "Cleaning up..."
-rm $tftpdir/netboot.tar.gz
+rm "$tftpdir/netboot.tar.gz"
 rm dban.iso
 rm memtest/memtest.bin.gz
 

--- a/modules/ocf_jenkins/files/update-plugins
+++ b/modules/ocf_jenkins/files/update-plugins
@@ -5,9 +5,9 @@ ssh_cmd="ssh -p 2222 -o StrictHostKeyChecking=no -i /opt/jenkins/deploy/ssh_cli 
 # Taken from https://stackoverflow.com/a/25647793 and modified to use SSH
 # instead of the jenkins-cli jar
 updates=$($ssh_cmd list-plugins | grep -e ')$' | awk '{ print $1 }');
-if [ ! -z "${updates}" ]; then
-    echo "Updating Jenkins Plugins: ${updates}"
-    $ssh_cmd install-plugin ${updates}
+if [ ! -z "$updates" ]; then
+    echo "Updating Jenkins Plugins: $updates"
+    $ssh_cmd install-plugin "$updates"
     echo "Restarting Jenkins..."
     $ssh_cmd safe-restart
 fi

--- a/modules/ocf_kubernetes/files/kubeconfig.sh
+++ b/modules/ocf_kubernetes/files/kubeconfig.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 export KUBECONFIG=/etc/kubernetes/admin.conf
 
 # etcd clients require the CA and server cert or it won't trust responses.
@@ -9,4 +11,5 @@ export ETCDCTL_KEY_FILE=/etc/kubernetes/pki/etcd/server.key
 # the etcd certs were generated for with kubetool. If we used
 # the fqdn here, the etcd client would complain that the cert
 # is issued for the hostname only.
+# shellcheck disable=SC2155
 export ETCDCTL_ENDPOINT="https://$(hostname -s):2379"

--- a/modules/ocf_ldap/files/munin/slapd-open-files
+++ b/modules/ocf_ldap/files/munin/slapd-open-files
@@ -12,7 +12,7 @@ fi
 pid=$(pidof slapd)
 
 if [ "$pid" -gt 0 ]; then
-    echo "open_files.value $(ls -l /proc/$pid/fd/ | wc -l)"
+    echo "open_files.value $(find "/proc/$pid/fd/" | wc -l)"
 else
     exit 1
 fi

--- a/modules/ocf_mirrors/files/project/ubuntu/sync-releases
+++ b/modules/ocf_mirrors/files/project/ubuntu/sync-releases
@@ -28,4 +28,4 @@ fi
   --stats --delete-after \
   ${RSYNCSOURCE} ${BASEDIR} || fatal "Failed to rsync from ${RSYNCSOURCE}."
 
-date -u > ${BASEDIR}/.trace/$(hostname -f)
+date -u > "${BASEDIR}/.trace/$(hostname -f)"

--- a/modules/ocf_mirrors/files/report-sizes
+++ b/modules/ocf_mirrors/files/report-sizes
@@ -4,8 +4,7 @@
 set -euo pipefail
 
 {
-    cd /opt/mirrors/ftp
-    find -mindepth 1 -maxdepth 1 -type d |
+    find /opt/mirrors/ftp -mindepth 1 -maxdepth 1 -type d |
         sort |
         cut -d/ -f2 |
         grep -vE '^\.' |

--- a/modules/ocf_puppet/manifests/init.pp
+++ b/modules/ocf_puppet/manifests/init.pp
@@ -13,10 +13,14 @@ class ocf_puppet {
     # Keychain is useful for managing SSH and GPG agents
     'keychain':;
 
+    # Provides google-authenticator utility for generating google authenticator
+    # OTP secrets
+    'libpam-google-authenticator':;
+
+    # Used for puppet repo pre-commit checks
+    'shellcheck':;
+
     # Staff need to use virtualenv to run tests.
     'virtualenv':;
-
-    # Provides google-authenticator utility for generating google authenticator OTP secrets
-    'libpam-google-authenticator':;
   }
 }


### PR DESCRIPTION
I was told to do it!
> \<jvperrin-slack\> !8ball steal puppet PR #1000
> \<create\> jvperrin-slack: signs point to yes

Anyway, I noticed that while [utils has shellcheck](https://github.com/ocf/utils/blob/48f1453e84c854a9543f6c2e0d03abaa12c98d04/.pre-commit-config.yaml#L39-L43), this repo does not, so I decided to try enabling it here too. I also tried out the shellcheck hook from https://github.com/gruntwork-io/pre-commit but I liked the simpler one from detailyang instead, especially since newer shellcheck versions do things like check for shebangs automatically instead of doing anything [more custom for that](https://github.com/gruntwork-io/pre-commit/blob/4373c1e6b21003c566c466744ee0d904f6ae81dd/hooks/shellcheck.sh#L39-L47).

I'd like to try and test most of these scripts before just merging this, but I think these all should be safe changes.