### PR TITLE
add chrome to extrapackages

### DIFF
--- a/modules/ocf/manifests/extrapackages.pp
+++ b/modules/ocf/manifests/extrapackages.pp
@@ -12,6 +12,7 @@
 # without concerns of redeclaring ocf::packages with different parameters.
 class ocf::extrapackages {
   # special snowflake packages that require some config
+  include ocf::packages::chrome
   include ocf::packages::emacs
   include ocf::packages::kubectl
   include ocf::packages::matplotlib


### PR DESCRIPTION
blocker for a some apphosts and sites nowadays that require chrome to run their fancy hack build scripts