### PR TITLE
Update sinkhole's scale factor to 1.0

### DIFF
--- a/hieradata/nodes/sinkhole.yaml
+++ b/hieradata/nodes/sinkhole.yaml
@@ -1,1 +1,1 @@
-ocf_desktop::xsession::scale: 1.5
+ocf_desktop::xsession::scale: 1.0


### PR DESCRIPTION
Sinkhole's 4k monitor died so we put a 1080p one there but now all the UI elements are gigantic so we need to bump the scale factor back down to 100%