### PR TITLE
Added required NodeName field to slurm.conf

### DIFF
--- a/modules/ocf_hpc/templates/slurm.conf.erb
+++ b/modules/ocf_hpc/templates/slurm.conf.erb
@@ -3,6 +3,7 @@
 # See the slurm.conf man page for more information.
 #
 SlurmctldHost=<%= @slurm_controller_hostname %>
+NodeName=<%= @slurm_controller_hostname %>
 #SlurmctldHost=
 GresTypes=gpu
 #DisableRootJobs=NO


### PR DESCRIPTION
Fixes error when running `systemctl start slurmctld` due to NodeName not being assigned in slurm.conf