### PR TITLE
Limit importlib_metadata version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: vendor .resource_types install-hooks
 venv: bin/venv-update Makefile
 	bin/venv-update \
 		venv= $@ -ppython3 \
-		install= 'pre-commit>=1.0.0'
+		install= 'pre-commit>=1.0.0 importlib-metadata<2.0.0'
 
 .PHONY: test
 test: venv install-hooks

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: vendor .resource_types install-hooks
 venv: bin/venv-update Makefile
 	bin/venv-update \
 		venv= $@ -ppython3 \
-		install= 'pre-commit>=1.0.0 importlib-metadata<2.0.0'
+		install= pre-commit>=1.0.0 importlib-metadata<2.0.0
 
 .PHONY: test
 test: venv install-hooks

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: vendor .resource_types install-hooks
 venv: bin/venv-update Makefile
 	bin/venv-update \
 		venv= $@ -ppython3 \
-		install= pre-commit>=1.0.0 importlib-metadata<2.0.0
+		install= pre-commit\>=1.0.0 importlib-metadata\<2.0.0
 
 .PHONY: test
 test: venv install-hooks


### PR DESCRIPTION
Bugged for now and breaking builds see https://jenkins.ocf.berkeley.edu/blue/organizations/jenkins/ocf%2Fpuppet/detail/master/42/pipeline