### PR TITLE
fix: make policyd-weight actually work with v6 DNS

### DIFF
--- a/modules/ocf_mail/manifests/spam.pp
+++ b/modules/ocf_mail/manifests/spam.pp
@@ -113,4 +113,12 @@ class ocf_mail::spam {
     hour        => '05',
     minute      => '00';
   }
+
+  exec { 'fix-policyd-weight':
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=933972 (how is this not fixed???)
+    command => 'sed -i -e \'/use IO::Socket::INET;/ause IO::Socket::INET6;\' /usr/sbin/policyd-weight',
+    unless  => 'grep -Fq \'use IO::Socket::INET6;\' /usr/sbin/policyd-weight',
+    require => Package['policyd-weight'],
+    notify  => Service['policyd-weight'];
+  }
 }


### PR DESCRIPTION
Apparently all Debian packages for policyd-weight don't work when the system DNS server is IPv6, and there's a Debian bug from 2019 for it that is *still open*. So, patch it ourselves with a hacky `exec` resource.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=933972