### PR TITLE
Proxy apphosts through death

### DIFF
--- a/modules/ocf_apphost/files/vhost-app.jinja
+++ b/modules/ocf_apphost/files/vhost-app.jinja
@@ -4,6 +4,13 @@ server {
     listen [::]:{{vhost.port}};
     server_name "{{vhost.fqdn}}";
 
+    # Trust forwarded traffic from death
+    real_ip_header X-Forwarded-For;
+    set_real_ip_from 169.229.226.23; # death
+    set_real_ip_from 2607:f140:8801::1:23;
+    set_real_ip_from 169.229.226.37; # dev-death
+    set_real_ip_from 2607:f140:8801::1:37;
+
     location /.well-known/ {
         alias /var/lib/lets-encrypt/.well-known/;
     }

--- a/modules/ocf_www/files/build-vhosts
+++ b/modules/ocf_www/files/build-vhosts
@@ -102,6 +102,10 @@ class VirtualHost(namedtuple('VirtualHost', (
         return self.bind_type == 'redirect'
 
     @property
+    def is_apphost(self):
+        return self.bind_type == 'socket'
+
+    @property
     def docroot(self):
         assert self.bind_type == 'docroot'
         return os.path.join(
@@ -386,7 +390,16 @@ def main():
 
     if args.target == 'web':
         site_cfg = APACHE_SITE_CONFIG
+        # Build app vhosts so that they can get proxied to apphost.o.b.e
+        # Placed before regular vhosts so they take priority in domain matching
+        # (sometimes hosts have entries in both vhost.conf and vhost-app.conf)
         config = build_config(
+            get_app_vhosts(),
+            jinja_env.get_template('vhost-web.jinja'),
+            dev_config=args.dev,
+        )
+        config += '\n\n'
+        config += build_config(
             get_vhosts(),
             jinja_env.get_template('vhost-web.jinja'),
             dev_config=args.dev,

--- a/modules/ocf_www/files/vhost-web.jinja
+++ b/modules/ocf_www/files/vhost-web.jinja
@@ -18,7 +18,6 @@
         # Doesn't matter too much for vhosts.
         RewriteRule ^(.*)$ {{vhost.redirect_dest}}$1 [L,R=302]
     {% elif vhost.is_apphost %}
-        RewriteEngine on
         RequestHeader set X-Forwarded-Proto https
         ProxyPreserveHost On
         SSLProxyEngine on

--- a/modules/ocf_www/files/vhost-web.jinja
+++ b/modules/ocf_www/files/vhost-web.jinja
@@ -17,6 +17,13 @@
         # 301 redirects are more correct, but get cached forever by dumb browsers.
         # Doesn't matter too much for vhosts.
         RewriteRule ^(.*)$ {{vhost.redirect_dest}}$1 [L,R=302]
+    {% elif vhost.is_apphost %}
+        RewriteEngine on
+        RequestHeader set X-Forwarded-Proto https
+        ProxyPreserveHost On
+        SSLProxyEngine on
+        # Proxy to apphost server
+        ProxyPass / https://apphost.ocf.berkeley.edu/ upgrade=websocket
     {% elif vhost.disabled %}
         # Proxy to the local "unavailable" vhost, which serves up a friendly
         # "your website is rekt" page.


### PR DESCRIPTION
Still need to figure out how we want to handle groups who want to switch to apphosting, since our current method of adding them to `vhost-app.conf` will cause their development domain to be promoted to production immediately even if they're still working on developing their app or configuring systemd. Maybe we initially add `group-studentorg-berkeley-edu.apphost.ocf.berkeley.edu` as their domain and then edit it to `group.studentorg.berkeley.edu` when they're ready to promote the site to production?