### PR TITLE
Slurm changes to encourage fairness

### DIFF
--- a/modules/ocf_hpc/templates/nodes-partitions.erb
+++ b/modules/ocf_hpc/templates/nodes-partitions.erb
@@ -3,4 +3,4 @@
 <% @slurm_nodes_facts.each do |facts| -%>
 NodeName=<%= facts["hostname"] %> NodeAddr=<%= facts["ipaddress"] %> CPUs=<%= facts["processorcount"] %> Sockets=<%= facts["physicalprocessorcount"] %> CoresPerSocket=<%= facts["cores_per_socket"] %> ThreadsPerCore=<%= facts["threads_per_core"] %> RealMemory=<%= facts["memorysize_mb"].floor %> Gres=<% JSON.parse(facts["nvidia_gpu_info"]).each do |_, model| -%>gpu:<%= model %>:1,<% end -%> State=UNKNOWN
 <% end -%>
-PartitionName=ocf-hpc Nodes=ALL Default=YES MaxTime=48:00:00 State=UP
+PartitionName=ocf-hpc Nodes=ALL Default=YES MaxTime=12:00:00 State=UP

--- a/modules/ocf_hpc/templates/slurm.conf.erb
+++ b/modules/ocf_hpc/templates/slurm.conf.erb
@@ -83,7 +83,7 @@ Waittime=0
 #
 #
 # SCHEDULING
-#DefMemPerCPU=0
+DefMemPerCPU=1000
 FastSchedule=0
 #MaxMemPerCPU=0
 #SchedulerTimeSlice=30


### PR DESCRIPTION
- Set default mem per cpu to 1G
- Reduce max reservation time to 12 hours
- I set max jobs per user to 1 using saactmgr for the default qos, we'll see if that works