### PR TITLE
Increase number of inotify watchers

### DIFF
--- a/modules/ocf/manifests/networking.pp
+++ b/modules/ocf/manifests/networking.pp
@@ -97,6 +97,8 @@ class ocf::networking(
       value => 'fq';
     'net.ipv4.tcp_congestion_control':
       value => 'bbr';
+    'fs.inotify.max_user_watches':
+      value => '524288';
 
   }
 


### PR DESCRIPTION
This allows us to watch multiple filesystems for development servers running simultaneously on supernova. (This problem arose when I tried to serve decalweb while another staff was also serving on their account.)