### PR TITLE
ocf: mitigate CVE-2026-31431 (Copy Fail) by disabling algif_aead

### DIFF
--- a/modules/ocf/files/modprobe.d/disable-algif-aead.conf
+++ b/modules/ocf/files/modprobe.d/disable-algif-aead.conf
@@ -1,0 +1,4 @@
+# CVE-2026-31431 (Copy Fail): Prevent loading algif_aead to mitigate
+# a privilege escalation via AF_ALG + splice() page cache corruption.
+# https://nvd.nist.gov/vuln/detail/CVE-2026-31431
+install algif_aead /bin/false

--- a/modules/ocf/manifests/copy_fail.pp
+++ b/modules/ocf/manifests/copy_fail.pp
@@ -1,0 +1,23 @@
+# CVE-2026-31431 (Copy Fail) mitigation.
+#
+# Prevents loading the algif_aead kernel module, which exposes a privilege
+# escalation via AF_ALG + splice() page cache corruption. An unprivileged
+# local user can corrupt the page cache of setuid binaries to obtain root.
+#
+# The long-term fix is a patched kernel; this class provides an immediate
+# mitigation by blocking the vulnerable module from loading.
+class ocf::copy_fail {
+  file { '/etc/modprobe.d/disable-algif-aead.conf':
+    owner  => root,
+    group  => root,
+    mode   => '0644',
+    source => 'puppet:///modules/ocf/modprobe.d/disable-algif-aead.conf',
+  }
+
+  # Unload the module if it is currently loaded.
+  exec { 'rmmod algif_aead':
+    command => '/sbin/rmmod algif_aead',
+    onlyif  => '/bin/grep -q "^algif_aead " /proc/modules',
+    require => File['/etc/modprobe.d/disable-algif-aead.conf'],
+  }
+}

--- a/modules/ocf/manifests/init.pp
+++ b/modules/ocf/manifests/init.pp
@@ -2,6 +2,7 @@ class ocf {
   include ocf::apt
   include ocf::auth
   include ocf::autologout
+  include ocf::copy_fail
   include ocf::etc
   include ocf::firewall
   include ocf::groups


### PR DESCRIPTION
Blacklist the algif_aead kernel module fleet-wide to prevent a local privilege escalation via AF_ALG + splice() page cache corruption.