### PR TITLE
fix(oldk8s): update selectors for ingress service

### DIFF
--- a/modules/ocf_kubernetes/templates/ingress/ingress_expose.yaml.erb
+++ b/modules/ocf_kubernetes/templates/ingress/ingress_expose.yaml.erb
@@ -32,6 +32,7 @@ spec:
       targetPort: 80
       protocol: TCP
   selector:
+    app.kubernetes.io/component: controller
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
 

--- a/modules/ocf_kubernetes/templates/ingress/ingress_expose.yaml.erb
+++ b/modules/ocf_kubernetes/templates/ingress/ingress_expose.yaml.erb
@@ -32,7 +32,7 @@ spec:
       targetPort: 80
       protocol: TCP
   selector:
+    app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/part-of: ingress-nginx
 
 ---


### PR DESCRIPTION
The current resources deployed for ingress-nginx have changed the labels used for the service. This points our ingress traffic to the actual managed, up-to-date ingress-nginx deployment instead of the old pre-0.31 version that still happens to be in the cluster.