### PR TITLE
feat: use sha512 for dns tsig key

### DIFF
--- a/modules/ocf/templates/ssl/dehydrated-hook-ddns-tsig.conf.erb
+++ b/modules/ocf/templates/ssl/dehydrated-hook-ddns-tsig.conf.erb
@@ -5,5 +5,5 @@ verbosity = 1
 # not seem to be actually documented anywhere
 key_name = letsencrypt.ocf.io
 key_secret = "<%= @letsencrypt_ddns_key -%>"
-key_algorithm = hmac-md5
+key_algorithm = hmac-sha512
 dns_rewrite = s/^_acme-challenge\.(.*)(ocf\.berkeley\.edu|ocf\.io)$/\1letsencrypt.ocf.io/

--- a/modules/ocf_ns/templates/named.conf.options.erb
+++ b/modules/ocf_ns/templates/named.conf.options.erb
@@ -59,11 +59,6 @@ zone "multi.uribl.com" {
 };
 
 key "letsencrypt.ocf.io" {
-  // Unfortunately bind9 does not appear to support algorithms stronger than
-  // hmac-md5 for user keys (used for dynamic DNS), but we can make the key
-  // size fairly large at least. HMAC with md5 does not suffer from the
-  // collision problems that md5 has, but ideally this would still be changed
-  // to something stronger in the future.
-  algorithm HMAC-MD5;
+  algorithm HMAC-SHA512;
   secret "<%= @letsencrypt_ddns_key -%>";
 };


### PR DESCRIPTION
bind9 apparently supports SHA-based algorithms now