### PR TITLE
Chrome filesystem usage fix

### DIFF
--- a/modules/ocf_desktop/files/xsession/lightdm/session-cleanup
+++ b/modules/ocf_desktop/files/xsession/lightdm/session-cleanup
@@ -7,4 +7,8 @@ if [ -n "$USER" ]; then
   pkill -9 -u "$USER"
 fi
 
+# Cleanup Chrome filesystem usage
+rm -rf $HOME/.cache/google-chrome
+rm -rf $HOME/.config/google-chrome
+
 sudo -u ocfstats /opt/stats/update-delay.sh cleanup &

--- a/modules/ocf_desktop/files/xsession/lightdm/session-cleanup
+++ b/modules/ocf_desktop/files/xsession/lightdm/session-cleanup
@@ -8,7 +8,7 @@ if [ -n "$USER" ]; then
 fi
 
 # Cleanup Chrome filesystem usage
-rm -rf $HOME/.cache/google-chrome
-rm -rf $HOME/.config/google-chrome
+rm -rf "$HOME/.cache/google-chrome"
+rm -rf "$HOME/.config/google-chrome"
 
 sudo -u ocfstats /opt/stats/update-delay.sh cleanup &


### PR DESCRIPTION
Added code to clear google chrome cache and config
upon xsession cleanup (ie user logging out).

This should fix an issue with chrome cache and
config taking up too much space to the point
of crashing the desktops.

Does remove persistance of config between user
sessions, but it is chrome specific, and we
do not explicitly support such persistance
anyways.

Tested on my laptop with lightdm and works.
Tested on OCF desktop by trinity.
``