### PR TITLE
Add HPC packages to extrapackages

### DIFF
--- a/modules/ocf/manifests/extrapackages.pp
+++ b/modules/ocf/manifests/extrapackages.pp
@@ -72,6 +72,7 @@ class ocf::extrapackages {
     'julia',
     'jupyter-console',
     'jupyter-core',
+    'jupyterhub'
     'jupyter-notebook',
     'keychain',
     'kubernetes-deploy',
@@ -109,6 +110,7 @@ class ocf::extrapackages {
     'neofetch',
     'nodeenv',
     'nodejs',
+    'npm',
     'octave',
     'pandoc',
     'pdfchain',

--- a/modules/ocf/manifests/extrapackages.pp
+++ b/modules/ocf/manifests/extrapackages.pp
@@ -72,7 +72,7 @@ class ocf::extrapackages {
     'julia',
     'jupyter-console',
     'jupyter-core',
-    'jupyterhub'
+    'jupyterhub',
     'jupyter-notebook',
     'keychain',
     'kubernetes-deploy',


### PR DESCRIPTION
This is for corruption. Should consider removing jupyterhub from some machines.