### PR TITLE
fix: use correct service name for mariadb

### DIFF
--- a/modules/ocf/manifests/packages/mysql_server.pp
+++ b/modules/ocf/manifests/packages/mysql_server.pp
@@ -10,7 +10,12 @@ class ocf::packages::mysql_server(
   }
 
   if $manage_service {
-    service { 'mysql':
+    if Integer($::os[release][major]) < 11 {
+      $servicename = 'mysql'
+    } else {
+      $servicename = 'mariadb'
+    }
+    service { $servicename:
       ensure  => stopped,
       enable  => false,
       require => Package['mariadb-server'],


### PR DESCRIPTION
On bullseye, the `mysql` service is now a native systemd alias to `mariadb.service`. For some reason, systemd always reports aliases as "enabled", which causes Puppet to try to disable it every run, even though the alias target is actually disabled.

I'm not sure if it's even necessary to disable mariadb on bullseye, since older debian versions had mariadb.service coexisting alongside the sysvinit script, and this class never tried to manage mariadb.service but everything still worked.