### PR TITLE
mirrors: exclude temporarily some files for puppetlabs

### DIFF
--- a/modules/ocf_mirrors/manifests/projects/puppetlabs.pp
+++ b/modules/ocf_mirrors/manifests/projects/puppetlabs.pp
@@ -2,6 +2,7 @@ class ocf_mirrors::projects::puppetlabs {
   ocf_mirrors::ftpsync { 'puppetlabs':
     rsync_host  => 'rsync.puppet.com',
     rsync_path  => 'packages/apt',
+    rsync_extra => '--exclude=work*',
     cron_minute => '55',
   }
 


### PR DESCRIPTION
They have some files with permission 600 and that is causing our rsync
to fail. The files do not show up in their https mirror site, and are
named "work.xxxxx.yyyyyyyyyy" where x is [0-9] and y is [0-9a-zA-Z],
which seem like temp files.