### PR TITLE
Adding pass to ocf desktops

### DIFF
--- a/modules/ocf/manifests/packages/pass.pp
+++ b/modules/ocf/manifests/packages/pass.pp
@@ -1,7 +1,0 @@
-class ocf::packages::pass {
-  class { 'ocf::packages::pass::apt':
-    stage => first,
-  }
-
-  package { 'pass':; }
-}

--- a/modules/ocf/manifests/packages/pass.pp
+++ b/modules/ocf/manifests/packages/pass.pp
@@ -1,0 +1,7 @@
+class ocf::packages::pass {
+  class { 'ocf::packages::pass::apt':
+    stage => first,
+  }
+
+  package { 'pass':; }
+}

--- a/modules/ocf_desktop/manifests/packages.pp
+++ b/modules/ocf_desktop/manifests/packages.pp
@@ -18,7 +18,7 @@ class ocf_desktop::packages {
     ['arandr', 'blender', 'claws-mail', 'clementine', 'eog', 'evince',
       'filezilla', 'freeplane', 'geany', 'gimp',
       'gnome-calculator', 'gparted', 'hexchat', 'imagej', 'inkscape', 'lyx',
-      'musescore3', 'mpv', 'mssh', 'mumble', 'numlockx',
+      'musescore3', 'mpv', 'mssh', 'mumble', 'numlockx', 'pass',
       'simple-scan', 'ssh-askpass-gnome', 'texmaker',
       'texstudio', 'tigervnc-viewer', 'vlc', 'xarchiver', 'xcape', 'xournalpp',
       'xterm']:;


### PR DESCRIPTION
https://www.passwordstore.org/
Added pass.

Having a simple password manager installed opens up many more potential uses for ocf computers. There is negligible downside.