### PR TITLE
fix: increase kerberos ticket validity for backup script

### DIFF
--- a/modules/ocf_backups/files/rsnapshot.conf
+++ b/modules/ocf_backups/files/rsnapshot.conf
@@ -21,7 +21,7 @@ cmd_ssh	/usr/bin/ssh
 cmd_logger	/usr/bin/logger
 
 # remote backups require login as ocfbackups, then `sudo rsync-no-vanished'
-cmd_preexec	/usr/bin/kinit -t /opt/share/backups/ocfbackups.keytab ocfbackups
+cmd_preexec	/usr/bin/kinit -l 12h -t /opt/share/backups/ocfbackups.keytab ocfbackups
 cmd_postexec	/usr/bin/kdestroy
 
 # default is "--delete --numeric-ids --relative --delete-excluded"


### PR DESCRIPTION
current validity is too short and causes later stages of the backup to fail