### PR TITLE
Add websocket support to app vhosts

### DIFF
--- a/modules/ocf_apphost/files/vhost-app.jinja
+++ b/modules/ocf_apphost/files/vhost-app.jinja
@@ -25,6 +25,16 @@ server {
         {% endif %}
     }
 
+    {% for ws_location in vhost.websocket_locations %}
+    location /{{ws_location}} {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $host;
+            proxy_pass http://unix:{{vhost.socket}};
+    }
+    {% endfor %}
+
     access_log /var/log/nginx/vhost_access.log vhost;
 
     {% if vhost.ssl %}

--- a/modules/ocf_www/files/build-vhosts
+++ b/modules/ocf_www/files/build-vhosts
@@ -2,6 +2,7 @@
 import argparse
 import grp
 import os.path
+import re
 import shutil
 import subprocess
 import sys
@@ -76,6 +77,7 @@ class VirtualHost(namedtuple('VirtualHost', (
         'ssl',
         'bind_type',
         'bind_dest',
+        'additional_rules',
 ))):
     """A logical representation of a virtual host directive in one of
     the webserver configs.
@@ -91,6 +93,11 @@ class VirtualHost(namedtuple('VirtualHost', (
     bind_type can be any of 'socket', 'docroot', or 'redirect'.
     bind_dest is then respectively the user socket name, the website
     root directory relative to public_html, or URL to redirect to.
+
+    additional_rules should be a dictionary of
+    additional rules that you'll have to add logic to handle in this
+    class. Currently the only supported one is 'ws', which is meant
+    to add an additional WebSockets path for socket-based app vhosts.
     """
     @property
     def contact_email(self):
@@ -133,6 +140,13 @@ class VirtualHost(namedtuple('VirtualHost', (
         assert self.is_redirect
         return self.bind_dest
 
+    @property
+    def websocket_locations(self):
+        if self.bind_type == 'socket' and 'ws' in self.additional_rules:
+            return self.additional_rules['ws']
+        else:
+            return []
+
     def dev_alias(self, dev_config=False):
         return '{}.{}.ocf.berkeley.edu'.format(
             self.fqdn.replace('.', '-'),
@@ -147,7 +161,7 @@ def report(*args, **kwargs):
 
 
 def build_config(src_vhosts, template, dev_config=False):
-    vhosts = set()
+    vhosts = list()
 
     for domain, vhost in src_vhosts.items():
         user = vhost['username']
@@ -161,6 +175,13 @@ def build_config(src_vhosts, template, dev_config=False):
             bind_type = 'docroot'
         bind_dest = vhost[bind_type]
 
+        # Match and process supported flags
+        additional_rules = {}
+        for flag in vhost['flags']:
+            ws_match = re.match(r'ws\=(.+)', flag)
+            if ws_match:
+                additional_rules.setdefault('ws', []).append(ws_match.group(1))
+
         # primary vhost
         primary = VirtualHost(
             fqdn=domain,
@@ -169,33 +190,36 @@ def build_config(src_vhosts, template, dev_config=False):
             ssl=ssl,
             bind_type=bind_type,
             bind_dest=bind_dest,
+            additional_rules=additional_rules,
         )
         # Only add the full vhost if SSL is valid (redirects, like HTTP ->
         # HTTPS are added regardless)
         #
         # We used to support non-HTTPS vhosts, but no longer do (rt#5347)
         if ssl.is_valid:
-            vhosts.add(primary)
+            vhosts.append(primary)
 
         # for app vhosts, define a dev vhost as well
         if bind_type == 'socket':
             dev_alias = primary.dev_alias(dev_config)
-            vhosts.add(VirtualHost(
+            vhosts.append(VirtualHost(
                 fqdn=dev_alias,
                 user=user,
                 comment='{} (dev alias of {})'.format(dev_alias, domain),
                 ssl=SystemSSL(getfqdn()),
                 bind_type='socket',
                 bind_dest=vhost['socket'],
+                additional_rules=additional_rules,
             ))
 
-            vhosts.add(VirtualHost(
+            vhosts.append(VirtualHost(
                 fqdn=dev_alias,
                 user=user,
                 comment='{} (dev alias of {}, redirect to HTTPS)'.format(dev_alias, domain),
                 ssl=None,
                 bind_type='redirect',
                 bind_dest='https://' + dev_alias,
+                additional_rules={},
             ))
 
         # Redirect from http://{domain} to https://{domain} for all vhosts
@@ -211,13 +235,14 @@ def build_config(src_vhosts, template, dev_config=False):
                 redirects.add((alias, ssl))
 
         for fqdn, ssl in redirects:
-            vhosts.add(VirtualHost(
+            vhosts.append(VirtualHost(
                 fqdn=fqdn,
                 user=user,
                 comment='{} (redirect to {})'.format(fqdn, primary.fqdn),
                 ssl=ssl,
                 bind_type='redirect',
                 bind_dest=primary.canonical_url,
+                additional_rules={},
             ))
 
     return '\n\n'.join(


### PR DESCRIPTION
Context: HKN is deploying a new app that requires websockets. This is also a good exercise to see how we can support additional reverse-proxying options and enable more types of applications.

```
3381 # hkn-tutoring.eecs.berkeley.edu (user hkn)
3382 server {
3383     listen 443;
3384     listen [::]:443;
3385     server_name "hkn-tutoring.eecs.berkeley.edu";
3386 
3387     location /.well-known/ {
3388         alias /var/lib/lets-encrypt/.well-known/;
3389     }
3390 
3391     location / {
3392 
3393 
3394                 proxy_pass http://unix:/srv/apps/hkn/tutoring.sock;
3395                 proxy_set_header Host $host;
3396 
3397             proxy_set_header X-Forwarded-For $remote_addr;
3398             proxy_set_header X-Real-IP $remote_addr;
3399 
3400     }
3401 
3402 
3403 
3404     location /socket.io/ {
3405             proxy_http_version 1.1;
3406             proxy_set_header Upgrade $http_upgrade;
3407             proxy_set_header Connection "Upgrade";
3408             proxy_set_header Host $host;
3409             proxy_pass http://unix:/srv/apps/hkn/tutoring.sock;
3410     }
3411 
3412 
3413 
3414     access_log /var/log/nginx/vhost_access.log vhost;
3415 
3416 
3417         ssl on;
3418         ssl_certificate /etc/ssl/apphost/hkn-tutoring.eecs.berkeley.edu.bundle;
3419         ssl_certificate_key /etc/ssl/lets-encrypt/le-vhost.key;
3420         add_header Strict-Transport-Security "max-age=31536000";
3421 
3422 }

```