### PR TITLE
Remove brave from xfce panel

### DIFF
--- a/modules/ocf_desktop/files/xsession/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+++ b/modules/ocf_desktop/files/xsession/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
@@ -14,7 +14,6 @@
         <value type="int" value="9"/>
         <value type="int" value="16"/>
         <value type="int" value="10"/>
-        <value type="int" value="20"/>
         <value type="int" value="12"/>
         <value type="int" value="13"/>
         <value type="int" value="14"/>

--- a/modules/ocf_desktop/files/xsession/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+++ b/modules/ocf_desktop/files/xsession/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
@@ -69,11 +69,6 @@
         <value type="string" value="13847210642.desktop"/>
       </property>
     </property>
-    <property name="plugin-20" type="string" value="launcher">
-      <property name="items" type="array">
-        <value type="string" value="15228073682.desktop"/>
-      </property>
-    </property>
     <property name="plugin-12" type="string" value="launcher">
       <property name="items" type="array">
         <value type="string" value="13912984412.desktop"/>


### PR DESCRIPTION
See #1103 and #308 for more details.

Now that Brave is removed from the desktops, the launcher on the topbar errors when clicked. This edit removes the launcher shortcut.