### PR TITLE
fix: apparmor policy for whiteout SSL

### DIFF
--- a/modules/ocf_printhost/files/usr.sbin.cupsd
+++ b/modules/ocf_printhost/files/usr.sbin.cupsd
@@ -1,0 +1,1 @@
+/var/lib/lets-encrypt/certs/** r,

--- a/modules/ocf_printhost/manifests/cups.pp
+++ b/modules/ocf_printhost/manifests/cups.pp
@@ -14,7 +14,7 @@ class ocf_printhost::cups {
     '/etc/cups/cupsd.conf':
       content => template('ocf_printhost/cups/cupsd.conf.erb');
 
-    '/etc/apparmor.d/local/usr.sbin.cupsd":
+    '/etc/apparmor.d/local/usr.sbin.cupsd':
       source => 'puppet:///modules/ocf_printhost/usr.sbin.cupsd';
 
     '/etc/cups/cups-files.conf':

--- a/modules/ocf_printhost/manifests/cups.pp
+++ b/modules/ocf_printhost/manifests/cups.pp
@@ -15,7 +15,7 @@ class ocf_printhost::cups {
       content => template('ocf_printhost/cups/cupsd.conf.erb');
 
     '/etc/apparmor.d/local/usr.sbin.cupsd":
-      content => 'puppet:///modules/ocf_printhost/usr.sbin.cupsd';
+      source => 'puppet:///modules/ocf_printhost/usr.sbin.cupsd';
 
     '/etc/cups/cups-files.conf':
       source => 'puppet:///modules/ocf_printhost/cups-files.conf';

--- a/modules/ocf_printhost/manifests/cups.pp
+++ b/modules/ocf_printhost/manifests/cups.pp
@@ -14,6 +14,9 @@ class ocf_printhost::cups {
     '/etc/cups/cupsd.conf':
       content => template('ocf_printhost/cups/cupsd.conf.erb');
 
+    '/etc/apparmor.d/local/usr.sbin.cupsd":
+      content => 'puppet:///modules/ocf_printhost/usr.sbin.cupsd';
+
     '/etc/cups/cups-files.conf':
       source => 'puppet:///modules/ocf_printhost/cups-files.conf';
 


### PR DESCRIPTION
Default apparmor policies prevent CUPSd from reading the SSL privkey