### PR TITLE
filehost: kerberos support + refactor nfs_export

### DIFF
--- a/modules/ocf_filehost/manifests/init.pp
+++ b/modules/ocf_filehost/manifests/init.pp
@@ -13,12 +13,14 @@ class ocf_filehost(
         # We don't root_squash admin, ssh, or apphost because they need to access
         # /services/crontabs/$server/ as root.
         options => ['rw', 'fsid=0', 'no_subtree_check', 'no_root_squash'],
-        hosts   => ['admin', 'www', 'ssh', 'apphost', 'adenine', 'guanine', 'cytosine', 'thymine', 'fluttershy', 'rainbowdash'],
+        hosts   => ['admin', 'www', 'ssh', 'apphost', 'adenine', 'guanine', 'cytosine', 'thymine', 'tsunami', 'supernova'],
       },
       {
         # allow other hosts (including desktops) to mount nfs, but with limitations (no
-        # root, strict subtree checking, kerberos auth/integrity/encryption.
-        options => ['rw', 'fsid=0', 'subtree_check', 'root_squash', 'sec=krb5p'],
+        # root, kerberos auth/integrity/encryption). subtree_check absolutely destroyed
+        # performance in testing, especially with git repositories (git status would hang),
+        # so lets disable that.
+        options => ['rw', 'fsid=0', 'no_subtree_check', 'root_squash', 'sec=krb5p'],
         hosts   => ['*.ocf.berkeley.edu'],
       },
     ],

--- a/modules/ocf_filehost/manifests/init.pp
+++ b/modules/ocf_filehost/manifests/init.pp
@@ -8,11 +8,20 @@ class ocf_filehost(
   }
 
   ocf_filehost::nfs_export {
-    '/opt/homes':
-      # We don't root_squash admin, ssh, or apphost because they need to access
-      # /services/crontabs/$server/ as root.
-      options => ['rw', 'fsid=0', 'no_subtree_check', 'no_root_squash'],
-      hosts   => ['admin', 'www', 'ssh', 'apphost', 'adenine', 'guanine', 'cytosine', 'thymine', 'fluttershy', 'rainbowdash'];
+    '/opt/homes': clients => [
+      {
+        # We don't root_squash admin, ssh, or apphost because they need to access
+        # /services/crontabs/$server/ as root.
+        options => ['rw', 'fsid=0', 'no_subtree_check', 'no_root_squash'],
+        hosts   => ['admin', 'www', 'ssh', 'apphost', 'adenine', 'guanine', 'cytosine', 'thymine', 'fluttershy', 'rainbowdash'],
+      },
+      {
+        # allow other hosts (including desktops) to mount nfs, but with limitations (no
+        # root, strict subtree checking, kerberos auth/integrity/encryption.
+        options => ['rw', 'fsid=0', 'subtree_check', 'root_squash', 'sec=krb5p'],
+        hosts   => ['*.ocf.berkeley.edu'],
+      },
+    ],
   }
 
   file {

--- a/modules/ocf_filehost/manifests/nfs_export.pp
+++ b/modules/ocf_filehost/manifests/nfs_export.pp
@@ -1,14 +1,35 @@
 define ocf_filehost::nfs_export (
-  Array[String] $options,
-  Array[String] $hosts,
+  # allow specifying an export point that is different from the title; useful
+  # for exports where you want to specify different options for different
+  # groups of hosts that all share the same export point.
+  #
+  # a map is used so that each groups of hosts with the same export point are
+  # listed in the file as under the same export point:
+  #   /path/to/dir \
+  #     host1(opts) \
+  #     host2(opts) \
+  # instead of:
+  #   /path/to/dir \
+  #     host1(opts) \
+  #   /path/to/dir \
+  #     host2(opts) \
+
+  Array[Struct[{
+    options => Array[String],
+    hosts => Array[String],
+  }]] $clients,
 ) {
 
-  $option_string = join($options, ',');
-  $hosts_plus_option = $hosts.map |$host| { "    ${host}(${option_string})" };
-  $export_string = join($hosts_plus_option, " \\\n");
+  $export_chunks = $clients.map |$client| {
+    $option_string = join($client['options'], ',');
+    $hosts_plus_option = $client['hosts'].map |$host| { "    ${host}(${option_string})" };
+    join($hosts_plus_option, " \\\n")
+  }
 
-  concat::fragment { "nfs-export-${name}":
+  $export_string = join($export_chunks, " \\\n");
+
+  concat::fragment { "nfs-export-${title}":
     target  => '/etc/exports',
-    content => "${name} \\\n${export_string}\n\n"
+    content => "${title} \\\n${export_string}\n\n"
   }
 }


### PR DESCRIPTION
- kerberized nfs for *.ocf.berkeley.edu
- use map to allow different options for different groups of clients under the same export point