### PR TITLE
Unconditionally use restic 0.12.0

### DIFF
--- a/modules/ocf/manifests/packages/restic.pp
+++ b/modules/ocf/manifests/packages/restic.pp
@@ -1,30 +1,30 @@
 class ocf::packages::restic {
 
   if $::lsbdistcodename == 'buster' {
-    package { 'restic':; }
-  } else {
-    # This is not a package, but until newer version of Restic appears in Debian repos this is a good workaround.
-    $install_path        = '/usr/local/bin'
-    $package_name        = 'restic'
-    $package_ensure      = '0.12.0'
-    $download_url        = "https://github.com/restic/restic/releases/download/v0.12.0/${package_name}_${package_ensure}_linux_amd64.bz2"
-    $archive_name        = "${package_name}-${package_ensure}_linux_amd64.bz2"
-
-    archive {
-      $archive_name:
-        path            => "/tmp/${archive_name}",
-        source          => $download_url,
-        extract         => true,
-        extract_path    => $install_path,
-        extract_command => "bzcat %s > ${install_path}/${package_name}",
-        creates         => "${install_path}/${package_name}",
-        cleanup         => true,
-    } ~>
-    file {
-      "${install_path}/${package_name}":
-        ensure => 'present',
-        mode   => '0755',
-        owner  => 'root';
+    package { 'restic':
+      ensure => 'purged',
     }
+  }
+  $install_path        = '/usr/local/bin'
+  $package_name        = 'restic'
+  $package_ensure      = '0.12.0'
+  $download_url        = "https://github.com/restic/restic/releases/download/v0.12.0/${package_name}_${package_ensure}_linux_amd64.bz2"
+  $archive_name        = "${package_name}-${package_ensure}_linux_amd64.bz2"
+
+  archive {
+    $archive_name:
+      path            => "/tmp/${archive_name}",
+      source          => $download_url,
+      extract         => true,
+      extract_path    => $install_path,
+      extract_command => "bzcat %s > ${install_path}/${package_name}",
+      creates         => "${install_path}/${package_name}",
+      cleanup         => true,
+  } ~>
+  file {
+    "${install_path}/${package_name}":
+      ensure => 'present',
+      mode   => '0755',
+      owner  => 'root';
   }
 }


### PR DESCRIPTION
I realized that restic's repository format is not stable, so we should just use a single version of it across our machines. This is mostly a defensive thing, but I don't want anything to break because we are using different versions.