### PR TITLE
Install xvfb and osxmesa on hpc

### DIFF
--- a/modules/ocf_hpc/manifests/compute.pp
+++ b/modules/ocf_hpc/manifests/compute.pp
@@ -5,7 +5,7 @@ class ocf_hpc::compute {
   include ocf::firewall::allow_ssh
 
   include ocf_hpc::singularity
-  
+
   # install extra hpc packages
   package { ['libosmesa6-dev', 'xvfb']:; }
 

--- a/modules/ocf_hpc/manifests/compute.pp
+++ b/modules/ocf_hpc/manifests/compute.pp
@@ -7,7 +7,7 @@ class ocf_hpc::compute {
   include ocf_hpc::singularity
   
   # install extra hpc packages
-  package { ['libosmesa6-dev', 'xvfb'] }
+  package { ['libosmesa6-dev', 'xvfb']:; }
 
   # install proprietary nvidia drivers and CUDA.
   ocf::repackage { ['nvidia-driver', 'nvidia-settings', 'nvidia-cuda-toolkit', 'nvidia-persistenced']:

--- a/modules/ocf_hpc/manifests/compute.pp
+++ b/modules/ocf_hpc/manifests/compute.pp
@@ -7,7 +7,7 @@ class ocf_hpc::compute {
   include ocf_hpc::singularity
 
   # install proprietary nvidia drivers and CUDA.
-  ocf::repackage { ['nvidia-driver', 'nvidia-settings', 'nvidia-cuda-toolkit', 'nvidia-persistenced']:
+  ocf::repackage { ['nvidia-driver', 'nvidia-settings', 'nvidia-cuda-toolkit', 'nvidia-persistenced', 'libosmesa6-dev', 'xvfb']:
       backport_on => buster;
   } -> file { '/etc/modules-load.d/nvidia-uvm.conf':
     # The nvidia-uvm kernel module, which is needed for CUDA apps, can't be loaded as needed from within Singularity.

--- a/modules/ocf_hpc/manifests/compute.pp
+++ b/modules/ocf_hpc/manifests/compute.pp
@@ -5,9 +5,12 @@ class ocf_hpc::compute {
   include ocf::firewall::allow_ssh
 
   include ocf_hpc::singularity
+  
+  # install extra hpc packages
+  package { ['libosmesa6-dev', 'xvfb'] }
 
   # install proprietary nvidia drivers and CUDA.
-  ocf::repackage { ['nvidia-driver', 'nvidia-settings', 'nvidia-cuda-toolkit', 'nvidia-persistenced', 'libosmesa6-dev', 'xvfb']:
+  ocf::repackage { ['nvidia-driver', 'nvidia-settings', 'nvidia-cuda-toolkit', 'nvidia-persistenced']:
       backport_on => buster;
   } -> file { '/etc/modules-load.d/nvidia-uvm.conf':
     # The nvidia-uvm kernel module, which is needed for CUDA apps, can't be loaded as needed from within Singularity.


### PR DESCRIPTION
These are required to run Mujoco, a simulator for real environments.
