### PR TITLE
Restore default font size for paper-genmon

### DIFF
--- a/modules/ocf_desktop/files/skel/config/xfce4/panel/genmon-4.rc
+++ b/modules/ocf_desktop/files/skel/config/xfce4/panel/genmon-4.rc
@@ -2,4 +2,4 @@ Command=/usr/local/bin/paper-genmon
 UseLabel=0
 Text=(genmon)
 UpdatePeriod=60000
-Font=Sans 13
+Font=Sans 10


### PR DESCRIPTION
Uhh, please don't merge for now, there seem to be differences between monitor sizes