### PR TITLE
add iPerf3

### DIFF
--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -94,6 +94,7 @@ class ocf::packages {
       'iftop',
       'iotop',
       'iperf',
+      'iperf3',
       'jq',
       'lsof',
       'man-db',


### PR DESCRIPTION
* install iperf3, no reason why iperf2 is installled but iperf3 isn't
* remove ipython which is Python 2-based