### PR TITLE
Use iptables-legacy when possible

### DIFF
--- a/modules/ocf/manifests/firewall/chains.pp
+++ b/modules/ocf/manifests/firewall/chains.pp
@@ -1,4 +1,6 @@
 class ocf::firewall::chains {
+  require ocf::firewall::use_legacy
+
   # We put all puppet input/output firewall rules in dedicated chains managed
   # by puppet. This way, puppet will automatically purge rules which get
   # deleted from the manifest.

--- a/modules/ocf/manifests/firewall/use_legacy.pp
+++ b/modules/ocf/manifests/firewall/use_legacy.pp
@@ -1,0 +1,11 @@
+class ocf::firewall::use_legacy {
+  # Buster and greater use iptables-nft by default, but puppetlabs-firewall requires iptables-legacy
+  # So we check if we are using iptables-nft, and if so, change it to iptables-legacy
+
+  exec { 'update-alternatives --set iptables /usr/sbin/iptables-legacy':
+    onlyif => "update-alternatives --query iptables | grep 'Value: /usr/sbin/iptables-nft'",
+  }
+  exec { 'update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy':
+    onlyif => "update-alternatives --query ip6tables | grep 'Value: /usr/sbin/ip6tables-nft'",
+  }
+}


### PR DESCRIPTION
This fixes needing to manually change iptables-nft to iptables-legacy on buster.