### PR TITLE
switch to cri-o for kubernetes

### DIFF
--- a/modules/ocf/manifests/packages/kube/apt_first_stage.pp
+++ b/modules/ocf/manifests/packages/kube/apt_first_stage.pp
@@ -21,7 +21,7 @@ class ocf::packages::kube::apt_first_stage {
   apt::key { 'crio repo key':
     id     => '2472D6D0D2F66AF87ABA8DA34D64390375060AA4',
     # the key is the same for both
-    source => 'https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_${::operatingsystemmajrelease}/Release.key';
+    source => "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_${::operatingsystemmajrelease}/Release.key";
   }
 
   $is_dev = $::hostname in lookup('kube_dev::controller_nodes')
@@ -39,7 +39,7 @@ class ocf::packages::kube::apt_first_stage {
   }
   apt::source { 'libcontainers':
       architecture => 'amd64',
-      location     => 'https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_${::operatingsystemmajrelease}/',
+      location     => "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_${::operatingsystemmajrelease}/",
       repos        => '/',
       require      => Apt::Key['crio repo key'],
   }

--- a/modules/ocf/manifests/packages/kube/apt_first_stage.pp
+++ b/modules/ocf/manifests/packages/kube/apt_first_stage.pp
@@ -17,4 +17,30 @@ class ocf::packages::kube::apt_first_stage {
       # pull.
       release  => 'kubernetes-xenial',
   }
+
+  apt::key { 'crio repo key':
+    id     => '2472D6D0D2F66AF87ABA8DA34D64390375060AA4',
+    # the key is the same for both
+    source => 'https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_${::operatingsystemmajrelease}/Release.key';
+  }
+
+  $is_dev = $::hostname in lookup('kube_dev::controller_nodes')
+  $kube_prefix = if $is_dev { 'kube_dev' } else { 'kube' }
+  $kube_version = lookup("${kube_prefix}::kubernetes_version")
+  $split_version = split($kube_version, '.')
+  $crio_version = $split_version[0] + '.' + $split_version[1]
+
+  # for packages: cri-o cri-o-runc
+  apt::source { 'crio':
+      architecture => 'amd64',
+      location     => "http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${crio_version}/Debian_${::operatingsystemmajrelease}/",
+      repos        => '/',
+      require      => Apt::Key['crio repo key'],
+  }
+  apt::source { 'libcontainers':
+      architecture => 'amd64',
+      location     => 'https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_${::operatingsystemmajrelease}/',
+      repos        => '/',
+      require      => Apt::Key['crio repo key'],
+  }
 }

--- a/modules/ocf/manifests/packages/kube/apt_first_stage.pp
+++ b/modules/ocf/manifests/packages/kube/apt_first_stage.pp
@@ -28,7 +28,7 @@ class ocf::packages::kube::apt_first_stage {
   $kube_prefix = if $is_dev { 'kube_dev' } else { 'kube' }
   $kube_version = lookup("${kube_prefix}::kubernetes_version")
   $split_version = split($kube_version, '.')
-  $crio_version = $split_version[0] + '.' + $split_version[1]
+  $crio_version = "${split_version[0]}.${split_version[1]}"
 
   # for packages: cri-o cri-o-runc
   apt::source { 'crio':

--- a/modules/ocf_kube/files/containerd.toml
+++ b/modules/ocf_kube/files/containerd.toml
@@ -1,7 +1,0 @@
-[plugins]
-  [plugins.cri.containerd]
-    snapshotter = "overlayfs"
-    [plugins.cri.containerd.default_runtime]
-      runtime_type = "io.containerd.runtime.v1.linux"
-      runtime_engine = "/usr/bin/runc"
-      runtime_root = ""

--- a/modules/ocf_kube/files/crio.conf
+++ b/modules/ocf_kube/files/crio.conf
@@ -1,5 +1,5 @@
 [crio.metrics]
-enable_metrics = True
+enable_metrics = true
 metrics_port = 9090
 
 # TODO: crio.telemetry

--- a/modules/ocf_kube/files/crio.conf
+++ b/modules/ocf_kube/files/crio.conf
@@ -1,0 +1,5 @@
+[crio.metrics]
+enable_metrics = True
+metrics_port = 9090
+
+# TODO: crio.telemetry

--- a/modules/ocf_kube/templates/kubelet.service
+++ b/modules/ocf_kube/templates/kubelet.service
@@ -7,7 +7,7 @@ After=network-online.target
 [Service]
 ExecStart=/usr/bin/kubelet --config /etc/kubernetes/kubelet.yaml \
                            --container-runtime=remote \
-                           --container-runtime-endpoint=unix:///var/run/containerd/containerd.sock \
+                           --container-runtime-endpoint=unix:///var/run/crio/crio.sock \
                            --register-node=true \
                            --kubeconfig=/etc/kubernetes/kubelet.conf
 Restart=always


### PR DESCRIPTION
Here's why we're switching from containerd...

- the NVidia driver only just added support for it because there are weird issues
- other kubernetes distributions seem to be moving to cri-o over containerd https://github.com/poseidon/typhoon/issues/899
- I ran into the issue where java apps just don't work on containerd out of the box one too many times