### PR TITLE
ocf_www: proxy apphost vhosts directly from nginx

### DIFF
--- a/modules/ocf_www/files/vhost-web-nginx.jinja
+++ b/modules/ocf_www/files/vhost-web-nginx.jinja
@@ -22,6 +22,18 @@ server {
     location / {
         {% if vhost.is_redirect %}
         return {{vhost.redirect_type}} {{vhost.redirect_dest}}$request_uri;
+        {% elif vhost.is_apphost and vhost.disabled %}
+        proxy_pass http://127.0.0.1:{{backend_port}};
+        proxy_set_header Host unavailable.ocf.berkeley.edu;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        {% elif vhost.is_apphost %}
+        proxy_pass https://apphost.ocf.berkeley.edu;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
         {% else %}
         proxy_pass http://127.0.0.1:{{backend_port}};
         proxy_set_header Host $host;
@@ -40,7 +52,7 @@ server {
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_pass http://127.0.0.1:{{backend_port}};
+        proxy_pass https://apphost.ocf.berkeley.edu;
     }
     {% endfor %}
 

--- a/modules/ocf_www/manifests/init.pp
+++ b/modules/ocf_www/manifests/init.pp
@@ -69,13 +69,8 @@ class ocf_www {
       backport_on => 'stretch';
   }
 
-  # Apache no longer serves SSL directly (nginx handles it), but mod_ssl is
-  # still needed for SSLProxyEngine (outbound HTTPS to apphost).
-  include apache::mod::ssl
-
   include ocf_www::lets_encrypt
   include ocf_www::logging
-  include ocf_www::ssl
 
   # sites
   include ocf_www::site::ocfweb_redirects


### PR DESCRIPTION
Have nginx talk to apphost.ocf.berkeley.edu directly instead of going through Apache. Apache no longer needs SSL support so drop apache::mod::ssl and ocf_www::ssl.