### PR TITLE
Only clone qfm script if not already cloned

### DIFF
--- a/modules/ocf_mirrors/manifests/qfm.pp
+++ b/modules/ocf_mirrors/manifests/qfm.pp
@@ -14,6 +14,7 @@ define ocf_mirrors::qfm(
 
   exec { "get-qfm-${title}":
     command => "sh -c 'git clone https://pagure.io/quick-fedora-mirror.git ${project_path}'",
+    onlyif  => "test ! -f ${project_path}",
     user    => 'mirrors';
   }
 


### PR DESCRIPTION
This caused Puppet on fallingrocks to fail due to git bailing out because the directory already existed.