### PR TITLE
Fix linting on stretch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,9 @@ repos:
     rev: v2.1.0
     hooks:
     -   id: puppet-validate
+        additional_dependencies: ['puppet:<7']
     -   id: erb-validate
+        additional_dependencies: ['puppet:<7']
     -   id: puppet-lint
         args:
         -   --fail-on-warnings
@@ -13,9 +15,13 @@ repos:
         -   --no-puppet_url_without_modules-check
         -   --no-arrow_on_right_operand_line-check
         -   --no-variable_is_lowercase-check
+        additional_dependencies: ['puppet:<7', 'puppet-lint']
     -   id: epp-validate
+        additional_dependencies: ['puppet:<7']
     -   id: r10k-validate
+        additional_dependencies: ['puppet:<7', 'r10k']
     -   id: ruby-validate
+        additional_dependencies: ['puppet:<7']
 -   repo: https://github.com/pre-commit/pre-commit-hooks.git
     # We need to be using python3.6 by default before this can be upgraded to 3.x+
     rev: v2.5.0


### PR DESCRIPTION
Puppet 7 and up requires ruby 2.5, so pin the version of puppet we use to lint with.