### PR TITLE
Remove cooperc as recipient of backups for now

### DIFF
--- a/modules/ocf_backups/files/create-encrypted-backup
+++ b/modules/ocf_backups/files/create-encrypted-backup
@@ -56,7 +56,6 @@ encrypt_cmd="gpg --homedir $gpgdir \
                  --recipient abizer@ocf.berkeley.edu \
                  --recipient benzhang4@gmail.com \
                  --recipient daniel@dkess.me \
-                 --recipient cooperc@ocf.berkeley.edu \
                  --recipient kmo@ocf.berkeley.edu \
                  --output \$FILE.gpg -"
 


### PR DESCRIPTION
Backups were breaking for several months (!) because cooperc's public key was broken so this is a quick fix.