### PR TITLE
Fix puppet on desktops, riot-web -> element-desktop

### DIFF
--- a/modules/ocf/manifests/packages/element.pp
+++ b/modules/ocf/manifests/packages/element.pp
@@ -1,0 +1,7 @@
+class ocf::packages::element {
+  class { 'ocf::packages::element::apt':
+    stage => first,
+  }
+
+  package { 'element-desktop':; }
+}

--- a/modules/ocf/manifests/packages/element/apt.pp
+++ b/modules/ocf/manifests/packages/element/apt.pp
@@ -1,16 +1,16 @@
-# Include Riot apt repo.
-class ocf::packages::riot::apt {
-  apt::key { 'riot':
+# Include Element apt repo.
+class ocf::packages::element::apt {
+  apt::key { 'element':
     ensure => refreshed,
     id     => '12D4CD600C2240A9F4A82071D7B0B66941D01538',
     source => 'https://packages.riot.im/debian/riot-im-archive-keyring.asc',
   }
 
-  apt::source { 'riot':
+  apt::source { 'element':
     architecture => 'amd64',
     location     => 'https://packages.riot.im/debian',
     release      => $::lsbdistcodename,
     repos        => 'main',
-    require      => Apt::Key['riot'],
+    require      => Apt::Key['element'],
   }
 }

--- a/modules/ocf/manifests/packages/riot.pp
+++ b/modules/ocf/manifests/packages/riot.pp
@@ -1,7 +1,0 @@
-class ocf::packages::riot {
-  class { 'ocf::packages::riot::apt':
-    stage => first,
-  }
-
-  package { 'riot-web':; }
-}

--- a/modules/ocf_desktop/manifests/init.pp
+++ b/modules/ocf_desktop/manifests/init.pp
@@ -3,9 +3,9 @@ class ocf_desktop {
   include ocf::packages::brave
   include ocf::packages::chrome
   include ocf::packages::cups
+  include ocf::packages::element
   include ocf::packages::firefox
   include ocf::packages::pulse
-  include ocf::packages::riot
   include ocf::packages::vscode
   include ocf_desktop::crondeny
   include ocf_desktop::defaults


### PR DESCRIPTION
Looks like this is a simple rename. I made it a bit more complex by also renaming the puppet resources. Tested on `volcano`, seems to have worked fine and should fix puppet across all the desktops:
```
Info: Computing checksum on file /etc/apt/sources.list.d/riot.list
Info: /Stage[first]/Apt/File[/etc/apt/sources.list.d/riot.list]: Filebucketed /etc/apt/sources.list.d/riot.list to main with sum e4c12d5eba9a9a93e2565adaf50b375b
Notice: /Stage[first]/Apt/File[/etc/apt/sources.list.d/riot.list]/ensure: removed
Info: sources.list.d: Scheduling refresh of Class[Apt::Update]
Notice: /Stage[first]/Ocf::Packages::Element::Apt/Apt::Source[element]/Apt::Setting[list-element]/File[/etc/apt/sources.list.d/element.list]/ensure: defined content as '{md5}5633750d1d0b7780d52765f6b2125eb6'
Info: /Stage[first]/Ocf::Packages::Element::Apt/Apt::Source[element]/Apt::Setting[list-element]/File[/etc/apt/sources.list.d/element.list]: Scheduling refresh of Class[Apt::Update]
Info: Class[Apt::Update]: Scheduling refresh of Exec[apt_update]
Notice: /Stage[first]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 1 event
Notice: /Stage[main]/Ocf::Packages::Element/Package[element-desktop]/ensure: created
Notice: Applied catalog in 26.24 seconds
```