### PR TITLE
ocf_www: fix ocf.io/ofc shorturl

### DIFF
--- a/modules/ocf_www/manifests/site/shorturl.pp
+++ b/modules/ocf_www/manifests/site/shorturl.pp
@@ -104,6 +104,7 @@ class ocf_www::site::shorturl {
       #{rewrite_rule => '^/newstaff$ https://forms.gle/guESY2ykNkshNxsf8 [R]'},
       {rewrite_rule => '^/notes$ https://notes.ocf.berkeley.edu/ [R]'},
       #{rewrite_rule => '^/now$ https://www.ocf.berkeley.edu/tv$1 [R]'},
+      {rewrite_rule => '^/ofc$ https://www.ocf.berkeley.edu/announcements/2016-04-01/renaming-ocf [R]'},
       {rewrite_rule => '^/officers$ https://www.ocf.berkeley.edu/docs/about/officers/ [R]'},
       #{rewrite_rule => '^/onboarding$ https://forms.gle/KKgp6fLhGkrfTKea8 [R]'},
       {rewrite_rule => '^/opstaff-schedule$ https://docs.google.com/spreadsheets/d/18EBPiC0HtW_ij_3MH5y3FyFVaG4ElnYHxJduQQ3IZM8/edit?usp=sharing [R]'},


### PR DESCRIPTION
ocf.io/ofc is supposed to redirect to www.ocf.b.e/~ofc which is supposed to then redirect to https://www.ocf.berkeley.edu/announcements/2016-04-01/renaming-ocf, but the latter redirect is frequently broken because the `ofc` account is usually sorried. Make it an explicit shorturl to avoid this problem.