### PR TITLE
Disable the FAH Client

### DIFF
--- a/modules/ocf/manifests/packages/fahclient.pp
+++ b/modules/ocf/manifests/packages/fahclient.pp
@@ -17,8 +17,8 @@ class ocf::packages::fahclient {
 
   service {
     'FAHClient':
-      enable  => false,
       ensure  => 'stopped',
+      enable  => false,
       require => Package['fahclient'];
   }
 }

--- a/modules/ocf/manifests/packages/fahclient.pp
+++ b/modules/ocf/manifests/packages/fahclient.pp
@@ -17,6 +17,8 @@ class ocf::packages::fahclient {
 
   service {
     'FAHClient':
+      enable => false,
+      ensure => 'stopped',
       require => Package['fahclient'];
   }
 }

--- a/modules/ocf/manifests/packages/fahclient.pp
+++ b/modules/ocf/manifests/packages/fahclient.pp
@@ -17,8 +17,8 @@ class ocf::packages::fahclient {
 
   service {
     'FAHClient':
-      enable => false,
-      ensure => 'stopped',
+      enable  => false,
+      ensure  => 'stopped',
       require => Package['fahclient'];
   }
 }


### PR DESCRIPTION
Prepare for the opening of the lab

jk I think we've been running it for long enough and it is causing a lot of high heat alerts