### PR TITLE
fix: disable privacy sandbox popup in chrome

### DIFF
--- a/modules/ocf/templates/chrome/ocf_policy.json.erb
+++ b/modules/ocf/templates/chrome/ocf_policy.json.erb
@@ -36,5 +36,11 @@
 	"DisablePrintPreview": true,
 
 	<%# Printing from Chrome's PDF viewer often results in cut-off pages %>
-	"AlwaysOpenPdfExternally": true
+	"AlwaysOpenPdfExternally": true,
+
+	<%# Disable Privacy Sandbox popup %>
+	"PrivacySandboxAdMeasurementEnabled": false,
+	"PrivacySandboxPromptEnabled": false,
+	"PrivacySandboxAdTopicsEnabled": false,
+	"PrivacySandboxSiteEnabledAdsEnabled": false,
 }

--- a/modules/ocf/templates/chrome/ocf_policy.json.erb
+++ b/modules/ocf/templates/chrome/ocf_policy.json.erb
@@ -42,5 +42,5 @@
 	"PrivacySandboxAdMeasurementEnabled": false,
 	"PrivacySandboxPromptEnabled": false,
 	"PrivacySandboxAdTopicsEnabled": false,
-	"PrivacySandboxSiteEnabledAdsEnabled": false,
+	"PrivacySandboxSiteEnabledAdsEnabled": false
 }


### PR DESCRIPTION
removes the random popup that we get