### PR TITLE
Update Chrome policy to always open PDF files externally

### DIFF
--- a/modules/ocf/templates/chrome/ocf_policy.json.erb
+++ b/modules/ocf/templates/chrome/ocf_policy.json.erb
@@ -36,5 +36,5 @@
 	"DisablePrintPreview": true,
 
 	"//": "Printing from Chrome's PDF viewer often results in cut-off pages",
-	"DisabledPlugins": ["Chrome PDF Viewer"]
+	"AlwaysOpenPdfExternally": true
 }

--- a/modules/ocf/templates/chrome/ocf_policy.json.erb
+++ b/modules/ocf/templates/chrome/ocf_policy.json.erb
@@ -1,21 +1,21 @@
 {
-	"//": "http://www.chromium.org/administrators/policy-list-3",
-	"//": "http://www.chromium.org/administrators/configuring-other-preferences",
-	"//": "Set OCF homepage.",
+	// http://www.chromium.org/administrators/policy-list-3
+	// http://www.chromium.org/administrators/configuring-other-preferences
+	// Set OCF homepage.
 	"HomepageLocation": "<%= @browser_homepage %>",
 	"HomepageIsNewTabPage": false,
 	"ShowHomeButton": true,
 	"RestoreOnStartup": 4,
 	"RestoreOnStartupURLs": ["<%= @browser_homepage %>"],
 
-	"//": "Do not store browser history etc.",
+	// Do not store browser history etc.
 	"ForceEphemeralProfiles": true,
 	"SavingBrowserHistoryDisabled": true,
 	"PasswordManagerEnabled": false,
 	"AutoFillEnabled": false,
 	"IncognitoModeAvailability": 0,
 
-	"//": "Avoid reporting data to and integrating with Google.",
+	// Avoid reporting data to and integrating with Google.
 	"SigninAllowed": false,
 	"MetricsReportingEnabled": false,
 	"CloudPrintProxyEnabled": false,
@@ -24,17 +24,17 @@
 	"SyncDisabled": true,
 	"TranslateEnabled": true,
 
-	"//": "Allow SPNEGO for Keycloak SSO.",
+	// Allow SPNEGO for Keycloak SSO.
 	"AuthServerWhitelist": "auth.ocf.berkeley.edu",
 	"AuthNegotiateDelegateWhitelist": "auth.ocf.berkeley.edu",
 
-	"//": "Misc settings",
+	// Misc settings
 	"DefaultBrowserSettingEnabled": false,
 
-	"//": "Disable print preview",
-	"//": "(fails when CUPS takes too long to respond, shows invalid settings)",
+	// Disable print preview
+	// (fails when CUPS takes too long to respond, shows invalid settings)
 	"DisablePrintPreview": true,
 
-	"//": "Printing from Chrome's PDF viewer often results in cut-off pages",
+	// Printing from Chrome's PDF viewer often results in cut-off pages
 	"AlwaysOpenPdfExternally": true
 }


### PR DESCRIPTION
The "DisabledPlugins" Chrome policy has been deprecated, and the replacement is `"AlwaysOpenPdfExternally": true`.

https://chromeenterprise.google/policies/#AlwaysOpenPdfExternally

fixes: cut-off pages