### PR TITLE
ocf: mitigate Dirty Frag LPE by disabling esp4, esp6, rxrpc modules

### DIFF
--- a/modules/ocf/files/modprobe.d/dirtyfrag.conf
+++ b/modules/ocf/files/modprobe.d/dirtyfrag.conf
@@ -1,0 +1,5 @@
+# Mitigate Dirty Frag LPE (https://github.com/V4bel/dirtyfrag)
+# Prevent loading of vulnerable kernel modules: esp4, esp6, rxrpc
+install esp4 /bin/false
+install esp6 /bin/false
+install rxrpc /bin/false

--- a/modules/ocf/manifests/dirtyfrag.pp
+++ b/modules/ocf/manifests/dirtyfrag.pp
@@ -1,0 +1,20 @@
+# Mitigate CVE-less Dirty Frag Linux LPE
+# https://github.com/V4bel/dirtyfrag
+#
+# Disables the esp4, esp6, and rxrpc kernel modules which are exploited
+# by the Dirty Frag vulnerability to gain root privileges.
+class ocf::dirtyfrag {
+  file { '/etc/modprobe.d/dirtyfrag.conf':
+    owner  => root,
+    group  => root,
+    mode   => '0644',
+    source => 'puppet:///modules/ocf/modprobe.d/dirtyfrag.conf',
+  }
+
+  exec { 'remove-dirtyfrag-modules':
+    command     => 'rmmod esp4 esp6 rxrpc 2>/dev/null; true',
+    path        => ['/sbin', '/usr/sbin', '/bin', '/usr/bin'],
+    subscribe   => File['/etc/modprobe.d/dirtyfrag.conf'],
+    refreshonly => true,
+  }
+}

--- a/modules/ocf/manifests/init.pp
+++ b/modules/ocf/manifests/init.pp
@@ -3,6 +3,7 @@ class ocf {
   include ocf::auth
   include ocf::autologout
   include ocf::copy_fail
+  include ocf::dirtyfrag
   include ocf::etc
   include ocf::firewall
   include ocf::groups


### PR DESCRIPTION
Dirty Frag is a universal Linux LPE that chains vulnerabilities in the esp4/esp6 (xfrm-ESP) and rxrpc kernel modules to gain root privileges. No CVE or patch exists yet. Mitigation is to prevent these modules from loading via modprobe install directives.

See https://github.com/V4bel/dirtyfrag

Generated with [Devin](https://cli.devin.ai/docs)