### PR TITLE
add cri-tools to kubernetes nodes

### DIFF
--- a/modules/ocf_kube/manifests/controller.pp
+++ b/modules/ocf_kube/manifests/controller.pp
@@ -75,6 +75,9 @@ class ocf_kube::controller {
   }
   ~> service { 'crio': }
 
+  # install cri-tools for crictl
+  package { 'cri-tools': }
+
   # Ensure /var/lib/etcd has mode 700
   file { '/var/lib/etcd':
     ensure => directory,


### PR DESCRIPTION
Gives us `crictl` which is helpful for debugging clusters when etcd or apiserver are down.