### PR TITLE
feat: option for 301 instead of 302 redirect

### DIFF
--- a/modules/ocf_www/files/build-vhosts
+++ b/modules/ocf_www/files/build-vhosts
@@ -139,6 +139,12 @@ class VirtualHost(namedtuple('VirtualHost', (
         return self.bind_dest
 
     @property
+    def redirect_type(self):
+        if '301' in self.additional_rules:
+            return 301
+        return 302
+
+    @property
     def websocket_locations(self):
         if self.bind_type == 'socket' and 'ws' in self.additional_rules:
             return self.additional_rules['ws']
@@ -179,6 +185,8 @@ def build_config(src_vhosts, template, dev_config=False):
             ws_match = re.match(r'ws\=(.+)', flag)
             if ws_match:
                 additional_rules.setdefault('ws', []).append(ws_match.group(1))
+            elif flag == '301':
+                additional_rules['301'] = True
 
         # primary vhost
         primary = VirtualHost(
@@ -240,7 +248,7 @@ def build_config(src_vhosts, template, dev_config=False):
                 ssl=ssl,
                 bind_type='redirect',
                 bind_dest=primary.canonical_url,
-                additional_rules={},
+                additional_rules=additional_rules,
             ))
 
     return '\n\n'.join(

--- a/modules/ocf_www/files/vhost-web.jinja
+++ b/modules/ocf_www/files/vhost-web.jinja
@@ -16,7 +16,7 @@
         RewriteCond %{REQUEST_URI} !^/\.well-known/
         # 301 redirects are more correct, but get cached forever by dumb browsers.
         # Doesn't matter too much for vhosts.
-        RewriteRule ^(.*)$ {{vhost.redirect_dest}}$1 [L,R=302]
+        RewriteRule ^(.*)$ {{vhost.redirect_dest}}$1 [L,R={{vhost.redirect_type}}]
     {% elif vhost.is_apphost %}
         RequestHeader set X-Forwarded-Proto https
         ProxyPreserveHost On


### PR DESCRIPTION
defaults to 302 because dumb browsers cache 301 redirects forever, but this adds an option if 301 is desired and whoever puts it knows what they're doing

(mainly for SEO purposes, 301 is better than 302)
