### PR TITLE
Increase as limit

### DIFF
--- a/modules/ocf/files/limits.conf
+++ b/modules/ocf/files/limits.conf
@@ -1,5 +1,5 @@
 # <domain> <type> <item> <value>
-@ocf hard as 10000000
+@ocf hard as 12000000
 @ocf hard core 0
 @ocf soft cpu 60
 @ocf hard cpu 1440


### PR DESCRIPTION
Increase the address space limit beyond 10 GiB to allow wasm to work properly