### PR TITLE
Update vcsrepo to 5.3.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -31,6 +31,6 @@ mod 'puppetlabs-puppet_authorization',     '0.4.0'
 mod 'puppetlabs-puppetdb',                 '6.0.2'
 mod 'puppetlabs-stdlib',                   '4.25.1'
 mod 'puppetlabs-tagmail',                  '2.4.0'
-mod 'puppetlabs-vcsrepo',                  '2.3.0'
+mod 'puppetlabs-vcsrepo',                  '5.3.0'
 mod 'thias-sysctl',                        '1.0.6'
 mod 'puppetlabs/translate',                '2.0.0' # Dependency of puppetlabs-kubernetes


### PR DESCRIPTION
vcsrepo 2.3.0 doesn't support Puppet 7