### PR TITLE
Add membership shorturl

### DIFF
--- a/modules/ocf_www/manifests/site/shorturl.pp
+++ b/modules/ocf_www/manifests/site/shorturl.pp
@@ -95,6 +95,7 @@ class ocf_www::site::shorturl {
       {rewrite_rule => '^/mastodon$ https://mastodon.ocf.berkeley.edu [R]'},
       {rewrite_rule => '^/matrix$ https://chat.ocf.berkeley.edu [R]'},
       {rewrite_rule => '^/meet$ https://meet.google.com/cqz-kjwj-hbx [R]'},
+      {rewrite_rule => '^/membership$ https://www.ocf.berkeley.edu/docs/membership/ [R]'},
       {rewrite_rule => '^/minutes(/.*)?$ https://www.ocf.berkeley.edu/~staff/bod$1 [R]'},
       {rewrite_rule => '^/mirrorstats$ https://grafana.ocf.berkeley.edu/d/Jo_bRsyiz/mirrors?orgId=1 [R]'},
       {rewrite_rule => '^/mlk$ https://www.ocf.berkeley.edu/mlk [R]'},


### PR DESCRIPTION
I would like to add `membership` to the shorturl list since I refer to it a lot when configuring vhosts (check RT for [this URL]( https://www.ocf.berkeley.edu/docs/membership/)). 

PR for reserving username is here (ocf/ocflib#243).