### PR TITLE
Install "python3.7" on Stretch only

### DIFF
--- a/modules/ocf/manifests/packages.pp
+++ b/modules/ocf/manifests/packages.pp
@@ -154,6 +154,7 @@ class ocf::packages {
         'python3.7-venv',
         ]:;
       }
+  }
   # Packages to only install on Debian (not on Raspbian for example)
   if $::lsbdistid == 'Debian' {
     package {


### PR DESCRIPTION
`python3` is `python3.7` on Buster and `python3.9` on Bullseye.

Fixes puppet errors on bullseye