### PR TITLE
low key oom should restart desktops

### DIFF
--- a/modules/ocf_desktop/manifests/init.pp
+++ b/modules/ocf_desktop/manifests/init.pp
@@ -14,6 +14,7 @@ class ocf_desktop {
   include ocf_desktop::firewall_output
   include ocf_desktop::grub
   include ocf_desktop::modprobe
+  include ocf_desktop::oom_manage
   include ocf_desktop::packages
   include ocf_desktop::printnotify
   include ocf_desktop::sshfs

--- a/modules/ocf_desktop/manifests/oom_manage.pp
+++ b/modules/ocf_desktop/manifests/oom_manage.pp
@@ -1,0 +1,6 @@
+class ocf_desktop::oom_manage {
+  sysctl {
+    'vm.panic_on_oom': value => '1';
+    'kernel.panic': value => '5';
+  }
+}


### PR DESCRIPTION
Desktops just hang on a frozen screen if they run out of memory. Chrome likes using a lot of memory. I would argue that restarting the computer automatically is a more desirable behaviour for the end user than just freezing.

Therefore, on out of memory we now kernel panic, and on kernel panics we restart the computer after 5 seconds.

Already tested on firewhirl

etw wanted to test something else though before merging this.