### PR TITLE
fix: stop using deprecated contextmanager pymysql api

### DIFF
--- a/modules/ocf_desktop/files/xsession/notify
+++ b/modules/ocf_desktop/files/xsession/notify
@@ -31,8 +31,11 @@ def main():
 
     # Show user's print quota when changed
     user = current_user()
-    with get_connection() as c:
+    conn = get_connection()
+    with conn.cursor() as c:
         quota = get_quota(c, user)
+    conn.commit()
+    conn.close()
 
     msg = '   → {} {}\n'.format(quota.semesterly, 'remaining this semester')
     msg += '   → {} {}\n'.format(quota.daily, 'remaining today')

--- a/modules/ocf_desktop/files/xsession/paper-genmon
+++ b/modules/ocf_desktop/files/xsession/paper-genmon
@@ -18,10 +18,13 @@ def main(argv=None):
     user = current_user()
 
     if user_exists(user) and not user_is_group(user):
-        with get_connection() as c:
+        conn = get_connection()
+        with conn.cursor() as c:
             quota = get_quota(c, user)
             daily_quota = quota.daily
             semester_quota = quota.semesterly
+        conn.commit()
+        conn.close()
 
     PANEL_TEXT = '{} {} left today | {} left this semester'
     print(PANEL_TEXT.format(daily_quota, 'side of paper' if daily_quota == 1 else 'sides of paper',

--- a/modules/ocf_labstats/files/bin/close-old-sessions
+++ b/modules/ocf_labstats/files/bin/close-old-sessions
@@ -20,8 +20,11 @@ def close_old_sessions(ocfstats_pass):
                 `last_update` < ADDDATE(NOW(), INTERVAL -{} MINUTE)
     """.format(HOST_TIMEOUT)
 
-    with get_connection(user='ocfstats', password=ocfstats_pass) as c:
+    conn = get_connection(user='ocfstats', password=ocfstats_pass)
+    with conn.cursor() as c:
         c.execute(query)
+    conn.commit()
+    conn.close()
 
 
 def main():

--- a/modules/ocf_labstats/files/bin/update-groups
+++ b/modules/ocf_labstats/files/bin/update-groups
@@ -9,7 +9,8 @@ from ocflib.lab.stats import get_connection
 def update_group(ocfstats_pass, table, users):
     """Update any tables of usernames used in ocfstats to generate views."""
 
-    with get_connection(user='ocfstats', password=ocfstats_pass) as c:
+    conn = get_connection(user='ocfstats', password=ocfstats_pass)
+    with conn.cursor() as c:
         # This is not great, but this seems like the only way to insert lists
         # into a SQL query without the possibility of SQL injection. That being
         # said, if a staff member has a username that actually causes SQL
@@ -25,6 +26,8 @@ def update_group(ocfstats_pass, table, users):
             'REPLACE INTO `{}` (`user`) VALUES (%s)'.format(table),
             users,
         )
+    conn.commit()
+    conn.close()
 
 
 def main():

--- a/modules/ocf_labstats/files/bin/update-printer-stats
+++ b/modules/ocf_labstats/files/bin/update-printer-stats
@@ -15,7 +15,8 @@ def update_printer_stats(ocfstats_pass, printer):
     except OSError as ex:
         return
 
-    with get_connection(user='ocfstats', password=ocfstats_pass) as c:
+    conn = get_connection(user='ocfstats', password=ocfstats_pass)
+    with conn.cursor() as c:
         c.execute(
             (
                 'INSERT INTO `printer_toner` (`date`, `printer`, `value`, `max`)'
@@ -31,6 +32,8 @@ def update_printer_stats(ocfstats_pass, printer):
             ),
             (printer, lifetime_pages),
         )
+    conn.commit()
+    conn.close()
 
 
 def main():

--- a/modules/ocf_mirrors/files/collect-mirrors-stats
+++ b/modules/ocf_mirrors/files/collect-mirrors-stats
@@ -31,13 +31,16 @@ RSYNC_LOG_REGEX = re.compile(
 
 
 def log_to_mysql(projects, log_date, quiet=False):
-    with get_connection(user='ocfstats', password=OCFSTATS_PWD) as cursor:
+    conn = get_connection(user='ocfstats', password=OCFSTATS_PWD)
+    with conn.cursor() as cursor:
         for name, data in projects.items():
             cursor.execute(
                 'INSERT INTO `mirrors` (`date`, `dist`, `up`, `down`) '
                 'VALUES (%s, %s, %s, %s)',
                 (log_date, name, data['up'], data['down'])
             )
+    conn.commit()
+    conn.close()
 
 
 def process_nginx_log(projects, fn, log_date):


### PR DESCRIPTION
The context manager implementation for PyMySql Connection objects was replaced with different functionality in the versions between bullseye and bookworm; change the code to not use Connections as context managers at all to maintain compatibility with both versions.