### PR TITLE
Update report-sizes

### DIFF
--- a/modules/ocf_mirrors/files/report-sizes
+++ b/modules/ocf_mirrors/files/report-sizes
@@ -4,13 +4,8 @@
 set -euo pipefail
 
 {
-    find /opt/mirrors/ftp -mindepth 1 -maxdepth 1 -type d |
-        sort |
-        cut -d/ -f2 |
-        grep -vE '^\.' |
-        (xargs nice ionice du -hs || true) \
-        2> >(grep -v '^du: cannot access' >&2)
-
+    /sbin/zfs list | /usr/bin/awk '{printf("%-30s %-10s\n", $1, $2);}'
+    echo
     echo -n 'Last updated: '
     date
 } | sponge /opt/mirrors/ftp/sizes


### PR DESCRIPTION
We are using zfs with each project as a dataset, so we can simply process the output of `zfs list` to get the sizes.