### PR TITLE
ocf_www: Support php on buster

### DIFF
--- a/modules/ocf_www/manifests/mod/php.pp
+++ b/modules/ocf_www/manifests/mod/php.pp
@@ -1,7 +1,12 @@
 class ocf_www::mod::php {
   package { ['php-cgi', 'php-apcu']:; }
 
-  file { '/etc/php/7.0/cgi/conf.d/99-ocf.ini':
+  $php_version = $::lsbdistcodename ? {
+    'stretch' => '7.0',
+    'buster'  => '7.3',
+  }
+
+  file { "/etc/php/${php_version}/cgi/conf.d/99-ocf.ini":
     source  => 'puppet:///modules/ocf_www/apache/mods/php/99-ocf.ini',
     require => Package['php-cgi'],
     notify  => Service['httpd'];


### PR DESCRIPTION
Just a small fix to make puppet work on `dev-death` (on buster).

Tested by running puppet on both `death` (noop) and `dev-death` (ran cleanly, created `/etc/php/7.3/cgi/conf.d/99-ocf.ini`).