### PR TITLE
Delete zombies.yaml

### DIFF
--- a/hieradata/nodes/zombies.yaml
+++ b/hieradata/nodes/zombies.yaml
@@ -1,2 +1,0 @@
-classes:
-    - ocf_csgo


### PR DESCRIPTION
Zombies isn't used anymore, and when I tried to use it to host a minecraft server on Saturday, it was painfully slow...

E: to be clear, I couldn't even set up a minecraft server, *everything* took several seconds to run