### PR TITLE
feat(ocf_www): add nginx reverse proxy in front of apache

### DIFF
--- a/modules/ocf_www/files/build-vhosts
+++ b/modules/ocf_www/files/build-vhosts
@@ -22,6 +22,10 @@ from ocflib.vhost.web import get_vhosts
 
 APACHE_SITE_CONFIG = '/etc/apache2/ocf-vhost.conf'
 NGINX_SITE_CONFIG = '/etc/nginx/sites-enabled/virtual'
+NGINX_WEB_SITE_CONFIG = '/etc/nginx/ocf-vhost.conf'
+
+# Must match $backend_port in ocf_www::init
+BACKEND_PORT = 16767
 
 LETS_ENCRYPT_SSL = Path('/services/http/ssl')
 SYSTEM_SSL = Path('/etc/ssl/private')
@@ -259,7 +263,7 @@ def build_config(src_vhosts, template, dev_config=False):
             ))
 
     return '\n\n'.join(
-        template.render(vhost=vhost)
+        template.render(vhost=vhost, backend_port=BACKEND_PORT)
         for vhost in sorted(
             vhosts,
             key=lambda vhost: (vhost.user, vhost.fqdn, bool(vhost.ssl)),
@@ -267,7 +271,7 @@ def build_config(src_vhosts, template, dev_config=False):
     )
 
 
-def test_and_overwrite_config(config_path, new_config, target):
+def test_and_overwrite_config(config_path, new_config, test_cmd):
     """Diffs and tests the new config and overwrites the old config if
     the test passes.
 
@@ -306,10 +310,7 @@ def test_and_overwrite_config(config_path, new_config, target):
         os.rename(new_path, config_path)
 
         report('Performing config test.')
-        if target == 'web':
-            ret = subprocess.call(('apachectl', 'configtest'))
-        else:
-            ret = subprocess.call(('nginx', '-t'))
+        ret = subprocess.call(test_cmd)
 
         if ret != 0:
             report('Test failed!')
@@ -404,7 +405,6 @@ def main():
         changed |= process_app_vhosts()
 
     if args.target == 'web':
-        site_cfg = APACHE_SITE_CONFIG
         # Build app vhosts so that they can get proxied to apphost.o.b.e
         # Placed before regular vhosts so they take priority in domain matching
         # (sometimes hosts have entries in both vhost.conf and vhost-app.conf)
@@ -414,17 +414,58 @@ def main():
             for domain, conf in get_app_vhosts().items()
             if 'dev' not in conf['flags']
         }
-        config = build_config(
+
+        web_vhosts = get_vhosts()
+
+        # Apache config (existing behavior)
+        apache_config = build_config(
             prod_app_vhosts,
             jinja_env.get_template('vhost-web.jinja'),
             dev_config=args.dev,
         )
-        config += '\n\n'
-        config += build_config(
-            get_vhosts(),
+        apache_config += '\n\n'
+        apache_config += build_config(
+            web_vhosts,
             jinja_env.get_template('vhost-web.jinja'),
             dev_config=args.dev,
         )
+
+        # Nginx frontend config
+        nginx_config = build_config(
+            prod_app_vhosts,
+            jinja_env.get_template('vhost-web-nginx.jinja'),
+            dev_config=args.dev,
+        )
+        nginx_config += '\n\n'
+        nginx_config += build_config(
+            web_vhosts,
+            jinja_env.get_template('vhost-web-nginx.jinja'),
+            dev_config=args.dev,
+        )
+
+        if args.dry_run:
+            report('=== Apache config ===')
+            report(apache_config)
+            report('\n=== Nginx config ===')
+            report(nginx_config)
+            return 0
+
+        changed |= test_and_overwrite_config(
+            APACHE_SITE_CONFIG, apache_config, ('apachectl', 'configtest'),
+        )
+        changed |= test_and_overwrite_config(
+            NGINX_WEB_SITE_CONFIG, nginx_config, ('nginx', '-t'),
+        )
+
+        if changed:
+            if not args.no_reload:
+                report('Things changed, reloading.')
+                subprocess.check_call(('systemctl', 'reload', 'apache2'))
+                subprocess.check_call(('systemctl', 'reload', 'nginx'))
+            else:
+                report('Not reloading, as you requested.')
+        else:
+            report('Nothing changed, not doing anything.')
     else:
         site_cfg = NGINX_SITE_CONFIG
         config = build_config(
@@ -433,22 +474,22 @@ def main():
             dev_config=args.dev,
         )
 
-    if args.dry_run:
-        report(config)
-        return 0
+        if args.dry_run:
+            report(config)
+            return 0
 
-    changed |= test_and_overwrite_config(site_cfg, config, args.target)
-    if changed:
-        if not args.no_reload:
-            report('Things changed, reloading.')
-            if args.target == 'web':
-                subprocess.check_call(('systemctl', 'reload', 'apache2'))
-            else:
+        changed |= test_and_overwrite_config(
+            site_cfg, config, ('nginx', '-t'),
+        )
+
+        if changed:
+            if not args.no_reload:
+                report('Things changed, reloading.')
                 subprocess.check_call(('systemctl', 'reload', 'nginx'))
+            else:
+                report('Not reloading, as you requested.')
         else:
-            report('Not reloading, as you requested.')
-    else:
-        report('Nothing changed, not doing anything.')
+            report('Nothing changed, not doing anything.')
 
 
 if __name__ == '__main__':

--- a/modules/ocf_www/files/vhost-web-nginx.jinja
+++ b/modules/ocf_www/files/vhost-web-nginx.jinja
@@ -1,0 +1,63 @@
+# {{vhost.comment}}
+# CR-soon oliverni: move to 80/443
+
+{% if vhost.ssl %}
+server {
+    listen 8443 ssl http2;
+    listen [::]:8443 ssl http2;
+    server_name "{{vhost.fqdn}}";
+
+    ssl_certificate {{vhost.ssl.bundle}};
+    ssl_certificate_key {{vhost.ssl.key}};
+
+    add_header Strict-Transport-Security "max-age=31536000" always;
+
+    {% for name, value in vhost.response_headers.items() %}
+    add_header {{name}} "{{value}}" always;
+    {% endfor %}
+
+    location /.well-known/ {
+        alias /var/lib/lets-encrypt/.well-known/;
+    }
+
+    location / {
+        {% if vhost.is_redirect %}
+        return {{vhost.redirect_type}} {{vhost.redirect_dest}}$request_uri;
+        {% else %}
+        proxy_pass http://127.0.0.1:{{backend_port}};
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        {% endif %}
+    }
+
+    access_log /var/log/nginx/vhost-access.log vhost;
+}
+{% endif %}
+
+{% if not vhost.ssl or vhost.is_redirect %}
+# HTTP (redirect or non-SSL)
+server {
+    listen 8080;
+    listen [::]:8080;
+    server_name "{{vhost.fqdn}}";
+
+    location /.well-known/ {
+        alias /var/lib/lets-encrypt/.well-known/;
+    }
+
+    location / {
+        {% if vhost.is_redirect %}
+        return {{vhost.redirect_type}} {{vhost.redirect_dest}}$request_uri;
+        {% elif vhost.ssl %}
+        return 301 {{vhost.canonical_url}}$request_uri;
+        {% else %}
+        proxy_pass http://127.0.0.1:{{backend_port}};
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Real-IP $remote_addr;
+        {% endif %}
+    }
+}
+{% endif %}

--- a/modules/ocf_www/files/vhost-web.jinja
+++ b/modules/ocf_www/files/vhost-web.jinja
@@ -1,9 +1,11 @@
 # {{vhost.comment}}
-<VirtualHost *:{{vhost.port}}>
+{% set ports = [vhost.port, backend_port] if vhost.ssl else [vhost.port] %}
+{% for port in ports %}
+<VirtualHost *:{{port}}>
     ServerName {{vhost.fqdn}}
     ServerAdmin {{vhost.contact_email}}
 
-    {% if vhost.ssl %}
+    {% if vhost.ssl and port != backend_port %}
         # SSL
         SSLEngine on
         SSLCertificateFile {{vhost.ssl.bundle}}
@@ -27,7 +29,7 @@
         # Proxy to the local "unavailable" vhost, which serves up a friendly
         # "your website is rekt" page.
         RequestHeader set Host unavailable.ocf.berkeley.edu
-        ProxyPass / http://localhost/
+        ProxyPass / http://127.0.0.1/
     {% else %}
         DocumentRoot {{vhost.docroot}}
 
@@ -59,3 +61,4 @@
 
     UserDir disabled
 </VirtualHost>
+{% endfor %}

--- a/modules/ocf_www/manifests/init.pp
+++ b/modules/ocf_www/manifests/init.pp
@@ -10,7 +10,14 @@
 #
 # The interesting config is in ocf_www::site::www, which sets up
 # www.ocf.berkeley.edu, which is by far the most complicated domain.
+#
+# Nginx sits in front of Apache for slowloris protection.
+# CR-soon oliverni: swap nginx to 80/443, apache to 127.0.0.1:$backend_port only
 class ocf_www {
+  # Port Apache listens on as nginx's backend (plain HTTP on localhost).
+  # Must match BACKEND_PORT in build-vhosts.
+  # Phase 2: make this the only Apache port and bind to 127.0.0.1.
+  $backend_port = 16767
   include ocf::acct
   include ocf::extrapackages
   include ocf::firewall::allow_web
@@ -25,6 +32,9 @@ class ocf_www {
     cron => false,
     web  => false,
   }
+
+  # nginx reverse proxy (test ports for now)
+  include ocf_www::nginx
 
   class {
     '::apache':

--- a/modules/ocf_www/manifests/nginx.pp
+++ b/modules/ocf_www/manifests/nginx.pp
@@ -1,0 +1,147 @@
+# Nginx reverse proxy in front of Apache for slowloris protection.
+# CR-soon oliverni: move to 80/443, put apache on 127.0.0.1:$backend_port
+#
+# Static vhosts (www, shorturl, etc.) are defined here.
+# Dynamic user vhosts come from build-vhosts via /etc/nginx/ocf-vhost.conf.
+class ocf_www::nginx {
+  include ocf::ssl::default
+  include ocf_www::nginx::firewall
+
+  # CR-soon oliverni: change listen/ssl ports to 80/443
+  $http_port = 8080
+  $ssl_port  = 8443
+
+  $backend = "http://127.0.0.1:${ocf_www::backend_port}"
+
+  $ssl_cert = "/etc/ssl/private/${::fqdn}.bundle"
+  $ssl_key  = "/etc/ssl/private/${::fqdn}.key"
+
+  $proxy_headers = [
+    'Host $host',
+    'X-Forwarded-For $remote_addr',
+    'X-Forwarded-Proto $scheme',
+    'X-Real-IP $remote_addr',
+  ]
+
+  $www_canonical = $::host_env ? {
+    'dev'  => 'dev-www.ocf.berkeley.edu',
+    'prod' => 'www.ocf.berkeley.edu',
+  }
+
+  class { 'nginx':
+    manage_repo            => false,
+    confd_purge            => true,
+    server_purge           => true,
+    names_hash_bucket_size => 128,
+    client_max_body_size   => '64M',
+    log_format             => {
+      'vhost' => '$host $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent"',
+    },
+    http_cfg_append        => {
+      'include' => '/etc/nginx/ocf-vhost.conf',
+    },
+  }
+
+  Class['ocf::ssl::default'] ~> Class['Nginx::Service']
+
+  # HTTPS vhosts — all proxy to Apache
+  nginx::resource::server {
+    default:
+      listen_port       => $ssl_port,
+      ssl_port          => $ssl_port,
+      ssl               => true,
+      ssl_cert          => $ssl_cert,
+      ssl_key           => $ssl_key,
+      http2             => 'on',
+      proxy             => $backend,
+      proxy_set_header  => $proxy_headers,
+      add_header        => {
+        'Strict-Transport-Security' => 'max-age=31536000',
+      };
+
+    'www-ssl':
+      server_name         => [
+        'www.ocf.berkeley.edu', 'dev-www.ocf.berkeley.edu',
+        'ocf.berkeley.edu', 'dev-ocf.berkeley.edu',
+        'secure.ocf.berkeley.edu', $::fqdn,
+        'accounts.ocf.berkeley.edu', 'dev-accounts.ocf.berkeley.edu',
+        'wiki.ocf.berkeley.edu', 'dev-wiki.ocf.berkeley.edu',
+        'hello.ocf.berkeley.edu', 'dev-hello.ocf.berkeley.edu',
+        'staff.ocf.berkeley.edu', 'dev-staff.ocf.berkeley.edu',
+      ],
+      access_log          => '/var/log/nginx/www-access.log vhost',
+      error_log           => '/var/log/nginx/www-error.log';
+
+    'shorturl-ssl':
+      server_name => ['ocf.io', 'dev-ocf-io.ocf.berkeley.edu', 'www.ocf.io'],
+      add_header  => {
+        'Strict-Transport-Security' => 'max-age=31536000; includeSubDomains; preload',
+      },
+      access_log  => '/var/log/nginx/shorturl-access.log vhost',
+      error_log   => '/var/log/nginx/shorturl-error.log';
+
+    'unavailable-ssl':
+      server_name         => ['unavailable.ocf.berkeley.edu'],
+      listen_options      => 'default_server',
+      ipv6_listen_options => 'default_server',
+      proxy_set_header    => [
+        'Host unavailable.ocf.berkeley.edu',
+        'X-Forwarded-For $remote_addr',
+        'X-Forwarded-Proto $scheme',
+        'X-Real-IP $remote_addr',
+      ],
+      access_log          => '/var/log/nginx/unavailable-access.log vhost';
+  }
+
+  # HTTP redirects
+  $shorturl_canonical = $::host_env ? {
+    'dev'  => 'dev-ocf-io.ocf.berkeley.edu',
+    'prod' => 'ocf.io',
+  }
+
+  nginx::resource::server {
+    'www-http-redirect':
+      server_name       => [
+        'www.ocf.berkeley.edu', 'www',
+        'dev-www', 'dev-www.ocf.berkeley.edu',
+        'ocf.berkeley.edu', 'dev-ocf.berkeley.edu',
+        'secure', 'secure.ocf.berkeley.edu',
+        'ocf.asuc.org', 'death.berkeley.edu', 'linux.berkeley.edu',
+        'accounts.ocf.berkeley.edu', 'dev-accounts', 'dev-accounts.ocf.berkeley.edu', 'accounts',
+        'wiki.ocf.berkeley.edu', 'dev-wiki', 'dev-wiki.ocf.berkeley.edu', 'wiki',
+        'hello.ocf.berkeley.edu', 'dev-hello', 'dev-hello.ocf.berkeley.edu', 'hello',
+        'staff.ocf.berkeley.edu', 'dev-staff.ocf.berkeley.edu',
+        $::hostname, $::fqdn,
+      ],
+      listen_port       => $http_port,
+      server_cfg_append => {
+        'return' => "301 https://${www_canonical}\$request_uri",
+      };
+
+    'shorturl-http-redirect':
+      server_name       => ['ocf.io', 'dev-ocf-io.ocf.berkeley.edu', 'www.ocf.io'],
+      listen_port       => $http_port,
+      server_cfg_append => {
+        'return' => "301 https://${shorturl_canonical}\$request_uri",
+      };
+
+    'unavailable-http':
+      server_name         => ['unavailable.ocf.berkeley.edu'],
+      listen_port         => $http_port,
+      listen_options      => 'default_server',
+      ipv6_listen_options => 'default_server',
+      proxy               => $backend,
+      proxy_set_header    => [
+        'Host unavailable.ocf.berkeley.edu',
+        'X-Forwarded-For $remote_addr',
+        'X-Real-IP $remote_addr',
+      ];
+  }
+
+  # seed empty config so nginx starts before build-vhosts runs
+  file { '/etc/nginx/ocf-vhost.conf':
+    ensure  => file,
+    content => "# Generated by build-vhosts\n",
+    replace => false,
+  } ~> Class['Nginx::Service']
+}

--- a/modules/ocf_www/manifests/nginx/firewall.pp
+++ b/modules/ocf_www/manifests/nginx/firewall.pp
@@ -1,0 +1,12 @@
+# CR-soon oliverni: remove when nginx moves to 80/443
+class ocf_www::nginx::firewall {
+  ocf::firewall::firewall46 {
+    '101 allow nginx test ports':
+      opts => {
+        chain  => 'PUPPET-INPUT',
+        proto  => 'tcp',
+        dport  => [8080, 8443],
+        action => 'accept',
+      };
+  }
+}

--- a/modules/ocf_www/manifests/site/ocfweb_redirects.pp
+++ b/modules/ocf_www/manifests/site/ocfweb_redirects.pp
@@ -7,16 +7,10 @@ class ocf_www::site::ocfweb_redirects {
     'prod' => 'https://accounts.ocf.berkeley.edu/',
   }
 
-  apache::vhost { 'accounts':
+  $accounts_options = {
     servername    => 'accounts.ocf.berkeley.edu',
     serveraliases => ['dev-accounts.ocf.berkeley.edu'],
-    port          => 443,
     docroot       => '/var/www/html',
-
-    ssl           => true,
-    ssl_key       => "/etc/ssl/private/${::fqdn}.key",
-    ssl_cert      => "/etc/ssl/private/${::fqdn}.crt",
-    ssl_chain     => "/etc/ssl/private/${::fqdn}.intermediate",
 
     rewrites      => [
       {rewrite_rule => '^/(change-password(/.*)?)?$ https://www.ocf.berkeley.edu/account/password [R=301,L]'},
@@ -25,7 +19,22 @@ class ocf_www::site::ocfweb_redirects {
       {rewrite_rule => '^/request-vhost(/.*)?$ https://www.ocf.berkeley.edu/account/vhost/ [R=301,L]'},
       {rewrite_rule => '^.*$ https://www.ocf.berkeley.edu/'},
     ],
-    headers       => ['always set Strict-Transport-Security max-age=31536000'],
+  }
+
+  apache::vhost { 'accounts':
+    *         => $accounts_options,
+    port      => 443,
+    ssl       => true,
+    headers   => ['always set Strict-Transport-Security max-age=31536000'],
+    ssl_key   => "/etc/ssl/private/${::fqdn}.key",
+    ssl_cert  => "/etc/ssl/private/${::fqdn}.crt",
+    ssl_chain => "/etc/ssl/private/${::fqdn}.intermediate",
+  }
+
+  # nginx backend (plain HTTP on localhost)
+  apache::vhost { 'accounts-backend':
+    *    => $accounts_options,
+    port => $ocf_www::backend_port,
   }
 
   apache::vhost { 'accounts-http-redirect':
@@ -48,21 +57,30 @@ class ocf_www::site::ocfweb_redirects {
     'prod' => 'https://wiki.ocf.berkeley.edu/',
   }
 
-  apache::vhost { 'wiki':
+  $wiki_options = {
     servername    => 'wiki.ocf.berkeley.edu',
     serveraliases => ['dev-wiki.ocf.berkeley.edu'],
-    port          => 443,
     docroot       => '/var/www/html',
-
-    ssl           => true,
-    ssl_key       => "/etc/ssl/private/${::fqdn}.key",
-    ssl_cert      => "/etc/ssl/private/${::fqdn}.crt",
-    ssl_chain     => "/etc/ssl/private/${::fqdn}.intermediate",
 
     rewrites      => [
       {rewrite_rule => '^/(.*)$ https://www.ocf.berkeley.edu/docs/$1 [R=301]'},
     ],
-    headers       => ['always set Strict-Transport-Security max-age=31536000'],
+  }
+
+  apache::vhost { 'wiki':
+    *         => $wiki_options,
+    port      => 443,
+    ssl       => true,
+    headers   => ['always set Strict-Transport-Security max-age=31536000'],
+    ssl_key   => "/etc/ssl/private/${::fqdn}.key",
+    ssl_cert  => "/etc/ssl/private/${::fqdn}.crt",
+    ssl_chain => "/etc/ssl/private/${::fqdn}.intermediate",
+  }
+
+  # nginx backend (plain HTTP on localhost)
+  apache::vhost { 'wiki-backend':
+    *    => $wiki_options,
+    port => $ocf_www::backend_port,
   }
 
   apache::vhost { 'wiki-http-redirect':
@@ -85,26 +103,35 @@ class ocf_www::site::ocfweb_redirects {
     'prod' => 'https://hello.ocf.berkeley.edu/',
   }
 
-  apache::vhost { 'hello':
+  $hello_options = {
     servername    => 'hello.ocf.berkeley.edu',
     serveraliases => [
       'dev-hello.ocf.berkeley.edu',
       'dev-staff.ocf.berkeley.edu',
       'staff.ocf.berkeley.edu',
     ],
-    port          => 443,
     docroot       => '/var/www/html',
-
-    ssl           => true,
-    ssl_key       => "/etc/ssl/private/${::fqdn}.key",
-    ssl_cert      => "/etc/ssl/private/${::fqdn}.crt",
-    ssl_chain     => "/etc/ssl/private/${::fqdn}.intermediate",
 
     rewrites      => [
       {rewrite_rule => '^/lab.html$ https://www.ocf.berkeley.edu/about/lab/open-source [R=301,L]'},
       {rewrite_rule => '^.*$ https://www.ocf.berkeley.edu/about/staff [R=301]'},
     ],
-    headers       => ['always set Strict-Transport-Security max-age=31536000'],
+  }
+
+  apache::vhost { 'hello':
+    *         => $hello_options,
+    port      => 443,
+    ssl       => true,
+    headers   => ['always set Strict-Transport-Security max-age=31536000'],
+    ssl_key   => "/etc/ssl/private/${::fqdn}.key",
+    ssl_cert  => "/etc/ssl/private/${::fqdn}.crt",
+    ssl_chain => "/etc/ssl/private/${::fqdn}.intermediate",
+  }
+
+  # nginx backend (plain HTTP on localhost)
+  apache::vhost { 'hello-backend':
+    *    => $hello_options,
+    port => $ocf_www::backend_port,
   }
 
   apache::vhost { 'hello-http-redirect':

--- a/modules/ocf_www/manifests/site/shorturl.pp
+++ b/modules/ocf_www/manifests/site/shorturl.pp
@@ -4,16 +4,10 @@ class ocf_www::site::shorturl {
     'prod' => 'https://ocf.io/',
   }
 
-  apache::vhost { 'shorturl':
+  $shorturl_options = {
     servername    => 'ocf.io',
     serveraliases => ['dev-ocf-io.ocf.berkeley.edu', 'www.ocf.io'],
-    port          => 443,
     docroot       => '/var/www/html',
-
-    ssl           => true,
-    ssl_key       => "/etc/ssl/private/${::fqdn}.key",
-    ssl_cert      => "/etc/ssl/private/${::fqdn}.crt",
-    ssl_chain     => "/etc/ssl/private/${::fqdn}.intermediate",
 
     rewrites      => [
       # Short URLs
@@ -175,8 +169,22 @@ class ocf_www::site::shorturl {
       # Otherwise, send a temporary redirect to the appropriate userdir
       {rewrite_rule => '^/~?([a-z0-9]{3,16}(?:/.*)?)$ https://www.ocf.berkeley.edu/~$1 [R]'},
     ],
+  }
 
-    headers       => ['always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"'],
+  apache::vhost { 'shorturl':
+    *         => $shorturl_options,
+    port      => 443,
+    ssl       => true,
+    headers   => ['always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"'],
+    ssl_key   => "/etc/ssl/private/${::fqdn}.key",
+    ssl_cert  => "/etc/ssl/private/${::fqdn}.crt",
+    ssl_chain => "/etc/ssl/private/${::fqdn}.intermediate",
+  }
+
+  # nginx backend (plain HTTP on localhost)
+  apache::vhost { 'shorturl-backend':
+    *    => $shorturl_options,
+    port => $ocf_www::backend_port,
   }
 
   # canonical redirects

--- a/modules/ocf_www/manifests/site/unavailable.pp
+++ b/modules/ocf_www/manifests/site/unavailable.pp
@@ -53,4 +53,10 @@ class ocf_www::site::unavailable {
     ssl_cert  => "/etc/ssl/private/${::fqdn}.crt",
     ssl_chain => "/etc/ssl/private/${::fqdn}.intermediate",
   }
+
+  # nginx backend (plain HTTP on localhost)
+  apache::vhost { 'unavailable-backend':
+    *    => $options,
+    port => $ocf_www::backend_port,
+  }
 }

--- a/modules/ocf_www/manifests/site/vhosts.pp
+++ b/modules/ocf_www/manifests/site/vhosts.pp
@@ -6,11 +6,15 @@ class ocf_www::site::vhosts {
       require => [
         Package['python3-ocflib', 'python3-jinja2'],
         File['/opt/share/vhost-web.jinja'],
+        File['/opt/share/vhost-web-nginx.jinja'],
       ],
       notify  => Ocf::Exec_And_Cron['build-vhosts'];
 
     '/opt/share/vhost-web.jinja':
       source  => 'puppet:///modules/ocf_www/vhost-web.jinja';
+
+    '/opt/share/vhost-web-nginx.jinja':
+      source  => 'puppet:///modules/ocf_www/vhost-web-nginx.jinja';
 
     '/var/www/suexec':
       ensure  => directory,

--- a/modules/ocf_www/manifests/site/www.pp
+++ b/modules/ocf_www/manifests/site/www.pp
@@ -36,19 +36,11 @@ class ocf_www::site::www {
   }
 
   # TODO: dev-death should add a robots.txt disallowing everything
-  apache::vhost { 'www':
+  $www_options = {
     servername          => 'www.ocf.berkeley.edu',
     serveraliases       => ['dev-www.ocf.berkeley.edu'],
-    port                => 443,
     docroot             => '/services/http/users',
 
-    ssl                 => true,
-    ssl_key             => "/etc/ssl/private/${::fqdn}.key",
-    ssl_cert            => "/etc/ssl/private/${::fqdn}.crt",
-    ssl_chain           => "/etc/ssl/private/${::fqdn}.intermediate",
-
-    headers             => ['always set Strict-Transport-Security max-age=31536000'],
-    request_headers     => ['set X-Forwarded-Proto https'],
     proxy_preserve_host => true,
 
     aliases             => [
@@ -131,6 +123,23 @@ class ocf_www::site::www {
     ',
   }
 
+  apache::vhost { 'www':
+    *               => $www_options,
+    port            => 443,
+    ssl             => true,
+    ssl_key         => "/etc/ssl/private/${::fqdn}.key",
+    ssl_cert        => "/etc/ssl/private/${::fqdn}.crt",
+    ssl_chain       => "/etc/ssl/private/${::fqdn}.intermediate",
+    headers         => ['always set Strict-Transport-Security max-age=31536000'],
+    request_headers => ['set X-Forwarded-Proto https'],
+  }
+
+  # nginx backend (plain HTTP on localhost)
+  apache::vhost { 'www-backend':
+    *    => $www_options,
+    port => $ocf_www::backend_port,
+  }
+
   # canonical redirects
   $canonical_url = $::host_env ? {
     'dev'  => 'https://dev-www.ocf.berkeley.edu$1',
@@ -166,33 +175,44 @@ class ocf_www::site::www {
       redirectmatch_regexp => '^((?!\/\.well-known\/matrix\/(client|server)).*)',
       redirectmatch_dest   => $canonical_url;
 
-    # redirect weird HTTPS -> canonical HTTPS
-    'www-https-redirect':
-      servername           => 'ocf.berkeley.edu',
-      serveraliases        => [
-        'dev-ocf.berkeley.edu',
-        'secure.ocf.berkeley.edu',
-        $::fqdn,
-      ],
-      directories          => [
-        {
-          path            => '/.well-known/matrix/client',
-          provider        => 'location',
-          custom_fragment => '
-              Header set Access-Control-Allow-Origin "*"
-          ',
-        },
-      ],
-      port                 => 443,
-      docroot              => '/var/www/html',
-      redirectmatch_status => '301',
-      # ugly exceptions
-      redirectmatch_regexp => '^((?!\/\.well-known\/matrix\/(client|server)).*)',
-      redirectmatch_dest   => $canonical_url,
+  }
 
-      ssl                  => true,
-      ssl_key              => "/etc/ssl/private/${::fqdn}.key",
-      ssl_cert             => "/etc/ssl/private/${::fqdn}.crt",
-      ssl_chain            => "/etc/ssl/private/${::fqdn}.intermediate";
+  # redirect weird HTTPS -> canonical HTTPS
+  $https_redirect_options = {
+    servername           => 'ocf.berkeley.edu',
+    serveraliases        => [
+      'dev-ocf.berkeley.edu',
+      'secure.ocf.berkeley.edu',
+      $::fqdn,
+    ],
+    directories          => [
+      {
+        path            => '/.well-known/matrix/client',
+        provider        => 'location',
+        custom_fragment => '
+            Header set Access-Control-Allow-Origin "*"
+        ',
+      },
+    ],
+    docroot              => '/var/www/html',
+    redirectmatch_status => '301',
+    # ugly exceptions
+    redirectmatch_regexp => '^((?!\/\.well-known\/matrix\/(client|server)).*)',
+    redirectmatch_dest   => $canonical_url,
+  }
+
+  apache::vhost { 'www-https-redirect':
+    *         => $https_redirect_options,
+    port      => 443,
+    ssl       => true,
+    ssl_key   => "/etc/ssl/private/${::fqdn}.key",
+    ssl_cert  => "/etc/ssl/private/${::fqdn}.crt",
+    ssl_chain => "/etc/ssl/private/${::fqdn}.intermediate",
+  }
+
+  # nginx backend (plain HTTP on localhost)
+  apache::vhost { 'www-https-redirect-backend':
+    *    => $https_redirect_options,
+    port => $ocf_www::backend_port,
   }
 }


### PR DESCRIPTION
nginx proxying to apache as a slowloris mitigation layer

this pr adds apache listening on port 16767 (http only) along side current 80/443, then nginx listening on 8080/8443, to test. the next pr (#1462) makes nginx do 80/443 and makes apache http 16767 only