### PR TITLE
Fix typo in rsyncd

### DIFF
--- a/modules/ocf_mirrors/files/rsyncd.conf
+++ b/modules/ocf_mirrors/files/rsyncd.conf
@@ -18,7 +18,7 @@ reverse lookup = no
 [alpine]
 	comment = alpine mirror
 	path = /opt/mirrors/ftp/alpine
-	log fine = /var/log/rsync/alpine.log
+	log file = /var/log/rsync/alpine.log
 
 [archlinux]
 	comment = archlinux package mirror


### PR DESCRIPTION
Noticed this when looking at rsync logs trying to figure out why there's so much I/O on fallingrocks currently. I don't think this is really doing much besides printing these messages to `journalctl` and probably not making any logs for `alpine`:

```
Sep 27 23:38:50 fallingrocks rsyncd[49085]: Unknown Parameter encountered: "log fine"
Sep 27 23:38:50 fallingrocks rsyncd[49085]: IGNORING unknown parameter "log fine"
```