### PR TITLE
fix: upgrade nginx controller to 0.51.0

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -74,7 +74,7 @@ kubernetes::kube_api_advertise_address: "%{::ipaddress}"
 kubernetes::api_server_count: 3
 kubernetes::install_dashboard: false
 kubernetes::controller_address: 169.229.226.75:6443
-kubernetes::nginx_version: '0.34.1'
+kubernetes::nginx_version: '0.51.0'
 kubernetes::worker_nodes:
     - riptide
     - bedbugs


### PR DESCRIPTION
We are 3 years behind on our controller version. I checked the changelog and the minimum Kubernetes version should remain at 1.16 for this release, with no other breaking changes noted.