### PR TITLE
Install nvtop

### DIFF
--- a/modules/ocf_hpc/manifests/compute.pp
+++ b/modules/ocf_hpc/manifests/compute.pp
@@ -10,7 +10,8 @@ class ocf_hpc::compute {
   package { [
     'libosmesa6-dev',
     'pkg-config',
-    'xvfb'
+    'xvfb',
+    'nvtop'
   ]:; }
 
   # install proprietary nvidia drivers and CUDA.

--- a/modules/ocf_hpc/manifests/compute.pp
+++ b/modules/ocf_hpc/manifests/compute.pp
@@ -9,9 +9,9 @@ class ocf_hpc::compute {
   # install extra hpc packages
   package { [
     'libosmesa6-dev',
+    'nvtop',
     'pkg-config',
-    'xvfb',
-    'nvtop'
+    'xvfb'
   ]:; }
 
   # install proprietary nvidia drivers and CUDA.


### PR DESCRIPTION
NVtop is a tool for displaying the utilization rates in gpus. It will be helpful for HPC users.