### PR TITLE
fix disk pressure with  /run/ symlink to work around string comparison

### DIFF
--- a/modules/ocf_kube/templates/kubelet.service
+++ b/modules/ocf_kube/templates/kubelet.service
@@ -7,7 +7,7 @@ After=network-online.target
 [Service]
 ExecStart=/usr/bin/kubelet --config /etc/kubernetes/kubelet.yaml \
                            --container-runtime=remote \
-                           --container-runtime-endpoint=unix:///var/run/crio/crio.sock \
+                           --container-runtime-endpoint=unix:///run/crio/crio.sock \
                            --register-node=true \
                            --kubeconfig=/etc/kubernetes/kubelet.conf
 Restart=always


### PR DESCRIPTION
As explained in https://github.com/kubernetes/kubernetes/issues/106957#issuecomment-1167388634 -- the CRI-O team found performance issues in the CRI stats provider, so there's a hack in kubelet which falls back to cadvisor when crio is being used.

This is currently broken and causing a bunch of spam in our logs that looks like  "Unable to fetch pod log stats" -- leading to some nodes (like jaws, with a 64G disk) to become NotReady due to disk pressure.

This commit works around the above issue by subverting the string check using the fact that `/run` is symlinked to `/var/run`.