### PR TITLE
Remove packages which no longer exist on bullseye

### DIFF
--- a/modules/ocf/manifests/extrapackages.pp
+++ b/modules/ocf/manifests/extrapackages.pp
@@ -186,7 +186,6 @@ class ocf::extrapackages {
     'vagrant',
     'valgrind',
     'weechat',
-    'xvnc4viewer',
     'zlib1g-dev',
     'znc',
     ]:;

--- a/modules/ocf_desktop/manifests/drivers.pp
+++ b/modules/ocf_desktop/manifests/drivers.pp
@@ -5,8 +5,13 @@ class ocf_desktop::drivers {
   if $::gfx_brand == 'nvidia' {
     # Install nvidia-driver from backports so that it loads properly
     # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=903770
-    ocf::repackage { ['nvidia-smi', 'nvidia-driver', 'libgl1-nvidia-glx:i386', 'nvidia-cuda-toolkit']:
+    ocf::repackage { ['nvidia-smi', 'nvidia-driver', 'nvidia-cuda-toolkit']:
       backport_on => 'stretch';
+    }
+    if $::os['distro']['codename'] in ['buster', 'stretch'] {
+      ocf::repackage { ['libgl1-nvidia-glx:i386']:
+        backport_on => 'stretch';
+      }
     }
     package { ['xserver-xorg-video-nvidia', 'nvidia-settings', 'nvidia-cuda-mps']:; }
 


### PR DESCRIPTION
`xvnc4viewer` has been replaced with `tigervnc-viewer` on desktops (I'm pretty sure there's no purpose in installing a VNC viewer on anything that isn't a desktop...), and `libgl1-nvidia-glx:i386` isn't necessary any more.

Tested on headcrash