### PR TITLE
fix(mirrors): reload nginx when certs change

### DIFF
--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -99,6 +99,9 @@ class ocf_mirrors {
   }
   $ocfstats_password = lookup('ocfstats::mysql::password')
 
+  # Restart nginx if any cert changes occur
+  Class['ocf::ssl::default'] ~> Class['Nginx::Service']
+
   file {
     ['/opt/mirrors', '/opt/mirrors/ftp', '/opt/mirrors/project', '/opt/mirrors/bin']:
       ensure  => directory,

--- a/modules/ocf_mirrors/manifests/init.pp
+++ b/modules/ocf_mirrors/manifests/init.pp
@@ -97,7 +97,6 @@ class ocf_mirrors {
 
       END
   }
-  $ocfstats_password = lookup('ocfstats::mysql::password')
 
   # Restart nginx if any cert changes occur
   Class['ocf::ssl::default'] ~> Class['Nginx::Service']
@@ -218,9 +217,10 @@ class ocf_mirrors {
     mode   => '0755',
   }
 
+  $ocfstats_password = lookup('ocfstats::mysql::password')
   file {
     '/opt/ocfstats-password':
-      content   => lookup('ocfstats::mysql::password'),
+      content   => $ocfstats_password,
       mode      => '0600',
       owner     => 'root',
       group     => 'root',


### PR DESCRIPTION
Previously, nginx was not picking up renewed certs.

Also, clean up some code nearby :)