### PR TITLE
Add extrapackages to hpc controller

### DIFF
--- a/modules/ocf/manifests/extrapackages.pp
+++ b/modules/ocf/manifests/extrapackages.pp
@@ -217,6 +217,7 @@ class ocf::extrapackages {
     'unison',
     'vagrant',
     'valgrind',
+    'virtualenv',
     'weechat',
     'xvnc4viewer',
     'zlib1g-dev',

--- a/modules/ocf/manifests/extrapackages.pp
+++ b/modules/ocf/manifests/extrapackages.pp
@@ -217,7 +217,6 @@ class ocf::extrapackages {
     'unison',
     'vagrant',
     'valgrind',
-    'virtualenv',
     'weechat',
     'xvnc4viewer',
     'zlib1g-dev',

--- a/modules/ocf_hpc/manifests/controller.pp
+++ b/modules/ocf_hpc/manifests/controller.pp
@@ -1,6 +1,7 @@
 class ocf_hpc::controller {
   require ocf_hpc
 
+  include ocf::extrapackages
   include ocf::firewall::allow_ssh
   include ocf_hpc::singularity
 


### PR DESCRIPTION
We recommend stuff like virtualenv for HPC (https://www.ocf.berkeley.edu/docs/services/hpc/), but we don't have it installed. Also, it is a login server so we should keep the packages consistent.