### PR TITLE
make default netboot option bullseye

### DIFF
--- a/modules/ocf_dhcp/files/netboot/ocf-netboot
+++ b/modules/ocf_dhcp/files/netboot/ocf-netboot
@@ -13,7 +13,7 @@ set -euo pipefail
 # Whichever architecture and distribution is first in the arrays is the default,
 # and is (ab)used for the PXE boot menu.
 archs=(amd64)
-dists=(buster stretch bullseye bookworm)
+dists=(bullseye bookworm buster)
 menu_arch="${archs[0]}"
 menu_dist="${dists[0]}"
 menu_path="debian-installer/$menu_arch"


### PR DESCRIPTION
This way I can netboot something and walk away instead of having to be there to press down arrow 😁