### PR TITLE
fix: detect new scanner for desktop icon

### DIFF
--- a/modules/ocf_desktop/files/xsession/Xsession
+++ b/modules/ocf_desktop/files/xsession/Xsession
@@ -9,7 +9,7 @@ for d in .steam .local; do
 done
 
 # Remove scanner desktop icon if not detected as connected over USB
-if ! lsusb | grep -qE '(Fujitsu|CanoScan|Canon, Inc)'; then
+if ! lsusb | grep -qE '(Fujitsu|CanoScan|Canon, Inc|Seiko Epson)'; then
   rm $HOME/Desktop/scanner.desktop
 fi
 


### PR DESCRIPTION
Add the new Epson scanner (ES-400II) to the detection list for showing the Scanner desktop icon.