### PR TITLE
Replace xournal with xournalpp

### DIFF
--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -20,7 +20,7 @@ class ocf_desktop::packages {
       'gnome-calculator', 'gparted', 'hexchat', 'imagej', 'inkscape', 'lyx',
       'musescore3', 'mpv', 'mssh', 'mumble', 'numlockx',
       'simple-scan', 'ssh-askpass-gnome', 'texmaker',
-      'texstudio', 'tigervnc-viewer', 'vlc', 'xarchiver', 'xcape', 'xournal',
+      'texstudio', 'tigervnc-viewer', 'vlc', 'xarchiver', 'xcape', 'xournalpp',
       'xterm']:;
     # desktop
     ['desktop-base', 'anacron', 'accountsservice', 'arc-theme',


### PR DESCRIPTION
Xournalpp is a more feature-full rewrite of xournal. Potentially, we can make xournalpp our new default pdf viewer instead of Okular if we cannot fix the need to Force Rasterize for certain jobs. Even if we don't... xournalpp is still nice.