### PR TITLE
add xclip/xdotool to TV+desktops

### DIFF
--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -44,7 +44,7 @@ class ocf_desktop::packages {
     # utilities
     ['wakeonlan']:;
     # Xorg
-    ['xclip', 'xsel', 'xserver-xorg', 'xscreensaver', 'freerdp2-x11']:;
+    ['xclip', 'xdotool', 'xsel', 'xserver-xorg', 'xscreensaver', 'freerdp2-x11']:;
   }
 
   if $::lsbdistcodename == 'stretch' {

--- a/modules/ocf_tv/manifests/init.pp
+++ b/modules/ocf_tv/manifests/init.pp
@@ -24,6 +24,8 @@ class ocf_tv {
       'python3-usb',
       'vlc',
       'x11vnc',
+      'xclip',
+      'xdotool',
       'xinit',
     ]:;
   }


### PR DESCRIPTION
xclip & xdotool let us control the TV without needing a full VNC session (and make transferring URLs to the TV a lot less painful). Install xdotool on desktops too since they don't have it either.

Some quick examples (untested):
- `ssh tv DISPLAY=:0 xclip <<<"url here"` to get URL to TV clipboard
- `ssh tv DISPLAY=:0 xdotool key F11` to press F11
