### PR TITLE
fix systemd not having permissions to read procfs

### DIFF
--- a/modules/ocf/manifests/hidepid.pp
+++ b/modules/ocf/manifests/hidepid.pp
@@ -1,31 +1,32 @@
 class ocf::hidepid {
 
-  $group_cap_ptrace = 'capptrace'
-
-  group { $group_cap_ptrace:
-    ensure => present,
-    name   => $group_cap_ptrace,
-    system => true,
-    before => Mount['/proc'];
-  }
+  # only one group can be authorized to have full procfs access with hidepid=2,
+  # so we will reuse ocfstaff for everything else that needs it
+  # TODO: look into having a dedicated group that somehow has membership synced
+  # with ocfstaff?
+  $procfs_authorized_group = 'ocfstaff'
 
   # systemd-logind and policykit need to access info about all processes.
   # see here: https://wiki.debian.org/Hardening#Mounting_.2Fproc_with_hidepid
   ocf::systemd::override { 'hidepid-logind':
     unit    => 'systemd-logind.service',
-    content => "[Service]\nSupplementaryGroups=${group_cap_ptrace}\n",
-    require => Group[$group_cap_ptrace];
+    content => "[Service]\nSupplementaryGroups=${procfs_authorized_group}\n",
   }
 
   if str2bool($::polkit_priv_drop) {
     # Futureproof for policykit for version 0.115. policykit will create this
-    # user, we just need to add it to capptrace
+    # user, we just need to add it to the authorized group
     user { 'polkitd':
-      name    => 'polkitd',
-      groups  => $group_cap_ptrace,
-      system  => true,
-      require => Group[$group_cap_ptrace];
+      name   => 'polkitd',
+      groups => $procfs_authorized_group,
+      system => true,
     }
+  }
+
+  # user@.service needs this too: https://github.com/systemd/systemd/issues/12955
+  ocf::systemd::override { 'hidepid-user-service':
+    unit    => 'user@.service',
+    content => "[Service]\nSupplementaryGroups=${procfs_authorized_group}\n",
   }
 
   mount { '/proc':
@@ -36,7 +37,6 @@ class ocf::hidepid {
     remounts => true,
     device   => '/proc',
     fstype   => 'procfs',
-    options  => "rw,hidepid=2,gid=${group_cap_ptrace},gid=ocfstaff",
-    require  => Group[$group_cap_ptrace];
+    options  => "rw,hidepid=2,gid=${procfs_authorized_group}",
   }
 }


### PR DESCRIPTION
It seems `gid=` can only be specified once for procfs mount options, so the `capptrace` group was being ignored entirely; switch to using `ocfstaff` as the designated group, which is ugly but should work. In addition, systemd now also needs to read procfs for running the user daemon, so add a drop-in for `user@.service` as well.

Tested on famine, resolves audio not working (since pulseaudio is started by the systemd user daemon)